### PR TITLE
fix: preserve IME sequence when inserting space

### DIFF
--- a/apps/cli/src/plugins/tui/components/composer.test.ts
+++ b/apps/cli/src/plugins/tui/components/composer.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import { ImeCommitBarrier, isImeCommit } from "./composer"
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 function waitForBarrier(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 60))
+  return wait(60)
 }
 
 describe("ImeCommitBarrier", () => {
@@ -41,18 +45,18 @@ describe("ImeCommitBarrier", () => {
   })
 
   test("re-arms the flush whenever an IME commit is observed", async () => {
-    const barrier = new ImeCommitBarrier()
+    const barrier = new ImeCommitBarrier(100)
     const events: string[] = []
 
     barrier.enqueue(() => events.push(" "))
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    barrier.observeCommit()
+    await wait(25)
     expect(events).toEqual([])
 
     barrier.observeCommit()
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await wait(85)
     expect(events).toEqual([])
 
-    barrier.observeCommit()
     await waitForBarrier()
 
     expect(events).toEqual([" "])

--- a/apps/cli/src/plugins/tui/components/composer.test.ts
+++ b/apps/cli/src/plugins/tui/components/composer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { ImeCommitBarrier, isImeCommit } from "./composer"
 
 function waitForBarrier(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 20))
+  return new Promise((resolve) => setTimeout(resolve, 60))
 }
 
 describe("ImeCommitBarrier", () => {
@@ -12,6 +12,7 @@ describe("ImeCommitBarrier", () => {
 
     expect(isImeCommit({ sequence: commit, ctrl: false, meta: false })).toBe(true)
     barrier.enqueue(() => events.push(" "))
+    barrier.observeCommit()
     setTimeout(() => events.push(commit), 0)
     await waitForBarrier()
 
@@ -32,10 +33,29 @@ describe("ImeCommitBarrier", () => {
     barrier.enqueue(() => events.push("newline"))
     barrier.enqueue(() => events.push("submit"))
     barrier.enqueue(() => events.push("next-input"))
+    barrier.observeCommit()
     setTimeout(() => events.push("commit"), 0)
     await waitForBarrier()
 
     expect(events).toEqual(["commit", "space", "newline", "submit", "next-input"])
+  })
+
+  test("re-arms the flush whenever an IME commit is observed", async () => {
+    const barrier = new ImeCommitBarrier()
+    const events: string[] = []
+
+    barrier.enqueue(() => events.push(" "))
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(events).toEqual([])
+
+    barrier.observeCommit()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(events).toEqual([])
+
+    barrier.observeCommit()
+    await waitForBarrier()
+
+    expect(events).toEqual([" "])
   })
 
   test("clears pending actions", async () => {

--- a/apps/cli/src/plugins/tui/components/composer.ts
+++ b/apps/cli/src/plugins/tui/components/composer.ts
@@ -43,10 +43,11 @@ interface PastedImage {
   image: ImageInput
 }
 
+const IME_COMMIT_SETTLE_MS = 20
+
 export class ImeCommitBarrier {
   private actions: (() => void)[] = []
-  private firstTimer: ReturnType<typeof setTimeout> | undefined
-  private secondTimer: ReturnType<typeof setTimeout> | undefined
+  private timer: ReturnType<typeof setTimeout> | undefined
 
   get pending(): boolean {
     return this.actions.length > 0
@@ -54,22 +55,26 @@ export class ImeCommitBarrier {
 
   enqueue(action: () => void): void {
     this.actions.push(action)
-    if (this.firstTimer !== undefined || this.secondTimer !== undefined) return
-    this.firstTimer = setTimeout(() => {
-      this.firstTimer = undefined
-      this.secondTimer = setTimeout(() => {
-        this.secondTimer = undefined
-        for (const action of this.actions.splice(0)) action()
-      }, 0)
-    }, 0)
+    this.arm()
+  }
+
+  observeCommit(): void {
+    if (!this.pending) return
+    this.arm()
   }
 
   clear(): void {
-    if (this.firstTimer !== undefined) clearTimeout(this.firstTimer)
-    if (this.secondTimer !== undefined) clearTimeout(this.secondTimer)
-    this.firstTimer = undefined
-    this.secondTimer = undefined
+    if (this.timer !== undefined) clearTimeout(this.timer)
+    this.timer = undefined
     this.actions = []
+  }
+
+  private arm(): void {
+    if (this.timer !== undefined) clearTimeout(this.timer)
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      for (const action of this.actions.splice(0)) action()
+    }, IME_COMMIT_SETTLE_MS)
   }
 }
 
@@ -191,11 +196,22 @@ export class Composer {
         if (key.name === "space" && !key.ctrl && !key.meta && !key.super && !key.hyper) {
           key.preventDefault()
           this.imeCommit.enqueue(() => {
+            if (!this.input.isDestroyed) this.input.insertText(key.sequence)
+          })
+          return
+        }
+        if (isImeCommit(key)) {
+          this.imeCommit.observeCommit()
+          return
+        }
+        if (key.name === "space" && !key.ctrl && !key.meta && !key.super && !key.hyper) {
+          key.preventDefault()
+          this.imeCommit.enqueue(() => {
             if (!this.input.isDestroyed) this.input.insertText(" ")
           })
           return
         }
-        if (!this.imeCommit.pending || isImeCommit(key)) return
+        if (!this.imeCommit.pending) return
         key.preventDefault()
         this.imeCommit.enqueue(() => {
           if (!this.input.isDestroyed) this.input.handleKeyPress(key)

--- a/apps/cli/src/plugins/tui/components/composer.ts
+++ b/apps/cli/src/plugins/tui/components/composer.ts
@@ -46,8 +46,13 @@ interface PastedImage {
 const IME_COMMIT_SETTLE_MS = 20
 
 export class ImeCommitBarrier {
+  private readonly settleMs: number
   private actions: (() => void)[] = []
   private timer: ReturnType<typeof setTimeout> | undefined
+
+  constructor(settleMs = IME_COMMIT_SETTLE_MS) {
+    this.settleMs = settleMs
+  }
 
   get pending(): boolean {
     return this.actions.length > 0
@@ -74,7 +79,7 @@ export class ImeCommitBarrier {
     this.timer = setTimeout(() => {
       this.timer = undefined
       for (const action of this.actions.splice(0)) action()
-    }, IME_COMMIT_SETTLE_MS)
+    }, this.settleMs)
   }
 }
 


### PR DESCRIPTION
## Summary

The original fix in #5 (`Fix IME composition boundaries`) did not fully resolve the Korean IME issue, so this PR fixes the root cause in a fork and sends it back upstream.

Key-event log analysis revealed the actual cause: when Space is pressed during Korean IME composition, the terminal (kitty keyboard protocol) delivers a **single key event** with `name="space"` and `sequence="요 "` — i.e. the committed composing character plus the space. The previous logic always inserted a plain `" "`, discarding the composing character (`"요"`), which made the last character appear to be deleted.

## Changes

- **`composer.ts`** — Insert the full `key.sequence` for space events so the committed composing character is preserved. The space branch is moved ahead of the `isImeCommit` check so Korean IME sequences are handled safely.
- **`composer.ts`** — Simplify `ImeCommitBarrier` from a double-timer to a single timer with `observeCommit()` re-arming, delaying the flush while composition commits keep arriving.
- **`composer.test.ts`** — Add a test covering the `observeCommit()` re-arm behavior.

## Testing

- `bun checks:fix` passes (typecheck / lint / format / test)
- 363 tests pass / 0 fail
- Manual reproduction on macOS + Kitty terminal with Korean IME:
  - Type `안녕하세요`, press Space → `안녕하세요 ` is inserted with the last character preserved

## Screenshots

https://github.com/user-attachments/assets/59c990ca-53be-4716-953e-3f2b56986b96



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of IME input commits in the composer.
  * Prevented queued actions from flushing prematurely during rapid input.
  * Ensured repeated commit events correctly delay pending actions.
  * Updated space-key handling for more reliable text entry.
  * Improved text-entry reliability when multiple IME commits occur in quick succession.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->