### PR TITLE
Add GitHub Copilot provider integration

### DIFF
--- a/apps/cli/src/plugins/builtins.ts
+++ b/apps/cli/src/plugins/builtins.ts
@@ -4,6 +4,7 @@ import ask from "./ask/plugin"
 import codeReview from "./code-review/plugin"
 import deepseek from "./deepseek/plugin"
 import files from "./files/plugin"
+import githubCopilot from "./github-copilot/plugin"
 import memory from "./memory/plugin"
 import openaiChatgpt from "./openai-chatgpt/plugin"
 import promptCommands from "./prompt-commands/plugin"
@@ -26,6 +27,7 @@ export const builtinPlugins: Plugin[] = [
   mcp,
   deepseek,
   alibabaCloud,
+  githubCopilot,
   openaiChatgpt,
   ask,
   tui,

--- a/apps/cli/src/plugins/github-copilot/api.ts
+++ b/apps/cli/src/plugins/github-copilot/api.ts
@@ -1,0 +1,73 @@
+import { ProviderError } from "../../providers/errors"
+import { defaultClientIdentity, type ClientIdentity } from "../../providers/identity"
+import { errorDetail, httpError, providerFetch } from "../../providers/transport"
+
+export const PROVIDER_ID = "github-copilot"
+
+const API_VERSION = "2025-05-01"
+const INTEGRATION_ID = "copilot-developer-cli"
+const PERSONAL_API_BASE_URL = "https://api.githubcopilot.com"
+
+let domain = "github.com"
+let identity = defaultClientIdentity()
+const interactionId = crypto.randomUUID()
+
+export function setDomain(value: string): void {
+  domain = value
+}
+
+export function setClientIdentity(value: ClientIdentity): void {
+  identity = value
+}
+
+export function githubDomain(): string {
+  return domain
+}
+
+function baseUrl(): string {
+  return domain === "github.com" ? PERSONAL_API_BASE_URL : `https://copilot-api.${domain}`
+}
+
+export function isPersonalCopilotEndpoint(): boolean {
+  return baseUrl() === PERSONAL_API_BASE_URL
+}
+
+async function raiseForStatus(response: Response): Promise<never> {
+  const text = await response.text().catch(() => "")
+  const detail = errorDetail(text) ?? text.slice(0, 500)
+  if (response.status === 401) {
+    throw new ProviderError("GitHub Copilot authentication failed — reconnect the provider", { retryable: false })
+  }
+  if (response.status === 403) {
+    throw new ProviderError(
+      detail || "GitHub Copilot denied the request — confirm that this account has an active Copilot subscription",
+      { retryable: false },
+    )
+  }
+  throw httpError("GitHub Copilot", response, detail)
+}
+
+export async function copilotFetch(path: string, token: string, init: RequestInit = {}): Promise<Response> {
+  const response = await providerFetch(
+    "GitHub Copilot",
+    () =>
+      fetch(`${baseUrl()}${path}`, {
+        ...init,
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: "application/json",
+          "content-type": "application/json",
+          "copilot-integration-id": INTEGRATION_ID,
+          "openai-intent": "conversation-agent",
+          "user-agent": identity.userAgent,
+          "x-github-api-version": API_VERSION,
+          "x-initiator": "user",
+          "x-interaction-id": interactionId,
+          ...init.headers,
+        },
+      }),
+    init.signal,
+  )
+  if (!response.ok) await raiseForStatus(response)
+  return response
+}

--- a/apps/cli/src/plugins/github-copilot/auth.ts
+++ b/apps/cli/src/plugins/github-copilot/auth.ts
@@ -1,0 +1,92 @@
+import { setTimeout as sleep } from "node:timers/promises"
+import { appInfo } from "../../app-info"
+import { saveCredential, type ApiKeyCredential } from "../../config/credentials"
+import type { ConnectContext } from "../../providers/types"
+import { protectSecretValue } from "../../secrets/redactor"
+import { copilotFetch, githubDomain, isPersonalCopilotEndpoint, PROVIDER_ID } from "./api"
+import { cacheDiscoveredModels } from "./models"
+import { parseCopilotModels, parseDeviceAuthorization, parseDeviceToken, type DeviceAuthorization } from "./wire"
+
+const CLIENT_ID = "Ov23liczUGMpBbj2dzAn"
+const REQUEST_TIMEOUT_MS = 30_000
+const POLLING_SAFETY_MARGIN_MS = 3_000
+
+function oauthUrl(path: string): string {
+  return `https://${githubDomain()}${path}`
+}
+
+async function requestJson(url: string, init: RequestInit): Promise<unknown> {
+  const response = await fetch(url, init)
+  if (!response.ok) {
+    const text = await response.text().catch(() => "")
+    throw new Error(`GitHub login request failed (${response.status}): ${text.slice(0, 300)}`)
+  }
+  return response.json()
+}
+
+async function startDeviceFlow(): Promise<DeviceAuthorization> {
+  const raw = await requestJson(oauthUrl("/login/device/code"), {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      "user-agent": `${appInfo.name}/${appInfo.version}`,
+    },
+    body: JSON.stringify({ client_id: CLIENT_ID, scope: "read:user" }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  })
+  return parseDeviceAuthorization(raw)
+}
+
+async function pollForAccessToken(device: DeviceAuthorization): Promise<string> {
+  const deadline = Date.now() + device.expiresInSeconds * 1_000
+  let intervalMs = device.intervalSeconds * 1_000
+  while (Date.now() < deadline) {
+    await sleep(Math.max(0, Math.min(intervalMs + POLLING_SAFETY_MARGIN_MS, deadline - Date.now())))
+    if (Date.now() >= deadline) break
+    const raw = await requestJson(oauthUrl("/login/oauth/access_token"), {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+        "user-agent": `${appInfo.name}/${appInfo.version}`,
+      },
+      body: JSON.stringify({
+        client_id: CLIENT_ID,
+        device_code: device.deviceCode,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
+      signal: AbortSignal.timeout(Math.max(1, Math.min(REQUEST_TIMEOUT_MS, deadline - Date.now()))),
+    })
+    const result = parseDeviceToken(raw)
+    switch (result.type) {
+      case "complete":
+        return result.accessToken
+      case "pending":
+        break
+      case "slow_down":
+        intervalMs = result.intervalSeconds ? result.intervalSeconds * 1_000 : intervalMs + 5_000
+        break
+      case "failed":
+        throw new Error(result.message)
+    }
+  }
+  throw new Error("GitHub device login timed out")
+}
+
+export async function connect(ctx: ConnectContext): Promise<boolean> {
+  const device = await startDeviceFlow()
+  ctx.print(`open ${device.verificationUri}`)
+  ctx.print(`enter code: ${device.userCode}`)
+  ctx.print("")
+  ctx.print("waiting for GitHub authorization…")
+  const accessToken = await pollForAccessToken(device)
+  protectSecretValue(accessToken)
+  const response = await copilotFetch("/models", accessToken, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
+  const models = parseCopilotModels(await response.json(), isPersonalCopilotEndpoint())
+  await cacheDiscoveredModels(accessToken, models)
+  const credential: ApiKeyCredential = { type: "api_key", key: accessToken }
+  await saveCredential(PROVIDER_ID, credential)
+  ctx.print(`connected to GitHub Copilot${githubDomain() === "github.com" ? "" : ` on ${githubDomain()}`}`)
+  return true
+}

--- a/apps/cli/src/plugins/github-copilot/credential.ts
+++ b/apps/cli/src/plugins/github-copilot/credential.ts
@@ -1,0 +1,15 @@
+import { appInfo } from "../../app-info"
+import { loadCredential } from "../../config/credentials"
+import { PROVIDER_ID } from "./api"
+
+export async function token(): Promise<string> {
+  const credential = await loadCredential(PROVIDER_ID)
+  if (credential?.type !== "api_key") {
+    throw new Error(`not connected to GitHub Copilot — run: ${appInfo.name} connect copilot`)
+  }
+  return credential.key
+}
+
+export async function isLoggedIn(): Promise<boolean> {
+  return (await loadCredential(PROVIDER_ID))?.type === "api_key"
+}

--- a/apps/cli/src/plugins/github-copilot/models.test.ts
+++ b/apps/cli/src/plugins/github-copilot/models.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { appEnvVar, appInfo } from "../../app-info"
+import { saveCredential } from "../../config/credentials"
+import type { ModelInfo } from "../../providers/types"
+import { replaceSecretValues } from "../../secrets/redactor"
+import { setDomain } from "./api"
+import { cacheDiscoveredModels, listModels } from "./models"
+
+async function withHome(run: () => Promise<void>): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), `${appInfo.name}-copilot-models-test-`))
+  const home = join(directory, "home")
+  const homeEnv = appEnvVar("HOME")
+  const inheritedHome = process.env[homeEnv]
+  await mkdir(home, { recursive: true })
+  process.env[homeEnv] = home
+  setDomain("github.com")
+  try {
+    await run()
+  } finally {
+    replaceSecretValues("credentials", [])
+    if (inheritedHome === undefined) delete process.env[homeEnv]
+    else process.env[homeEnv] = inheritedHome
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+function responseModel(id: string): Record<string, unknown> {
+  return {
+    id,
+    name: id,
+    model_picker_enabled: true,
+    supported_endpoints: ["/chat/completions"],
+    policy: { state: "enabled" },
+    capabilities: {
+      limits: { max_context_window_tokens: 128_000 },
+      supports: { tool_calls: true },
+    },
+  }
+}
+
+async function saveTestCredential(accessToken: string): Promise<void> {
+  await saveCredential("github-copilot", { type: "api_key", key: accessToken })
+}
+
+test("Copilot model caches are bound to the credential that discovered them", async () => {
+  await withHome(async () => {
+    const cached: ModelInfo[] = [
+      { id: "account-a-model", name: "Account A Model", contextWindow: 128_000, inputModalities: ["text"] },
+    ]
+    await saveTestCredential("token-a")
+    await cacheDiscoveredModels("token-a", cached)
+    expect(await listModels(false)).toEqual({ models: cached, source: "cache" })
+
+    await saveTestCredential("token-b")
+    const inheritedFetch = globalThis.fetch
+    const requestHeaders: Headers[] = []
+    const urls: string[] = []
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: string | URL | Request, init?: RequestInit) => {
+        urls.push(String(input))
+        requestHeaders.push(new Headers(init?.headers))
+        return new Response(JSON.stringify({ data: [responseModel("account-b-model")] }))
+      },
+    })
+    try {
+      expect(await listModels(false)).toEqual({
+        models: [
+          {
+            id: "account-b-model",
+            name: "account-b-model",
+            contextWindow: 128_000,
+            inputModalities: ["text"],
+            thinking: undefined,
+          },
+        ],
+        source: "runtime",
+      })
+      expect(urls).toEqual(["https://api.githubcopilot.com/models"])
+      expect(Object.fromEntries(requestHeaders[0]!)).toMatchObject({
+        authorization: "Bearer token-b",
+        "copilot-integration-id": "copilot-developer-cli",
+        "openai-intent": "conversation-agent",
+        "x-github-api-version": "2025-05-01",
+        "x-initiator": "user",
+      })
+      expect(requestHeaders[0]!.get("x-interaction-id")).toMatch(/^[0-9a-f-]{36}$/)
+    } finally {
+      Object.defineProperty(globalThis, "fetch", { configurable: true, value: inheritedFetch })
+    }
+  })
+})
+
+test("Copilot model discovery fails without a matching validated cache", async () => {
+  await withHome(async () => {
+    await saveTestCredential("token")
+    const inheritedFetch = globalThis.fetch
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async () => {
+        throw new Error("offline")
+      },
+    })
+    try {
+      await expect(listModels(false)).rejects.toThrow("no validated cache is available")
+    } finally {
+      Object.defineProperty(globalThis, "fetch", { configurable: true, value: inheritedFetch })
+    }
+  })
+})

--- a/apps/cli/src/plugins/github-copilot/models.ts
+++ b/apps/cli/src/plugins/github-copilot/models.ts
@@ -1,0 +1,142 @@
+import { join } from "node:path"
+import { cacheDir } from "../../config/paths"
+import { describeError } from "../../lib/error"
+import { readJsonFile, writeSecureJson } from "../../lib/fs"
+import { asNumber, asString, asStringArray, isRecord } from "../../lib/json"
+import { isThinkingEffort, type ModelCatalog, type ModelInfo, type ThinkingOptions } from "../../providers/types"
+import { copilotFetch, githubDomain, isPersonalCopilotEndpoint } from "./api"
+import { token } from "./credential"
+import { parseCopilotModels } from "./wire"
+
+const CACHE_VERSION = 1
+
+function cachePath(): string {
+  return join(cacheDir(), "github-copilot-models.json")
+}
+
+async function credentialId(githubToken: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(githubToken))
+  return Buffer.from(digest).toString("base64url")
+}
+
+function positiveInteger(raw: unknown): number | undefined {
+  const value = asNumber(raw)
+  return value !== undefined && Number.isInteger(value) && value > 0 ? value : undefined
+}
+
+function cachedThinking(raw: unknown): ThinkingOptions | undefined {
+  if (!isRecord(raw)) return undefined
+  const options = asStringArray(raw.options).filter(isThinkingEffort)
+  const preferred = asString(raw.default)
+  if (options.length === 0 || !preferred || !isThinkingEffort(preferred) || !options.includes(preferred))
+    return undefined
+  return { options, default: preferred }
+}
+
+function cachedModel(raw: unknown): ModelInfo | undefined {
+  if (!isRecord(raw)) return undefined
+  const id = asString(raw.id)?.trim()
+  const name = asString(raw.name)?.trim()
+  if (!id || !name) return undefined
+  const modalities = asStringArray(raw.inputModalities)
+  if (modalities.length !== 1 || modalities[0] !== "text") return undefined
+  return {
+    id,
+    name,
+    contextWindow: positiveInteger(raw.contextWindow),
+    inputModalities: ["text"],
+    thinking: cachedThinking(raw.thinking),
+  }
+}
+
+async function readCache(githubToken: string): Promise<ModelInfo[] | undefined> {
+  const raw = await readJsonFile(cachePath())
+  if (raw === undefined) return undefined
+  if (!isRecord(raw)) throw new Error(`${cachePath()} is malformed — fix or delete it`)
+  if (raw.version !== CACHE_VERSION) return undefined
+  const domain = asString(raw.domain)
+  const storedCredentialId = asString(raw.credentialId)
+  if (!domain || !storedCredentialId || !Array.isArray(raw.models)) {
+    throw new Error(`${cachePath()} is malformed — fix or delete it`)
+  }
+  if (domain !== githubDomain() || storedCredentialId !== (await credentialId(githubToken))) return undefined
+  const models: ModelInfo[] = []
+  for (const entry of raw.models) {
+    const model = cachedModel(entry)
+    if (!model) throw new Error(`${cachePath()} is malformed — fix or delete it`)
+    models.push(model)
+  }
+  return models.length > 0 ? models : undefined
+}
+
+export async function cacheDiscoveredModels(githubToken: string, models: ModelInfo[]): Promise<void> {
+  await writeSecureJson(cachePath(), {
+    version: CACHE_VERSION,
+    domain: githubDomain(),
+    credentialId: await credentialId(githubToken),
+    models,
+  })
+}
+
+async function discoverModels(accessToken: string): Promise<ModelInfo[]> {
+  const response = await copilotFetch("/models", accessToken, { signal: AbortSignal.timeout(5_000) })
+  return parseCopilotModels(await response.json(), isPersonalCopilotEndpoint())
+}
+
+async function refreshModels(accessToken: string): Promise<ModelCatalog> {
+  try {
+    const models = await discoverModels(accessToken)
+    try {
+      await cacheDiscoveredModels(accessToken, models)
+      return { models, source: "runtime" }
+    } catch (error) {
+      return {
+        models,
+        source: "runtime",
+        warning: `models were discovered, but the cache could not be updated: ${describeError(error)}`,
+      }
+    }
+  } catch (discoveryError) {
+    let cached: ModelInfo[] | undefined
+    try {
+      cached = await readCache(accessToken)
+    } catch (cacheError) {
+      throw new Error(
+        `live model discovery failed: ${describeError(discoveryError)}; cache failed: ${describeError(cacheError)}`,
+        { cause: cacheError },
+      )
+    }
+    if (!cached) {
+      throw new Error(
+        `live model discovery failed and no validated cache is available: ${describeError(discoveryError)}`,
+        { cause: discoveryError },
+      )
+    }
+    return {
+      models: cached,
+      source: "cache",
+      warning: `live discovery failed: ${describeError(discoveryError)} — using cached models`,
+    }
+  }
+}
+
+export async function listModels(refresh: boolean): Promise<ModelCatalog> {
+  const accessToken = await token()
+  if (refresh) return refreshModels(accessToken)
+  try {
+    const cached = await readCache(accessToken)
+    if (cached) return { models: cached, source: "cache" }
+  } catch (cacheError) {
+    const refreshed = await refreshModels(accessToken)
+    if (refreshed.warning) return refreshed
+    return {
+      ...refreshed,
+      warning: `cached catalog failed: ${describeError(cacheError)} — replaced with live models`,
+    }
+  }
+  return refreshModels(accessToken)
+}
+
+export async function defaultModel(): Promise<string> {
+  return (await listModels(false)).models[0]!.id
+}

--- a/apps/cli/src/plugins/github-copilot/plugin.test.ts
+++ b/apps/cli/src/plugins/github-copilot/plugin.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { events } from "../../events"
+import type { PluginContext } from "../types"
+import { isPersonalCopilotEndpoint } from "./api"
+import plugin from "./plugin"
+
+function context(config: Record<string, unknown>): PluginContext {
+  return {
+    config,
+    events,
+    signal: new AbortController().signal,
+    registerTool() {},
+    unregisterTool() {},
+    registerProvider() {},
+    registerCli() {},
+    registerCommand() {},
+    registerHook() {},
+    registerPrompt() {},
+    registerPolicyRule() {},
+    registerPermissionRules() {},
+    registerSecrets() {},
+    registerUi() {},
+    registerToolRenderer() {},
+  }
+}
+
+describe("GitHub Copilot plugin", () => {
+  test("accepts GitHub.com and HTTPS enterprise domains", () => {
+    expect(() => plugin.register(context({}))).not.toThrow()
+    expect(isPersonalCopilotEndpoint()).toBe(true)
+    expect(() => plugin.register(context({ enterpriseDomain: "github.com" }))).not.toThrow()
+    expect(isPersonalCopilotEndpoint()).toBe(true)
+    expect(() => plugin.register(context({ enterpriseDomain: "https://github.example.com/" }))).not.toThrow()
+    expect(isPersonalCopilotEndpoint()).toBe(false)
+  })
+
+  test("rejects empty, malformed, and insecure enterprise domains", () => {
+    expect(() => plugin.register(context({ enterpriseDomain: "" }))).toThrow(
+      "github-copilot enterpriseDomain must be a non-empty domain or URL",
+    )
+    expect(() => plugin.register(context({ enterpriseDomain: "not a domain" }))).toThrow(
+      "github-copilot enterpriseDomain must be a valid domain or URL",
+    )
+    expect(() => plugin.register(context({ enterpriseDomain: "http://github.example.com" }))).toThrow(
+      "github-copilot enterpriseDomain must use HTTPS",
+    )
+  })
+})

--- a/apps/cli/src/plugins/github-copilot/plugin.ts
+++ b/apps/cli/src/plugins/github-copilot/plugin.ts
@@ -1,0 +1,36 @@
+import { asString } from "../../lib/json"
+import { configuredClientIdentity } from "../../providers/identity"
+import type { Plugin } from "../types"
+import { setClientIdentity, setDomain } from "./api"
+import { githubCopilotProvider } from "./provider"
+
+function domain(config: Record<string, unknown>): string {
+  const configured = asString(config.enterpriseDomain)?.trim()
+  if ("enterpriseDomain" in config && !configured) {
+    throw new Error("github-copilot enterpriseDomain must be a non-empty domain or URL")
+  }
+  if (!configured) return "github.com"
+  let url: URL
+  try {
+    url = new URL(configured.includes("://") ? configured : `https://${configured}`)
+  } catch {
+    throw new Error("github-copilot enterpriseDomain must be a valid domain or URL")
+  }
+  if (url.protocol !== "https:") throw new Error("github-copilot enterpriseDomain must use HTTPS")
+  const hostname = url.hostname.toLowerCase()
+  if (!hostname) throw new Error("github-copilot enterpriseDomain must include a hostname")
+  return hostname === "github.com" || hostname === "api.github.com" || hostname === "www.github.com"
+    ? "github.com"
+    : hostname
+}
+
+const plugin: Plugin = {
+  name: "github-copilot",
+  register(ctx) {
+    setDomain(domain(ctx.config))
+    setClientIdentity(configuredClientIdentity("github-copilot", ctx.config))
+    ctx.registerProvider(githubCopilotProvider)
+  },
+}
+
+export default plugin

--- a/apps/cli/src/plugins/github-copilot/provider.ts
+++ b/apps/cli/src/plugins/github-copilot/provider.ts
@@ -1,0 +1,18 @@
+import type { Provider } from "../../providers/types"
+import { PROVIDER_ID } from "./api"
+import { connect } from "./auth"
+import { isLoggedIn } from "./credential"
+import { defaultModel, listModels } from "./models"
+import { streamResponse } from "./transport"
+
+export const githubCopilotProvider: Provider = {
+  id: PROVIDER_ID,
+  name: "GitHub Copilot",
+  aliases: ["copilot"],
+  capabilities: { imageInput: false },
+  isLoggedIn,
+  connect,
+  listModels,
+  defaultModel,
+  stream: streamResponse,
+}

--- a/apps/cli/src/plugins/github-copilot/transport.ts
+++ b/apps/cli/src/plugins/github-copilot/transport.ts
@@ -1,0 +1,39 @@
+import type { JsonObject } from "../../lib/json"
+import { streamChatCompletions, type ChatCompletionProvider } from "../../providers/chat-completions"
+import type { StreamEvent, StreamRequest } from "../../providers/types"
+import { copilotFetch, PROVIDER_ID } from "./api"
+import { token } from "./credential"
+
+function requestOptions(request: StreamRequest): JsonObject {
+  if (!request.thinking || request.thinking === "none") return {}
+  return { reasoning_effort: request.thinking }
+}
+
+function initiator(request: StreamRequest): "user" | "agent" {
+  const last = request.input.at(-1)
+  return !last || last.type === "user_message" ? "user" : "agent"
+}
+
+function provider(accessToken: string, request: StreamRequest): ChatCompletionProvider {
+  return {
+    id: PROVIDER_ID,
+    name: "GitHub Copilot",
+    fetch(body, signal) {
+      return copilotFetch("/chat/completions", accessToken, {
+        method: "POST",
+        headers: {
+          accept: "text/event-stream",
+          "openai-intent": "conversation-edits",
+          "x-initiator": initiator(request),
+        },
+        body,
+        signal,
+      })
+    },
+    requestOptions,
+  }
+}
+
+export async function* streamResponse(request: StreamRequest): AsyncGenerator<StreamEvent> {
+  yield* streamChatCompletions(request, provider(await token(), request))
+}

--- a/apps/cli/src/plugins/github-copilot/wire.test.ts
+++ b/apps/cli/src/plugins/github-copilot/wire.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test"
+import { parseCopilotModels, parseDeviceAuthorization, parseDeviceToken } from "./wire"
+
+function model(
+  id: string,
+  endpoint: string | undefined,
+  options: { picker?: boolean; policy?: string; toolCalls?: boolean | "omitted" } = {},
+): Record<string, unknown> {
+  return {
+    id,
+    name: id.toUpperCase(),
+    model_picker_enabled: options.picker ?? false,
+    ...(endpoint === undefined ? {} : { supported_endpoints: [endpoint] }),
+    policy: { state: options.policy ?? "enabled" },
+    capabilities: {
+      limits: { max_context_window_tokens: 128_000, max_prompt_tokens: 64_000 },
+      supports: {
+        ...(options.toolCalls === "omitted" ? {} : { tool_calls: options.toolCalls ?? true }),
+        reasoning_effort: ["low", "medium", "invalid"],
+      },
+    },
+  }
+}
+
+describe("GitHub Copilot wire parsing", () => {
+  test("parses device authorization and polling results", () => {
+    expect(
+      parseDeviceAuthorization({
+        device_code: "device",
+        user_code: "ABCD-EFGH",
+        verification_uri: "https://github.com/login/device",
+        interval: 7,
+        expires_in: 900,
+      }),
+    ).toEqual({
+      deviceCode: "device",
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      intervalSeconds: 7,
+      expiresInSeconds: 900,
+    })
+    expect(parseDeviceToken({ error: "authorization_pending" })).toEqual({ type: "pending" })
+    expect(parseDeviceToken({ error: "slow_down", interval: 12 })).toEqual({
+      type: "slow_down",
+      intervalSeconds: 12,
+    })
+    expect(parseDeviceToken({ access_token: "secret" })).toEqual({ type: "complete", accessToken: "secret" })
+  })
+
+  test("rejects unsafe and malformed device responses", () => {
+    expect(() =>
+      parseDeviceAuthorization({
+        device_code: "device",
+        user_code: "code",
+        verification_uri: "file:///tmp/login",
+        expires_in: 900,
+      }),
+    ).toThrow("non-HTTPS verification URL")
+    expect(() => parseDeviceToken({})).toThrow("device token response was incomplete")
+  })
+
+  test("keeps picker-enabled, tool-capable chat models and their reasoning metadata", () => {
+    const models = parseCopilotModels(
+      {
+        data: [
+          model("chat-model", "/chat/completions", { picker: true }),
+          model("responses-model", "/responses", { picker: true }),
+          model("no-tools", "/chat/completions", { picker: true, toolCalls: false }),
+          model("policy-only", "/chat/completions"),
+        ],
+      },
+      false,
+    )
+    expect(models).toEqual([
+      {
+        id: "chat-model",
+        name: "CHAT-MODEL",
+        contextWindow: 128_000,
+        inputModalities: ["text"],
+        thinking: { options: ["low", "medium"], default: "medium" },
+      },
+    ])
+  })
+
+  test("uses enabled policy models only for Personal Copilot accounts", () => {
+    const response = {
+      data: [
+        model("omitted-metadata", undefined, { policy: "enabled", toolCalls: "omitted" }),
+        model("responses-only", "/responses", { policy: "enabled", toolCalls: "omitted" }),
+        model("disabled-tools", "/chat/completions", { policy: "enabled", toolCalls: false }),
+      ],
+    }
+    expect(parseCopilotModels(response, true).map((entry) => entry.id)).toEqual(["omitted-metadata"])
+    expect(() => parseCopilotModels(response, false)).toThrow(
+      "no compatible agent models enabled in the Enterprise model picker",
+    )
+  })
+
+  test("accepts Personal Copilot catalogs that omit endpoint, picker, and policy metadata", () => {
+    const data = Array.from({ length: 8 }, (_, index) => ({
+      id: `legacy-${index + 1}`,
+      name: `Legacy ${index + 1}`,
+      capabilities: { supports: {} },
+    }))
+    expect(parseCopilotModels({ data }, true).map((entry) => entry.id)).toEqual(data.map((entry) => entry.id))
+    expect(() =>
+      parseCopilotModels(
+        {
+          data: [
+            {
+              id: "empty-endpoints",
+              name: "Empty endpoints",
+              supported_endpoints: [],
+              capabilities: { supports: {} },
+            },
+          ],
+        },
+        true,
+      ),
+    ).toThrow("1 advertised, 0 protocol-compatible, 0 tool-compatible")
+  })
+
+  test("fails when the subscription exposes no compatible models", () => {
+    expect(() => parseCopilotModels({ data: [model("responses", "/responses", { picker: true })] }, true)).toThrow(
+      "no compatible tool-capable agent models (1 advertised, 0 protocol-compatible, 0 tool-compatible)",
+    )
+  })
+})

--- a/apps/cli/src/plugins/github-copilot/wire.ts
+++ b/apps/cli/src/plugins/github-copilot/wire.ts
@@ -1,0 +1,151 @@
+import { asNumber, asString, asStringArray, isRecord } from "../../lib/json"
+import { isThinkingEffort, type ModelInfo, type ThinkingEffort } from "../../providers/types"
+
+export interface DeviceAuthorization {
+  deviceCode: string
+  userCode: string
+  verificationUri: string
+  intervalSeconds: number
+  expiresInSeconds: number
+}
+
+export type DeviceTokenResult =
+  | { type: "complete"; accessToken: string }
+  | { type: "pending" }
+  | { type: "slow_down"; intervalSeconds?: number }
+  | { type: "failed"; message: string }
+
+interface ModelCandidate {
+  model: ModelInfo
+  pickerEnabled: boolean
+  policyEnabled: boolean
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  const number = asNumber(value)
+  return number !== undefined && number > 0 ? number : undefined
+}
+
+export function parseDeviceAuthorization(raw: unknown): DeviceAuthorization {
+  if (!isRecord(raw)) throw new Error("GitHub device authorization response was not an object")
+  const deviceCode = asString(raw.device_code)
+  const userCode = asString(raw.user_code)
+  const verificationUri = asString(raw.verification_uri)
+  const expiresInSeconds = positiveNumber(raw.expires_in)
+  if (!deviceCode || !userCode || !verificationUri || !expiresInSeconds) {
+    throw new Error("GitHub device authorization response was incomplete")
+  }
+  let url: URL
+  try {
+    url = new URL(verificationUri)
+  } catch {
+    throw new Error("GitHub device authorization response contained an invalid verification URL")
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("GitHub device authorization response contained a non-HTTPS verification URL")
+  }
+  return {
+    deviceCode,
+    userCode,
+    verificationUri: url.toString(),
+    intervalSeconds: positiveNumber(raw.interval) ?? 5,
+    expiresInSeconds,
+  }
+}
+
+export function parseDeviceToken(raw: unknown): DeviceTokenResult {
+  if (!isRecord(raw)) throw new Error("GitHub device token response was not an object")
+  const accessToken = asString(raw.access_token)
+  if (accessToken) return { type: "complete", accessToken }
+  const error = asString(raw.error)
+  if (!error) throw new Error("GitHub device token response was incomplete")
+  if (error === "authorization_pending") return { type: "pending" }
+  if (error === "slow_down") {
+    const intervalSeconds = positiveNumber(raw.interval)
+    return intervalSeconds === undefined ? { type: "slow_down" } : { type: "slow_down", intervalSeconds }
+  }
+  const description = asString(raw.error_description)
+  return { type: "failed", message: `GitHub device login failed: ${description ? `${error}: ${description}` : error}` }
+}
+
+function thinking(raw: unknown): ModelInfo["thinking"] {
+  const options = asStringArray(raw).filter(
+    (effort): effort is ThinkingEffort => effort !== "none" && isThinkingEffort(effort),
+  )
+  if (options.length === 0) return undefined
+  const preferred = options.includes("medium") ? "medium" : options[0]!
+  return { options, default: preferred }
+}
+
+function candidate(raw: unknown): ModelCandidate | undefined {
+  if (!isRecord(raw)) return undefined
+  const id = asString(raw.id)?.trim()
+  const name = asString(raw.name)?.trim()
+  const hasEndpoints = Object.hasOwn(raw, "supported_endpoints")
+  const endpoints = asStringArray(raw.supported_endpoints)
+  if (
+    !id ||
+    !name ||
+    (hasEndpoints &&
+      (!Array.isArray(raw.supported_endpoints) ||
+        endpoints.length !== raw.supported_endpoints.length ||
+        !endpoints.includes("/chat/completions")))
+  )
+    return undefined
+  const capabilities = isRecord(raw.capabilities) ? raw.capabilities : undefined
+  const supports = capabilities && isRecord(capabilities.supports) ? capabilities.supports : undefined
+  if (supports?.tool_calls === false) return undefined
+  const policy = isRecord(raw.policy) ? raw.policy : undefined
+  if (policy?.state === "disabled") return undefined
+  const limits = capabilities && isRecord(capabilities.limits) ? capabilities.limits : undefined
+  const contextWindow = positiveNumber(limits?.max_context_window_tokens) ?? positiveNumber(limits?.max_prompt_tokens)
+  return {
+    model: {
+      id,
+      name,
+      ...(contextWindow === undefined ? {} : { contextWindow }),
+      inputModalities: ["text"],
+      thinking: thinking(supports?.reasoning_effort),
+    },
+    pickerEnabled: raw.model_picker_enabled === true,
+    policyEnabled: policy?.state === "enabled",
+  }
+}
+
+export function parseCopilotModels(raw: unknown, allowPolicyFallback: boolean): ModelInfo[] {
+  if (!isRecord(raw) || !Array.isArray(raw.data)) throw new Error("GitHub Copilot models response was invalid")
+  const candidates = raw.data.flatMap((entry) => {
+    const parsed = candidate(entry)
+    return parsed ? [parsed] : []
+  })
+  if (candidates.length === 0) {
+    let protocolCompatible = 0
+    let toolCompatible = 0
+    for (const entry of raw.data) {
+      if (!isRecord(entry)) continue
+      const hasEndpoints = Object.hasOwn(entry, "supported_endpoints")
+      const endpoints = asStringArray(entry.supported_endpoints)
+      if (
+        hasEndpoints &&
+        (!Array.isArray(entry.supported_endpoints) ||
+          endpoints.length !== entry.supported_endpoints.length ||
+          !endpoints.includes("/chat/completions"))
+      )
+        continue
+      protocolCompatible += 1
+      const capabilities = isRecord(entry.capabilities) ? entry.capabilities : undefined
+      const supports = capabilities && isRecord(capabilities.supports) ? capabilities.supports : undefined
+      if (supports?.tool_calls !== false) toolCompatible += 1
+    }
+    throw new Error(
+      `GitHub Copilot returned no compatible tool-capable agent models (${raw.data.length} advertised, ${protocolCompatible} protocol-compatible, ${toolCompatible} tool-compatible)`,
+    )
+  }
+  const pickerModels = candidates.filter((entry) => entry.pickerEnabled)
+  if (pickerModels.length > 0) return pickerModels.map((entry) => entry.model)
+  if (!allowPolicyFallback) {
+    throw new Error("GitHub Copilot has no compatible agent models enabled in the Enterprise model picker")
+  }
+  const policyModels = candidates.filter((entry) => entry.policyEnabled)
+  return (policyModels.length > 0 ? policyModels : candidates).map((entry) => entry.model)
+}

--- a/apps/website/src/content/sections.ts
+++ b/apps/website/src/content/sections.ts
@@ -199,7 +199,7 @@ export const plugins: Block[] = [
       { name: "lsp", description: "definitions, references, call hierarchy, diagnostics — ts, python, rust, go" },
       {
         name: "providers",
-        description: "ChatGPT, DeepSeek and Qwen in the box; any OpenAI-compatible endpoint plugs in",
+        description: "ChatGPT, GitHub Copilot, DeepSeek and Qwen in the box; more providers plug in",
       },
       { name: "memory", description: "secure global memory that follows you across sessions" },
       { name: "code-review", description: "`/review` the diff before it ships" },

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -32,7 +32,7 @@ Commands that save model, thinking, or TUI display preferences write the user fi
 
 Malformed `permissions`, `modes`, `redaction`, or `agents` configuration fails startup instead of silently running without those rules.
 
-Built-in provider IDs are `openai-chatgpt`, `deepseek`, and `alibaba-cloud`. `chatgpt` is an alias for `openai-chatgpt`, and `dashscope` is an alias for `alibaba-cloud`. The only built-in UI ID is `tui`. Plugins may register more providers, aliases, and UIs.
+Built-in provider IDs are `openai-chatgpt`, `github-copilot`, `deepseek`, and `alibaba-cloud`. `chatgpt` is an alias for `openai-chatgpt`, `copilot` is an alias for `github-copilot`, and `dashscope` is an alias for `alibaba-cloud`. The only built-in UI ID is `tui`. Plugins may register more providers, aliases, and UIs.
 
 ### Agents
 
@@ -225,7 +225,7 @@ Custom plugins can add values from their own credential sources with `ctx.regist
 
 `<name> models` and the TUI's `/model` command refresh every connected provider's model catalog. The catalog supplies the model picker, context-window tracking, input modalities, and the choices shown by `/thinking`.
 
-The ChatGPT provider discovers the account-visible catalog from the authenticated Codex service and stores the last successful result in `<app-home>/cache/openai-chatgpt-models.json`. If live discovery is unavailable, the app reports the failure and uses that cache, then its bundled catalog. DeepSeek discovers models from its authenticated `/models` endpoint and reports when it must use bundled model metadata. Alibaba Cloud uses a bundled catalog of Qwen models shared by Model Studio and Coding Plan.
+The ChatGPT provider discovers the account-visible catalog from the authenticated Codex service and stores the last successful result in `<app-home>/cache/openai-chatgpt-models.json`. If live discovery is unavailable, the app reports the failure and uses that cache, then its bundled catalog. GitHub Copilot discovers the models enabled for the connected subscription and stores the compatible subset in `<app-home>/cache/github-copilot-models.json`, bound to the token and GitHub domain that produced it. It exposes tool-capable models that advertise `/chat/completions` or omit endpoint metadata, matching Copilot's default transport behavior; models that explicitly advertise only Responses or Anthropic Messages remain hidden instead of being sent through an incompatible protocol. Some Personal Copilot accounts leave every model-picker flag unset, so the canonical Personal endpoint falls back to explicitly policy-enabled compatible models; Enterprise endpoints keep strict picker visibility. If live discovery is unavailable, only a matching validated cache is used; without one, model discovery fails rather than publishing speculative models. DeepSeek discovers models from its authenticated `/models` endpoint and reports when it must use bundled model metadata. Alibaba Cloud uses a bundled catalog of Qwen models shared by Model Studio and Coding Plan.
 
 ## Prompt commands
 
@@ -405,6 +405,15 @@ Connected resource catalogs, resource templates, and prompts are exposed through
 
 Alibaba Cloud Model Studio API keys are region-specific. Set `baseUrl` to the OpenAI-compatible API Host shown when the key is created. Coding Plan keys use `https://coding-intl.dashscope.aliyuncs.com/v1`. `/connect` stores the key without making a billable model request; the first turn validates that the key, endpoint, and selected model are compatible.
 
+### `github-copilot`
+
+| Option             | Type   | Default                  | Description                                                  |
+| ------------------ | ------ | ------------------------ | ------------------------------------------------------------ |
+| `enterpriseDomain` | string | `github.com`             | GitHub Enterprise domain or HTTPS URL used for device login. |
+| `clientName`       | string | Package application name | Client name used in the provider request user agent.         |
+
+Run `<name> connect copilot`, open the displayed GitHub device-login URL, and enter its one-time code. The app uses the resulting GitHub OAuth token directly with the Copilot API, matching OpenCode's dedicated OAuth-app flow, and validates that the account returns at least one compatible agent model before storing the token. Personal catalogs that omit endpoint, picker, or policy metadata are accepted unless a model is explicitly incompatible or disabled. For GitHub Enterprise, configure `enterpriseDomain` before connecting.
+
 ### `openai-chatgpt`
 
 | Option          | Type             | Default  | Description                                                 |
@@ -471,6 +480,9 @@ Every option is optional. A configuration using all currently supported built-in
     },
     "alibaba-cloud": {
       "baseUrl": "https://coding-intl.dashscope.aliyuncs.com/v1"
+    },
+    "github-copilot": {
+      "enterpriseDomain": "github.example.com"
     },
     "openai-chatgpt": {
       "contextWindow": 260000


### PR DESCRIPTION
Add GitHub Copilot as a built-in provider with device-flow authentication, Personal and Enterprise endpoint support, compatible model discovery and credential-bound caching, and chat-completions streaming. Include validation tests plus configuration and website documentation updates.