### PR TITLE
Keep tool contracts out of the system prompt

### DIFF
--- a/apps/cli/src/agent/prompt/base.test.ts
+++ b/apps/cli/src/agent/prompt/base.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import type { Tool } from "../../tools/types"
+import { registerBasePrompt } from "./base"
+import { composeSystemPrompt } from "./registry"
+
+test("keeps tool contracts out of the ambient system prompt", () => {
+  const tool: Tool = {
+    name: "inspect",
+    description: "Inspect a value without directing the workflow.",
+    parameters: { type: "object", additionalProperties: false },
+    title: () => "inspect",
+    async execute() {
+      return { output: "value" }
+    },
+  }
+  registerBasePrompt()
+
+  const prompt = composeSystemPrompt({
+    appName: "Xal",
+    platform: "test",
+    cwd: "/workspace",
+    kind: "primary",
+    tools: [tool],
+    mode: "normal",
+  })
+
+  expect(prompt).toContain("You are Xal")
+  expect(prompt).not.toContain(tool.name)
+  expect(prompt).not.toContain(tool.description)
+})

--- a/apps/cli/src/agent/prompt/base.ts
+++ b/apps/cli/src/agent/prompt/base.ts
@@ -10,26 +10,12 @@ export function registerBasePrompt(): void {
     text: () =>
       [
         "Tool calls may require the user's approval before they run. If the user denies an action, respect the denial and adjust your approach instead of retrying the same action.",
-        "Issue independent tool calls together when that saves time. Keep calls sequential when one depends on another's result or side effect.",
-        "Gather a coherent evidence set per round, combine related read-only inspection when the available tools support it, and expand only to answer a concrete unresolved question.",
-        "Avoid rereading broad files. Reuse prior evidence or answer follow-up questions with a symbol search or targeted range. Stop exploring once the requested behavior and concrete risks are understood; do not seek certainty through open-ended inspection.",
-        "Keep the user informed during tool-based work with brief assistant messages that are separate from reasoning. Before the first tool call, state what you understand and what you will do next. Skip this for trivial single-step work.",
-        "Send another progress update only after a meaningful finding, a change in approach, or the completion of a substantial phase. Lead with what you learned and what comes next.",
-        "Progress updates must explain intent, decisions, or outcomes. Do not expose private chain-of-thought, restate the request, use generic activity labels, or narrate routine tool calls.",
-        "Ground your statements in what you actually observed from tool output. Keep responses concise.",
+        "Do not claim results that were not observed in the conversation or tool output.",
+        "Do not create commits or publish changes unless the user asks.",
       ].join("\n"),
   })
   registerPrompt({
     id: "environment",
     text: (prompt) => `Platform: ${prompt.platform}. Working directory: ${prompt.cwd}.`,
-  })
-  registerPrompt({
-    id: "tools",
-    text(prompt) {
-      if (prompt.tools.length === 0) return "You have no tools available."
-      const names = prompt.tools.map((tool) => tool.name).join(", ")
-      const guidance = prompt.tools.filter((tool) => tool.prompt).map((tool) => `${tool.name}: ${tool.prompt}`)
-      return [`Available tools: ${names}.`, ...guidance].join("\n")
-    },
   })
 }

--- a/apps/cli/src/agent/session/output-contract.ts
+++ b/apps/cli/src/agent/session/output-contract.ts
@@ -26,10 +26,9 @@ export class OutputContract {
 
     this.tool = {
       name: "submit_output",
-      description: "Submit the final response as an object matching the caller-provided JSON Schema.",
+      description:
+        "Submit the final response exactly once as an object matching the caller-provided JSON Schema. Text responses do not satisfy this output contract; correct and resubmit values rejected by the schema.",
       parameters: schema,
-      prompt:
-        "When the task is complete, call this tool exactly once with the final answer. Do not finish with a text response. If the value is rejected, correct it and call this tool again.",
       title: () => "Submit structured output",
       readOnly: () => true,
       concurrency: () => "exclusive",

--- a/apps/cli/src/agent/task/task.test.ts
+++ b/apps/cli/src/agent/task/task.test.ts
@@ -38,23 +38,20 @@ function modelCatalog(): ModelCatalog {
   }
 }
 
-test("requires explicit delegation after describing the task tool", async () => {
+test("keeps task mechanics in the tool contract and delegation policy in instructions", async () => {
   const provider = new ScriptedProvider([completedRound("Done.")])
   const session = harness.createSession(provider, { interactive: true })
 
   const outcome = await runSettledTurn(session, { text: "Inspect the project.", images: [] })
   const request = provider.requests[0]
   if (!request) throw new Error("provider request was not recorded")
-  const operationalGuidance = "When delegation is authorized, use task only for concrete, bounded work"
   const delegationPolicy = "Task agents are an available capability, not the default workflow."
 
   expect(outcome.status).toBe("completed")
-  expect(request.tools.some((tool) => tool.name === "task")).toBe(true)
-  expect(request.instructions).toContain(operationalGuidance)
+  const task = request.tools.find((tool) => tool.name === "task")
+  expect(task?.description).toContain("concrete, bounded assignments")
   expect(request.instructions).toContain(delegationPolicy)
-  expect(request.instructions.indexOf(delegationPolicy)).toBeGreaterThan(
-    request.instructions.indexOf(operationalGuidance),
-  )
+  expect(request.instructions).not.toContain("Use the smallest useful batch")
 })
 
 test("inherits deny rules and durably delivers a bounded task report", async () => {

--- a/apps/cli/src/agent/task/tool.ts
+++ b/apps/cli/src/agent/task/tool.ts
@@ -84,8 +84,6 @@ export const taskTool: SessionTool = {
     required: ["context", "tasks"],
     additionalProperties: false,
   },
-  prompt:
-    "When delegation is authorized, use task only for concrete, bounded work that can proceed independently alongside useful local work; otherwise continue locally. Use the smallest useful batch and dispatch multiple tasks only when they are genuinely independent. Put shared background and cross-task contracts in context. Give every task exact targets, explicit non-goals, and observable acceptance criteria. Give concurrent shared write tasks disjoint files; use worktree isolation when edits may overlap. Isolated changes stay in the reported checkout and branch until you integrate them, then remove the checkout with worktree_remove. Agents start blank, so do not rely on conversation history. Results auto-deliver into your session; do not poll them. Continue useful non-overlapping work or end the current response while they run. Use job_status to inspect a task's activity and remaining time or turn budget when a supervision decision is needed, job_send to redirect it, job_extend to add time or turns before its budget expires, and job_kill when it is no longer useful. Explicit job_output waits return before an agent deadline; inspect its status and extend or stop it at that checkpoint instead of immediately waiting again. Never work on a dispatched task's files or duplicate its work while it runs.",
   sessionAware: true,
   available(ctx) {
     return ctx.kind === "primary" && ctx.interactive

--- a/apps/cli/src/background/tools.ts
+++ b/apps/cli/src/background/tools.ts
@@ -155,7 +155,7 @@ function statusOutput(id: string | undefined, ownerId: string): string {
 export const jobOutputTool: SessionTool = {
   name: "job_output",
   description:
-    "Collect a background job explicitly. For a process, returns new output and waits for output or exit; prefer one long wait over repeated short polls. Task-agent results normally deliver automatically. An explicit task-agent wait returns before its deadline with a supervision checkpoint so you can inspect, extend, steer, or stop it, and collecting a finished report suppresses duplicate automatic delivery.",
+    "Collect a background job explicitly. For a process, returns new output and optionally waits for output or exit. Task-agent results normally deliver automatically. An explicit task-agent wait returns before its deadline with a supervision checkpoint, and collecting a finished report suppresses duplicate automatic delivery.",
   parameters: {
     type: "object",
     properties: {
@@ -262,7 +262,7 @@ function extensionValue(args: Record<string, unknown>, field: string, maximum: n
 export const jobExtendTool: SessionTool = {
   name: "job_extend",
   description:
-    "Extend a running or queued task agent's execution budget. Adds wall-clock minutes, turns, or both without restarting the agent. Use job_status first to inspect its remaining budget.",
+    "Extend a running or queued task agent's execution budget by wall-clock minutes, turns, or both without restarting it. job_status reports the current remaining budget.",
   parameters: {
     type: "object",
     properties: {

--- a/apps/cli/src/git/worktree-tools.ts
+++ b/apps/cli/src/git/worktree-tools.ts
@@ -48,8 +48,6 @@ export const worktreeEnterTool: SessionTool = {
     required: ["name"],
     additionalProperties: false,
   },
-  prompt:
-    "Use worktree_enter when risky or parallel work should be isolated from the user's checkout; skip it for ordinary tasks. Commit or stash current changes first, and finish with worktree_exit, choosing whether to keep the checkout or remove it.",
   sessionAware: true,
   available(ctx) {
     return ctx.kind === "primary"

--- a/apps/cli/src/permissions/modes.ts
+++ b/apps/cli/src/permissions/modes.ts
@@ -9,7 +9,7 @@ const builtins: ModeDefinition[] = [
     readOnly: false,
     skipAsk: false,
     guidance:
-      "Routine actions run without confirmation, so act instead of narrating what you are about to do. Actions that reach outside the workspace, privileged or destructive system commands, and actions the user marked as sensitive ask for approval first. A denied action means the user declined it; adjust instead of retrying.",
+      "Routine actions run without confirmation. Actions that reach outside the workspace, privileged or destructive system commands, and actions the user marked as sensitive ask for approval first. A denied action means the user declined it; adjust instead of retrying.",
     subagentGuidance:
       "This delegation may modify the workspace. Routine actions run automatically, but any action that still requires separate approval will be denied.",
   },

--- a/apps/cli/src/plans/tool.ts
+++ b/apps/cli/src/plans/tool.ts
@@ -39,7 +39,7 @@ function restartDescription(usage: ContextUsage | undefined): string {
 export const submitPlanTool: InteractiveTool = {
   name: "submit_plan",
   description:
-    "Save the implementation plan for this session and ask the user to approve it or request revisions. Available only in interactive plan mode.",
+    "Save the complete implementation plan for this session and ask the user to approve it or request revisions. Each call replaces the proposal. Available only in interactive plan mode after material questions are resolved.",
   parameters: {
     type: "object",
     properties: {
@@ -53,8 +53,6 @@ export const submitPlanTool: InteractiveTool = {
     required: ["plan"],
     additionalProperties: false,
   },
-  prompt:
-    "Call submit_plan only after material questions are resolved. Submit a self-contained, decision-complete Markdown plan with the intended outcome, behavior-grouped implementation steps, exact targets where needed, concrete verification, and any chosen assumptions. Each call replaces the complete proposal. The tool renders it for approval or revision feedback.",
   interactive: true,
   available(ctx) {
     return ctx.interactive && ctx.mode === "plan"

--- a/apps/cli/src/plugins/ask/tool.ts
+++ b/apps/cli/src/plugins/ask/tool.ts
@@ -51,7 +51,7 @@ function parseQuestions(args: Record<string, unknown>): ElicitationQuestion[] {
 export const requestUserInputTool: InteractiveTool = {
   name: "request_user_input",
   description:
-    "Ask the user structured questions and wait for the answers. Prefer one question with two or three exclusive choices; the interface adds a free-form alternative automatically.",
+    "Ask the user structured questions and wait for the answers when a decision requires user input. This does not request approval for another tool. The interface adds a free-form alternative automatically.",
   parameters: {
     type: "object",
     properties: {
@@ -104,8 +104,6 @@ export const requestUserInputTool: InteractiveTool = {
     required: ["questions"],
     additionalProperties: false,
   },
-  prompt:
-    "Use request_user_input only when a decision blocks progress and you cannot resolve it from the request, the code, or sensible defaults. Prefer a single question with distinct, concrete options, and ask related questions together rather than one at a time. Do not use it to ask permission for tool actions.",
   interactive: true,
   title(args) {
     const count = Array.isArray(args.questions) ? args.questions.length : 0

--- a/apps/cli/src/plugins/ask/tool.ts
+++ b/apps/cli/src/plugins/ask/tool.ts
@@ -58,7 +58,7 @@ export const requestUserInputTool: InteractiveTool = {
       questions: {
         type: "array",
         minItems: 1,
-        description: "Questions to show the user. Prefer one focused question when possible",
+        description: "Questions to show the user",
         items: {
           type: "object",
           properties: {
@@ -77,8 +77,7 @@ export const requestUserInputTool: InteractiveTool = {
             },
             options: {
               type: "array",
-              description:
-                'Choices for the user. Prefer two or three mutually exclusive choices, put the recommended option first, and end its label with "(Recommended)"; never include a catch-all option, since a free-form answer is offered automatically',
+              description: "Choices shown for the question. The interface adds a free-form answer automatically",
               items: {
                 type: "object",
                 properties: {

--- a/apps/cli/src/plugins/files/edit.ts
+++ b/apps/cli/src/plugins/files/edit.ts
@@ -33,8 +33,6 @@ export const editTool: Tool = {
     required: ["file_path", "old_string", "new_string"],
     additionalProperties: false,
   },
-  prompt:
-    "Use edit for targeted changes to existing files; use write only for new files or full rewrites. Read the file first and copy old_string exactly as it appears after read's line-number prefix, never including the prefix itself. When old_string matches several places, add surrounding lines to make it unique, or set replace_all to change every occurrence — also the way to rename a symbol across a file.",
   title(args, ctx) {
     return displayPath(asString(args.file_path) ?? "", ctx.cwd)
   },

--- a/apps/cli/src/plugins/files/read.ts
+++ b/apps/cli/src/plugins/files/read.ts
@@ -30,8 +30,6 @@ export const readTool: Tool = {
     required: ["file_path"],
     additionalProperties: false,
   },
-  prompt:
-    "Use read for a standalone file view. Read several known files in parallel and request the useful enclosing range instead of tiny repeated slices. Use read-only bash when related searches and ranges from several files can be inspected coherently in one call.",
   title(args, ctx) {
     return displayPath(asString(args.file_path) ?? "", ctx.cwd)
   },

--- a/apps/cli/src/plugins/files/write.ts
+++ b/apps/cli/src/plugins/files/write.ts
@@ -8,7 +8,7 @@ import { pathPermission } from "./permission"
 export const writeTool: Tool = {
   name: "write",
   description:
-    "Write a file with the given content, creating it and any missing parent directories or replacing the existing file entirely. Returns a diff of the change. Paths are absolute or relative to the working directory.",
+    "Write a file with the given raw content, creating it and any missing parent directories or replacing the existing file entirely. Returns a diff of the change. Paths are absolute or relative to the working directory.",
   parameters: {
     type: "object",
     properties: {
@@ -24,8 +24,6 @@ export const writeTool: Tool = {
     required: ["file_path", "content"],
     additionalProperties: false,
   },
-  prompt:
-    "Use write for new files and complete rewrites; prefer edit for changing part of an existing file. Read an existing file before overwriting it, and pass raw file text without read's line-number prefixes. Do not create documentation or README files unless the user asks for them.",
   title(args, ctx) {
     return displayPath(asString(args.file_path) ?? "", ctx.cwd)
   },

--- a/apps/cli/src/plugins/lsp/tool.ts
+++ b/apps/cli/src/plugins/lsp/tool.ts
@@ -74,8 +74,6 @@ export function lspTool(manager: LspManager): Tool {
       required: ["operation", "file_path"],
       additionalProperties: false,
     },
-    prompt:
-      "Prefer lsp over text search when navigating definitions, references, implementations, symbols, hover types, or call relationships. Use diagnostics after a file changes when a configured server can provide compiler-style feedback. Read returned locations when you need surrounding source.",
     available: () => manager.hasAvailableServer(),
     title(args, ctx) {
       const operation = asString(args.operation) ?? "query"

--- a/apps/cli/src/plugins/memory/tool.ts
+++ b/apps/cli/src/plugins/memory/tool.ts
@@ -46,8 +46,6 @@ export function createMemoryTool(store: GlobalMemoryStore): Tool {
       required: ["operation"],
       additionalProperties: false,
     },
-    prompt:
-      "Global memory is user-controlled and may be stale. Read it before a requested change, preserve unrelated entries, and use replace or clear only after the user explicitly asks. Current repository state and newer user instructions always take precedence.",
     available(ctx) {
       return ctx.kind === "primary"
     },

--- a/apps/cli/src/plugins/search/glob.ts
+++ b/apps/cli/src/plugins/search/glob.ts
@@ -24,8 +24,6 @@ export const globTool: Tool = {
     required: ["pattern"],
     additionalProperties: false,
   },
-  prompt:
-    "Use glob to find files by name instead of find or ls in bash. Patterns are gitignore-style globs like src/**/*.ts, and results come newest first so recently changed files surface at the top. Run several speculative patterns as parallel calls when exploring.",
   title(args, ctx) {
     const pattern = asString(args.pattern) ?? ""
     const path = asString(args.path)

--- a/apps/cli/src/plugins/search/grep.ts
+++ b/apps/cli/src/plugins/search/grep.ts
@@ -37,8 +37,6 @@ export const grepTool: Tool = {
     required: ["pattern"],
     additionalProperties: false,
   },
-  prompt:
-    'Use grep for a standalone repository search. Start with the default content mode so one search identifies both locations and matching lines; use output_mode "files" only when you need paths without context. Scope with path and glob, combine related patterns when practical, and run independent searches as parallel calls. Use read-only bash when several related searches and targeted reads can be combined into one coherent inspection.',
   title(args, ctx) {
     const pattern = asString(args.pattern) ?? ""
     const glob = asString(args.glob)

--- a/apps/cli/src/plugins/web/fetch.ts
+++ b/apps/cli/src/plugins/web/fetch.ts
@@ -80,8 +80,6 @@ export const webfetchTool: Tool = {
     required: ["url"],
     additionalProperties: false,
   },
-  prompt:
-    "Use webfetch to read web pages, documentation, and API references instead of curl in bash. Fetch the specific page you need rather than crawling from a landing page, and fetch independent pages in parallel calls.",
   title(args) {
     return asString(args.url) ?? ""
   },

--- a/apps/cli/src/skills/register.ts
+++ b/apps/cli/src/skills/register.ts
@@ -13,7 +13,7 @@ function catalogPrompt(): string {
   if (skills.length === 0) return ""
   const entries = skills.map((skill) => `- ${skill.name}: ${skill.description.replace(/\s+/g, " ")}`)
   return [
-    "Reusable skills are available. Their metadata is listed below; full instructions stay out of context until loaded with the skill tool or injected by an explicit $name invocation.",
+    "Reusable skills are available. Load a skill when its description matches the task. Full instructions stay out of context until loaded with the skill tool or injected by an explicit $name invocation.",
     ...entries,
   ].join("\n")
 }

--- a/apps/cli/src/skills/tool.ts
+++ b/apps/cli/src/skills/tool.ts
@@ -38,8 +38,6 @@ export const skillTool: Tool = {
     required: ["name"],
     additionalProperties: false,
   },
-  prompt:
-    "Use skill when a task implicitly matches one from the catalog, then follow its instructions over your defaults and read only the supporting files it requires. A skill selected with an explicit $name invocation is already present in that user message; do not load it again. Use path to read a listed supporting file when the loaded instructions require it.",
   title(args) {
     const name = asString(args.name) ?? ""
     const path = asString(args.path)

--- a/apps/cli/src/skills/tool.ts
+++ b/apps/cli/src/skills/tool.ts
@@ -22,7 +22,7 @@ export async function renderSkill(skill: Skill): Promise<string> {
 export const skillTool: Tool = {
   name: "skill",
   description:
-    "Load a discovered skill's instructions and supporting-file list into the conversation, or read one supporting text file from its package. Call without path before using a skill.",
+    "Load a discovered skill's instructions and supporting-file list into the conversation, or read one supporting text file from its package. Omitting path loads the skill instructions.",
   parameters: {
     type: "object",
     properties: {

--- a/apps/cli/src/tasks/reminders.test.ts
+++ b/apps/cli/src/tasks/reminders.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { MAX_STALE_REMINDERS, MISSING_LIST_CALLS, STALE_LIST_CALLS, TaskReminders } from "./reminders"
+import { MAX_STALE_REMINDERS, STALE_LIST_CALLS, TaskReminders } from "./reminders"
 import type { TrackedTask } from "./types"
 
 const open: TrackedTask[] = [
@@ -11,22 +11,15 @@ function record(reminders: TaskReminders, calls: number): void {
   for (let index = 0; index < calls; index++) reminders.recordToolCall()
 }
 
-test("nudges once per turn to create a missing list after enough tool calls", () => {
+test("does not direct the model to create a task list", () => {
   const reminders = new TaskReminders()
-  record(reminders, MISSING_LIST_CALLS - 1)
+  record(reminders, STALE_LIST_CALLS * 2)
   expect(reminders.take([])).toBeUndefined()
-  reminders.recordToolCall()
-  expect(reminders.take([])).toContain("without an active task list")
-  record(reminders, MISSING_LIST_CALLS)
-  expect(reminders.take([])).toBeUndefined()
-  reminders.startTurn()
-  record(reminders, MISSING_LIST_CALLS)
-  expect(reminders.take([])).toContain("without an active task list")
 })
 
 test("leaves a fully completed list alone", () => {
   const reminders = new TaskReminders()
-  record(reminders, MISSING_LIST_CALLS)
+  record(reminders, STALE_LIST_CALLS)
   expect(reminders.take([{ step: "Done", status: "completed" }])).toBeUndefined()
 })
 

--- a/apps/cli/src/tasks/reminders.ts
+++ b/apps/cli/src/tasks/reminders.ts
@@ -1,6 +1,5 @@
 import type { TrackedTask } from "./types"
 
-export const MISSING_LIST_CALLS = 4
 export const STALE_LIST_CALLS = 10
 export const MAX_STALE_REMINDERS = 2
 
@@ -22,12 +21,10 @@ export function taskListSnapshot(tasks: TrackedTask[]): string {
 
 export class TaskReminders {
   private calls = 0
-  private missingNudged = false
   private staleNudges = 0
 
   startTurn(): void {
     this.calls = 0
-    this.missingNudged = false
     this.staleNudges = 0
   }
 
@@ -41,16 +38,7 @@ export class TaskReminders {
 
   take(tasks: TrackedTask[]): string | undefined {
     const open = openSteps(tasks)
-    if (open === 0) {
-      if (tasks.length > 0 || this.missingNudged || this.calls < MISSING_LIST_CALLS) return undefined
-      this.calls = 0
-      this.missingNudged = true
-      return [
-        "You have made several tool calls this turn without an active task list.",
-        "If the remaining work involves several distinct steps, capture them with update_tasks before continuing; if it is a single step, carry on.",
-        "Do not mention this notice to the user.",
-      ].join("\n")
-    }
+    if (open === 0) return undefined
     if (this.staleNudges >= MAX_STALE_REMINDERS || this.calls < STALE_LIST_CALLS) return undefined
     this.calls = 0
     this.staleNudges += 1

--- a/apps/cli/src/tasks/tool.ts
+++ b/apps/cli/src/tasks/tool.ts
@@ -33,8 +33,6 @@ export const updateTasksTool: Tool = {
     required: ["tasks"],
     additionalProperties: false,
   },
-  prompt:
-    "Create a task list with update_tasks before starting work that needs several distinct steps, when the user gives multiple requests, or when new instructions arrive mid-task; skip it for single-step or conversational work. Keep steps short and concrete. Replace the whole list on every call and keep it truthful: set a step to in_progress before working on it, and mark it completed immediately after it is actually done — never batch completions and never complete a step ahead of the work. When the plan changes, rewrite the list before continuing; removing a step is how a step is cancelled. A call whose only purpose is updating the list is fine. Do not repeat the list in your prose; the interface already displays it.",
   title(args) {
     const count = Array.isArray(args.tasks) ? args.tasks.length : 0
     if (count === 0) return "Clear task list"

--- a/apps/cli/src/tools/bash/tool.ts
+++ b/apps/cli/src/tools/bash/tool.ts
@@ -88,23 +88,15 @@ function parameters(): Record<string, unknown> {
 }
 
 function description(): string {
-  const base = `Execute a command with the user's shell in a persistent session: cd, exported variables, and aliases or functions defined by earlier commands stay in effect for later ones. Returns combined stdout and stderr followed by the exit code. Commands run without a TTY and are killed after ${DEFAULT_TIMEOUT_S} seconds unless timeout says otherwise.`
+  const base = `Execute a command with the user's shell in a persistent session: cd, exported variables, and aliases or functions defined by earlier commands stay in effect for later ones. Returns combined stdout and stderr followed by the exit code. Commands run without a TTY and are killed after ${DEFAULT_TIMEOUT_S} seconds unless timeout says otherwise. Managed background execution is selected with background:true; processes detached inside the shell are not tracked.`
   if (!sandboxAvailable()) return `${base} Each command requires the user's approval before it runs.`
   return `${base} Sandboxed commands run immediately with OS-enforced filesystem and network restrictions; other commands require the user's approval before they run.`
-}
-
-function guidance(): string {
-  const base =
-    "Use bash for shell work: builds, tests, git, and composed read-only inspection. For exploration, combine related metadata queries, searches, and targeted file ranges in one command when each step is safe and this avoids provider round trips; keep output focused and stop dependent chains on failure with &&. Use dedicated tools for simple standalone operations and parallel calls for known independent work. Quote paths that contain spaces. Prefer non-interactive flags; anything that waits for input hangs until the timeout kills it. Start long-lived processes like dev servers and watchers with background:true, follow them with job_output (pass wait to block until new output or exit instead of sleeping between polls), and stop them with job_kill; never background quick commands. Never detach processes with nohup, setsid, or a trailing &; only managed background:true jobs are tracked, delivered, and cleaned up. Only commit, amend, or push with git when the user asks for it."
-  if (!sandboxAvailable()) return base
-  return `${base} Use sandbox:"read" for inspection commands because the OS blocks filesystem state changes. Use sandbox:"workspace" for builds and commands that may write only in the workspace or temporary directories. Omit sandbox when the command needs network or writes elsewhere.`
 }
 
 export const bashTool: Tool = {
   name: "bash",
   description: description(),
   parameters: parameters(),
-  prompt: guidance(),
   title(args) {
     return asString(args.command) ?? ""
   },

--- a/apps/cli/src/tools/types.ts
+++ b/apps/cli/src/tools/types.ts
@@ -67,7 +67,6 @@ export interface ToolCallContext {
 }
 
 interface ToolContract extends ToolDefinition {
-  prompt?: string
   available?(ctx: ToolAvailabilityContext): boolean
   title(args: Record<string, unknown>, ctx: ToolCallContext): string
   readOnly?(args: Record<string, unknown>, ctx: ToolCallContext): boolean

--- a/docs/background-work.md
+++ b/docs/background-work.md
@@ -36,6 +36,8 @@ A background session stays an ordinary session. Once the worker cleanly releases
 
 Task agents are available for explicit delegation, not as the primary model's default workflow. The primary model is instructed to dispatch them only when the user or applicable `AGENTS.md` or skill instructions ask for sub-agents, delegation, or parallel agent work. Requests for depth, thoroughness, research, investigation, or detailed codebase analysis alone do not authorize delegation.
 
+The task tool's model-facing schema describes its mechanics and constraints but does not add a second global workflow prompt. Delegation policy is a separate primary-session prompt section so capability does not imply authorization.
+
 The `task` tool dispatches a batch of up to 8 independent assignments. Each assignment becomes its own agent session that starts without conversation history: the batch's shared `context` plus the assignment text is everything it knows. The call returns agent ids immediately; up to `agents.maxConcurrent` agents run at once and the rest queue.
 
 Each task declares its `access`:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,6 +22,12 @@ The referenced directory must contain a `plugin.ts` whose default export has a `
 
 Plugin registration is transactional. If importing, validating, or registering a plugin fails, Xal records a plugin registration failure and keeps none of that plugin's contributions.
 
+## Model-facing context
+
+Xal keeps its built-in system prompt small: identity, current environment, permission state, and stateful workflows that the user explicitly entered, such as plan mode. Tool definitions reach the model through the provider's native tool schema. A tool description should explain capability, inputs, effects, limits, and failure conditions; it should not tell the model to prefer that tool or impose a general workflow.
+
+Plugins may contribute system-prompt sections with `ctx.registerPrompt`. Reserve these for runtime state, an explicitly enabled mode, or instructions intrinsic to the plugin as a whole. Project `AGENTS.md` files, the skill catalog, configured MCP server instructions, and global memory are intentional prompt contributions because the user enabled those context sources. Prompt hooks can replace individual user messages and therefore remain a separate, explicitly trusted extension point.
+
 ## Lifecycle
 
 `ctx.runtime` exposes the app name and version, app home and cache paths, profile-aware credential loading, saving, and compare-and-swap replacement, plus transient secret protection. Credential operations require both the provider ID and immutable profile ID. Provider plugins should use this runtime instead of reading or rewriting Xal's shared credential file directly. Provider model discovery and streaming also receive the profile ID, while `connect` returns a credential for the core to store under the user-provided profile name.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -24,7 +24,7 @@ These values live under `pluginConfig.tui`:
 }
 ```
 
-The `display.toggle-details` shortcut, Ctrl+O by default, temporarily toggles transcript details for the current session without changing `showOutputs`. Normal mode keeps task dispatches compact and shows completed background work as its ID plus the first report line. Expanded mode adds assignment metadata, status and line counts, spawned-agent details, and report output. A fully completed task list is dismissed when the session returns to idle; lists with pending or in-progress work remain visible.
+The `display.toggle-details` shortcut, Ctrl+O by default, temporarily toggles transcript details for the current session without changing `showOutputs`. Normal mode keeps task dispatches compact and shows completed background work as its ID plus the first report line. Expanded mode adds assignment metadata, status and line counts, spawned-agent details, and report output. Task lists are optional and created at the model's discretion. Once one exists, Xal reminds the model to keep its user-visible state current; a fully completed list is dismissed when the session returns to idle, while lists with pending or in-progress work remain visible.
 
 ## Keybindings
 


### PR DESCRIPTION
Remove per-tool workflow prompts from ambient model instructions, clarify essential behavior in native tool descriptions, and make task-list creation optional while retaining stale-list reminders. Update delegation tests and documentation to reflect the smaller, capability-neutral prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Streamlined assistant guidance for clearer, more focused interactions.
  * Improved descriptions for task delegation, background jobs, plans, user questions, file operations, and shell execution.
  * Clarified structured output requirements and skill-loading behavior.
  * Task lists are now optional, with more targeted stale-list reminders.

* **Documentation**
  * Added guidance explaining tool context, prompt behavior, background work, and optional task lists.

* **Tests**
  * Updated coverage for prompt content, task guidance, and task-list reminders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->