### PR TITLE
Fix native release builds on Windows and Alpine

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -166,7 +166,7 @@ jobs:
             -w /smoke/project \
             alpine:3.21.3 \
             /bin/sh -eu -c '
-              apk add --no-cache coreutils util-linux >/dev/null
+              apk add --no-cache coreutils libgcc libstdc++ util-linux >/dev/null
               test "$(/xal --version)" = "$EXPECTED"
               test "$(/xal --native-self-check)" = "$EXPECTED"
               test "$(/xal native-plugin-smoke)" = "[REDACTED]"

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,6 +24,8 @@ The supported targets are:
 | Linux            | x64, arm64    | glibc, musl   |
 | Windows          | x64, arm64    | Native `.exe` |
 
+The musl builds require the `libgcc` and `libstdc++` runtime packages. On Alpine Linux, install them with `apk add libgcc libstdc++`.
+
 Windows installation requires a POSIX shell such as Git Bash, MSYS2, or Cygwin. Running the command in WSL installs the Linux build inside WSL.
 
 Set `XAL_INSTALL_DIR` on the shell that runs the installer to choose another destination:

--- a/scripts/native/build.ts
+++ b/scripts/native/build.ts
@@ -227,9 +227,9 @@ async function nativeInputs(target: NativeTarget, portable: boolean): Promise<Na
   }
 }
 
-async function run(command: string[], env?: Record<string, string | undefined>): Promise<void> {
+async function run(command: string[], env?: Record<string, string | undefined>, cwd = ROOT): Promise<void> {
   const process = Bun.spawn(command, {
-    cwd: ROOT,
+    cwd,
     env,
     stdin: "ignore",
     stdout: "inherit",
@@ -408,17 +408,21 @@ async function compile(target: NativeTarget, version: string, outfile: string): 
     await rm(STAGED_ADDON, { force: true })
     await verifyArtifactManifest(manifestPath, await nativeInputs(target, true))
     await stageArtifact(manifestPath)
-    await run([
-      process.env.XAL_BUN ?? "bun",
-      "build",
-      "--compile",
-      "--minify",
-      `--target=${target.bunTarget}`,
-      "--define",
-      `XAL_VERSION=${JSON.stringify(version)}`,
-      join(ROOT, "apps/cli/src/index.ts"),
-      `--outfile=${resolve(outfile)}`,
-    ])
+    await run(
+      [
+        process.env.XAL_BUN ?? "bun",
+        "build",
+        "--compile",
+        "--minify",
+        `--target=${target.bunTarget}`,
+        "--define",
+        `XAL_VERSION=${JSON.stringify(version)}`,
+        join(ROOT, "apps/cli/src/index.ts"),
+        `--outfile=${resolve(outfile)}`,
+      ],
+      undefined,
+      process.platform === "win32" ? dirname(process.execPath) : ROOT,
+    )
   } finally {
     try {
       await rm(STAGED_ADDON, { force: true })

--- a/scripts/native/smoke.ts
+++ b/scripts/native/smoke.ts
@@ -86,7 +86,7 @@ async function main(): Promise<void> {
       throw new Error("standalone plugin redaction smoke output mismatch")
     }
   } finally {
-    await rm(directory, { recursive: true, force: true })
+    await rm(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
   }
 }
 


### PR DESCRIPTION
Run Windows native compilation from Bun’s executable directory, make smoke-test cleanup resilient to transient file locks, add Alpine C++ runtime dependencies to release smoke tests, and document the musl runtime requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows release builds by ensuring compilation runs from the correct location.
  - Made temporary smoke-test cleanup more reliable by retrying failed removals.

- **Documentation**
  - Added Alpine Linux installation guidance for required `libgcc` and `libstdc++` runtime packages.

- **Chores**
  - Updated Alpine Linux smoke testing to install the required runtime packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->