### PR TITLE
Add agent-friendly website resources and public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There is no stable installation channel during the beta rollout. See the [instal
 
 ## Documentation
 
-The [documentation](https://xal.sh/docs) covers configuration, the TUI, permissions, providers, integrations, plugins, reusable instructions, commands and skills, goals, and background work. The Markdown sources live in [`docs`](docs).
+The [documentation](https://xal.sh/docs) covers configuration, the TUI, permissions, providers, integrations, plugins, reusable instructions, commands and skills, goals, and background work. [Developer resources](https://xal.sh/developers) include the public product API, [OpenAPI specification](https://xal.sh/openapi.json), CLI automation, and MCP guidance. The Markdown sources live in [`docs`](docs).
 
 ## Run with Profiler
 

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "bun scripts/dev.ts",
     "build": "rm -rf dist && bun build src/index.html --outdir dist --minify --public-path=/ && bun scripts/prerender.ts",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/apps/website/scripts/dev.ts
+++ b/apps/website/scripts/dev.ts
@@ -1,6 +1,6 @@
 import { Glob } from "bun"
 import index from "../src/index.html"
-import { DOCS_PATH } from "../src/content/sections.ts"
+import { DOCS_PATH } from "../src/site.ts"
 import { loadDocuments } from "../src/docs/load.ts"
 import { documentPage, indexPage, type Shell } from "../src/docs/page.ts"
 import { navigation } from "../src/navigation.ts"

--- a/apps/website/scripts/prerender.ts
+++ b/apps/website/scripts/prerender.ts
@@ -1,7 +1,11 @@
 import { Glob } from "bun"
 import { GlobalRegistrator } from "@happy-dom/global-registrator"
-import type { Block } from "../src/tui/blocks.ts"
+import { docsIndexMarkdown, jsonLd, llmsFullText, llmsText } from "../src/agent-resources.ts"
+import { blocksMarkdown } from "../src/content/markdown.ts"
 import type { Shell } from "../src/docs/page.ts"
+import { openApi } from "../src/public-api.ts"
+import { DOCS_PATH, REPOSITORY, SITE_URL } from "../src/site.ts"
+import type { Block } from "../src/tui/blocks.ts"
 
 GlobalRegistrator.register()
 
@@ -19,7 +23,7 @@ const headers: Record<string, string> = {
 }
 if (Bun.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${Bun.env.GITHUB_TOKEN}`
 
-const repository = new URL(content.REPOSITORY)
+const repository = new URL(REPOSITORY)
 const response = await fetch(`https://api.github.com/repos${repository.pathname}`, { headers })
 if (!response.ok) throw new Error(`GitHub repository request failed with ${response.status}`)
 
@@ -45,13 +49,27 @@ function meta(html: string, selector: string, key: string, value: string): strin
   return html.replace(pattern, `<meta ${selector}="${key}" content="${attribute(value)}" />`)
 }
 
+const structuredData = jsonLd()
+
+function markdownPath(path: string): string {
+  if (path === "/") return "/index.md"
+  return `${path}/index.md`
+}
+
 const shell: Shell = ({ title, description, path, body }) => {
   let html = source.replace(/<title>[^<]*<\/title>/, `<title>${attribute(title)}</title>`)
   html = meta(html, "name", "description", description)
   html = meta(html, "property", "og:title", title)
   html = meta(html, "property", "og:description", description)
+  html = meta(html, "property", "og:url", `${SITE_URL}${path}`)
+  const links = [
+    `<link rel="canonical" href="${SITE_URL}${path}" />`,
+    `<link rel="alternate" type="text/markdown" href="${markdownPath(path)}" />`,
+    '<link rel="describedby" href="/llms.txt" />',
+    `<script type="application/ld+json">${structuredData}</script>`,
+  ].join("\n    ")
   return html
-    .replace("</head>", `<link rel="canonical" href="${content.SITE_URL}${path}" />\n  </head>`)
+    .replace("</head>", `${links}\n  </head>`)
     .replace("<body>", `<body>${navigation(path, githubStars)}`)
     .replace('<div id="app"></div>', body)
 }
@@ -61,27 +79,31 @@ function stream(blocks: Block[]): string {
   return `<div id="app"><div class="scrollback"><div class="stream">${nodes}</div></div></div>`
 }
 
-async function write(path: string, html: string): Promise<void> {
-  const file = path === "/" ? new URL("index.html", dist) : new URL(`.${path}/index.html`, dist)
-  await Bun.write(file, html)
+async function writePage(path: string, html: string, markdown: string): Promise<void> {
+  const directory = path === "/" ? "" : `.${path}/`
+  await Promise.all([
+    Bun.write(new URL(`${directory}index.html`, dist), html),
+    Bun.write(new URL(`${directory}index.md`, dist), markdown),
+  ])
 }
 
 const routes: string[] = []
 
-async function emit(path: string, html: string): Promise<void> {
-  await write(path, html)
+async function emit(path: string, html: string, markdown: string): Promise<void> {
+  await writePage(path, html, markdown)
   routes.push(path)
 }
 
 await emit(
   "/",
   shell({
-    title: "xal — a terminal coding harness",
+    title: "Xal terminal coding harness",
     description:
-      "A terminal coding harness with a headless agent core, where every capability — including the interface — is a plugin. One compiled binary.",
+      "Xal is an open-source terminal coding harness with a headless agent core and independent plugins for tools, interfaces, providers, language servers, MCP, skills, and workflows.",
     path: "/",
     body: stream(content.landing),
   }),
+  blocksMarkdown(content.landing),
 )
 
 for (const command of commands) {
@@ -107,21 +129,23 @@ for (const command of commands) {
 
   const label = command.name.slice(1)
   const path = command.route ?? command.name
+  const pageBlocks: Block[] = [content.banner, { kind: "user", text: command.name, at: "" }, ...blocks]
   await emit(
     path,
     shell({
-      title: `${label} · xal`,
-      description: `${command.describe} — xal, a terminal coding harness with a headless agent core.`,
+      title: `${label} | Xal terminal coding harness`,
+      description: `${command.describe}. Xal is an open-source terminal coding harness with a headless agent core.`,
       path,
-      body: stream([content.banner, { kind: "user", text: command.name, at: "" }, ...blocks]),
+      body: stream(pageBlocks),
     }),
+    blocksMarkdown(pageBlocks),
   )
 }
 
 const documents = await loadDocuments()
-await emit(content.DOCS_PATH, indexPage(shell, documents))
+await emit(DOCS_PATH, indexPage(shell, documents), docsIndexMarkdown(documents))
 for (const document of documents) {
-  await emit(`${content.DOCS_PATH}/${document.slug}`, documentPage(shell, documents, document))
+  await emit(`${DOCS_PATH}/${document.slug}`, documentPage(shell, documents, document), document.markdown)
 }
 
 const publicDir = new URL("../public/", import.meta.url)
@@ -130,14 +154,20 @@ for (const asset of assets) {
   await Bun.write(new URL(asset, dist), Bun.file(new URL(asset, publicDir)))
 }
 
+await Promise.all([
+  Bun.write(new URL("openapi.json", dist), `${JSON.stringify(openApi, null, 2)}\n`),
+  Bun.write(new URL("llms.txt", dist), llmsText(documents)),
+  Bun.write(new URL("llms-full.txt", dist), llmsFullText(documents)),
+])
+
 const sitemap = [
   '<?xml version="1.0" encoding="UTF-8"?>',
   '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-  ...routes.map((path) => `  <url><loc>${content.SITE_URL}${path}</loc></url>`),
+  ...routes.map((path) => `  <url><loc>${SITE_URL}${path}</loc></url>`),
   "</urlset>",
 ].join("\n")
 
 await Bun.write(new URL("sitemap.xml", dist), sitemap)
-await Bun.write(new URL("robots.txt", dist), `User-agent: *\nAllow: /\nSitemap: ${content.SITE_URL}/sitemap.xml\n`)
+await Bun.write(new URL("robots.txt", dist), `User-agent: *\nAllow: /\nSitemap: ${SITE_URL}/sitemap.xml\n`)
 
 console.log(`prerendered ${routes.length} routes: ${routes.join(" ")}`)

--- a/apps/website/src/agent-resources.ts
+++ b/apps/website/src/agent-resources.ts
@@ -119,7 +119,7 @@ export function llmsFullText(documents: Document[]): string {
 
 export function docsIndexMarkdown(documents: Document[]): string {
   const entries = documents
-    .map((document) => `- [${document.title}](/docs/${document.slug}): ${document.intro}`)
+    .map((document) => `- [${document.title}](${markdownUrl(`/docs/${document.slug}`)}): ${document.intro}`)
     .join("\n")
   return `# Xal documentation\n\nLearn how to install, configure, extend, and operate Xal.\n\n${entries}\n`
 }

--- a/apps/website/src/agent-resources.ts
+++ b/apps/website/src/agent-resources.ts
@@ -1,0 +1,125 @@
+import { appInfo } from "./app-info.ts"
+import type { Document } from "./docs/render.ts"
+import { product } from "./public-api.ts"
+import { INSTALL_COMMAND, PRODUCT_DESCRIPTION, REPOSITORY, SITE_URL } from "./site.ts"
+
+export function jsonLd(): string {
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": `${SITE_URL}/#website`,
+        name: "Xal",
+        alternateName: "xal.sh",
+        description: PRODUCT_DESCRIPTION,
+        url: SITE_URL,
+        inLanguage: "en",
+        publisher: { "@id": `${SITE_URL}/#organization` },
+      },
+      {
+        "@type": "Organization",
+        "@id": `${SITE_URL}/#organization`,
+        name: "Xal",
+        description: "The open-source project that develops and maintains the Xal terminal coding harness.",
+        url: SITE_URL,
+        logo: `${SITE_URL}/icon-512.png`,
+        sameAs: [`https://github.com/xal-sh`, REPOSITORY],
+        contactPoint: {
+          "@type": "ContactPoint",
+          contactType: "technical support",
+          url: `${SITE_URL}/contact`,
+          availableLanguage: "English",
+        },
+      },
+      {
+        "@type": "SoftwareApplication",
+        "@id": `${SITE_URL}/#software`,
+        name: "Xal",
+        alternateName: "xal",
+        description: PRODUCT_DESCRIPTION,
+        url: SITE_URL,
+        applicationCategory: "DeveloperApplication",
+        applicationSubCategory: "Terminal coding agent",
+        operatingSystem: product.platforms,
+        processorRequirements: product.architectures.join(", "),
+        softwareVersion: appInfo.version,
+        downloadUrl: `${SITE_URL}/install`,
+        installUrl: `${SITE_URL}/cli`,
+        softwareRequirements: "No runtime is required after installation.",
+        featureList: product.capabilities,
+        codeRepository: REPOSITORY,
+        license: `${REPOSITORY}/blob/main/LICENSE`,
+        isAccessibleForFree: true,
+        author: { "@id": `${SITE_URL}/#organization` },
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "USD",
+          availability: "https://schema.org/InStock",
+        },
+        sameAs: [REPOSITORY],
+      },
+    ],
+  }).replace(/</g, "\\u003c")
+}
+
+function markdownUrl(path: string): string {
+  if (path === "/") return `${SITE_URL}/index.md`
+  return `${SITE_URL}${path}/index.md`
+}
+
+export function llmsText(documents: Document[]): string {
+  const docs = documents
+    .map((document) => `- [${document.title}](${markdownUrl(`/docs/${document.slug}`)}): ${document.intro}`)
+    .join("\n")
+
+  return `# Xal
+
+> Xal is an open-source terminal coding harness with a headless agent core. It ships as one native CLI and uses independent plugins for tools, interfaces, AI providers, language servers, MCP integrations, skills, and workflows.
+
+Xal is currently in beta. The official command is \`xal\`, the canonical domain is ${SITE_URL}, and the source repository is ${REPOSITORY}. Install with \`${INSTALL_COMMAND}\`.
+
+## When to use Xal
+
+- [Repository development](${markdownUrl("/about")}): Use Xal when an agent needs to inspect, edit, test, or review a local software repository from a terminal.
+- [Permission-controlled automation](${markdownUrl("/docs/permissions")}): Use Xal when tool calls need explicit allow, ask, or deny policies, read-only planning, secret redaction, or reversible file changes.
+- [Extensible agent workflows](${markdownUrl("/docs/plugins")}): Use Xal when a team needs custom tools, providers, skills, commands, hooks, or a replacement interface without coupling plugins together.
+- [MCP and language servers](${markdownUrl("/mcp")}): Use Xal when a coding agent needs connected MCP systems or semantic code intelligence from language servers.
+- [Parallel coding work](${markdownUrl("/agents")}): Use Xal when sub-agents, background jobs, persistent sessions, or isolated worktrees fit the task.
+
+## Agent access
+
+- [Xal developer resources](${markdownUrl("/developers")}): API behavior, authentication status, CLI automation, plugin documentation, webhooks status, and MCP guidance.
+- [Xal OpenAPI specification](${SITE_URL}/openapi.json): OpenAPI 3.1 schema with a unique operationId, typed responses, and JSON error schemas.
+- [Xal public product API](${SITE_URL}/api/v1/product): Unauthenticated JSON metadata for product identity, version, install command, platforms, capabilities, and official links.
+- [Official Xal CLI](${markdownUrl("/cli")}): Installation, supported platforms, and commands for terminal automation.
+
+## Documentation
+
+- [Xal documentation index](${markdownUrl("/docs")}): Start here for installation, configuration, operation, and extension guides.
+${docs}
+
+## Trust and identity
+
+- [About Xal](${markdownUrl("/about")}): Product identity, capabilities, project status, license, and official links.
+- [Contact Xal](${markdownUrl("/contact")}): Official support route, issue-reporting guidance, and sensitive-data precautions.
+- [Xal privacy notice](${markdownUrl("/privacy")}): Website storage, hosting data, local application behavior, providers, and integrations.
+
+## Optional
+
+- [Xal source repository](${REPOSITORY}): MIT-licensed source, releases, issues, and project history.
+- [Xal sitemap](${SITE_URL}/sitemap.xml): Complete index of public human-readable pages.
+`
+}
+
+export function llmsFullText(documents: Document[]): string {
+  return `${llmsText(documents)}\n${documents.map((document) => document.markdown.trim()).join("\n\n---\n\n")}\n`
+}
+
+export function docsIndexMarkdown(documents: Document[]): string {
+  const entries = documents
+    .map((document) => `- [${document.title}](/docs/${document.slug}): ${document.intro}`)
+    .join("\n")
+  return `# Xal documentation\n\nLearn how to install, configure, extend, and operate Xal.\n\n${entries}\n`
+}

--- a/apps/website/src/content/commands.ts
+++ b/apps/website/src/content/commands.ts
@@ -59,6 +59,36 @@ export const commands: Command[] = [
     run: (context) => context.print(...content.agents),
   },
   {
+    name: "/contact",
+    routable: true,
+    describe: "official support and contact channels",
+    run: (context) => context.print(...content.contact),
+  },
+  {
+    name: "/privacy",
+    routable: true,
+    describe: "website and application privacy practices",
+    run: (context) => context.print(...content.privacy),
+  },
+  {
+    name: "/developers",
+    routable: true,
+    describe: "API, OpenAPI, CLI, plugins, and MCP",
+    run: (context) => context.print(...content.developers),
+  },
+  {
+    name: "/cli",
+    routable: true,
+    describe: "official Xal command-line tool",
+    run: (context) => context.print(...content.cli),
+  },
+  {
+    name: "/mcp",
+    routable: true,
+    describe: "connect Xal to MCP servers",
+    run: (context) => context.print(...content.mcp),
+  },
+  {
     name: "/install",
     routable: true,
     route: "/get",

--- a/apps/website/src/content/markdown.ts
+++ b/apps/website/src/content/markdown.ts
@@ -1,0 +1,68 @@
+import { appInfo } from "../app-info.ts"
+import type { Block, Doc } from "../tui/blocks.ts"
+
+function docMarkdown(node: Doc): string {
+  switch (node.kind) {
+    case "title":
+      return `# ${node.text}`
+    case "heading":
+      return `## ${node.text}`
+    case "paragraph":
+      return node.text
+    case "list":
+      return node.items.map((item) => `- ${item}`).join("\n")
+    case "code":
+      return `\`\`\`\n${node.lines.join("\n")}\n\`\`\``
+    case "rule":
+      return "---"
+  }
+}
+
+function blockMarkdown(block: Block): string {
+  switch (block.kind) {
+    case "banner":
+      return `${appInfo.name} v${appInfo.version}\n\nModel: ${block.model}\n\nWorking directory: ${block.cwd}`
+    case "info":
+      return block.text
+    case "user":
+      return `> ${block.text}`
+    case "doc":
+      return block.nodes.map(docMarkdown).join("\n\n")
+    case "command":
+      return `\`\`\`sh\n${block.text}\n\`\`\``
+    case "tool": {
+      const elapsed = block.elapsed ? ` in ${block.elapsed}` : ""
+      const output = block.output?.map((line) => line.text).join("\n")
+      return [`**Tool:** \`${block.label}\``, `${block.summary}${elapsed} (${block.outcome})`, output]
+        .filter(Boolean)
+        .join("\n\n")
+    }
+    case "tasks":
+      return [
+        `## Tasks`,
+        block.items.map((item) => `- [${item.state === "completed" ? "x" : " "}] ${item.text}`).join("\n"),
+      ].join("\n\n")
+    case "agents":
+      return [
+        `## ${block.heading}`,
+        block.rows.map((row) => `- **${row.title}**: ${row.metrics}; ${row.activity}`).join("\n"),
+      ].join("\n\n")
+    case "choices":
+      return [
+        `## ${block.header}`,
+        block.question,
+        block.options.map((option) => `- **${option.label}:** ${option.description}`).join("\n"),
+      ].join("\n\n")
+    case "diagram":
+      return [
+        `## ${block.core}`,
+        block.coreNote,
+        block.parts.map((part) => `- **${part.name}:** ${part.description}`).join("\n"),
+        block.caption,
+      ].join("\n\n")
+  }
+}
+
+export function blocksMarkdown(blocks: Block[]): string {
+  return `${blocks.map(blockMarkdown).join("\n\n")}\n`
+}

--- a/apps/website/src/content/sections.ts
+++ b/apps/website/src/content/sections.ts
@@ -279,7 +279,7 @@ export const contact: Block[] = [
       },
       {
         kind: "paragraph",
-        text: "Do not post API keys, access tokens, private repository content, personal data, or unredacted logs in a public issue. If a report describes a security vulnerability, do not publish exploit details. Open an issue that asks the maintainers to establish a private reporting channel, but leave all sensitive technical details out of that issue.",
+        text: "Do not post API keys, access tokens, private repository content, personal data, unredacted logs, or vulnerability details in a public issue. Report security vulnerabilities directly through [GitHub private vulnerability reporting](https://github.com/xal-sh/xal/security/advisories/new), where the report and follow-up discussion remain private between the reporter and Xal maintainers.",
       },
       {
         kind: "paragraph",

--- a/apps/website/src/content/sections.ts
+++ b/apps/website/src/content/sections.ts
@@ -1,9 +1,7 @@
+import { INSTALL_COMMAND } from "../site.ts"
 import type { Block } from "../tui/blocks.ts"
 
-export const SITE_URL = "https://xal.sh"
-export const DOCS_PATH = "/docs"
-export const REPOSITORY = "https://github.com/xal-sh/xal"
-export const INSTALL_COMMAND = "curl -fsSL https://xal.sh/install | sh -s -- --beta"
+export { DOCS_PATH, INSTALL_COMMAND, REPOSITORY, SITE_URL } from "../site.ts"
 
 export const MODEL = "gpt-5.6-sol"
 export const THINKING = "xhigh"
@@ -27,11 +25,27 @@ export const about: Block[] = [
   {
     kind: "doc",
     nodes: [
+      { kind: "title", text: "Xal terminal coding harness" },
       {
         kind: "paragraph",
-        text: "A terminal coding harness with a headless agent core — where every capability, is a plugin.",
+        text: "Xal is an open-source terminal coding harness with a headless agent core where every capability, including the interface, is a plugin. It gives coding agents the tools to inspect repositories, edit files, run commands, use language servers, connect to MCP servers, and complete real development work from a terminal.",
       },
-      { kind: "paragraph", text: "One compiled binary. Your providers, your rules, your terminal." },
+      {
+        kind: "paragraph",
+        text: "The default terminal interface ships as one compiled binary for macOS, Linux, and Windows. Xal supports multiple AI providers, reusable skills and commands, persistent sessions, background jobs, sub-agents, worktree isolation, code review, and project-specific instructions without requiring a JavaScript runtime after installation.",
+      },
+      {
+        kind: "paragraph",
+        text: "Xal starts with a small headless agent loop. Everything around it is a plugin: the terminal interface, AI providers, tools, language servers, MCP bridge, memory, skills, code review, and workflow hooks. Built-in features use the same plugin API available to project and user extensions, so the default harness is a starting point rather than a fixed product boundary.",
+      },
+      {
+        kind: "paragraph",
+        text: "Teams can add or replace individual capabilities, define custom modes and commands, register a different interface, and shape Xal around their own development process. Plugins remain independent by design and may not depend on one another, which keeps each customization removable and prevents the harness from turning into a tightly coupled framework.",
+      },
+      {
+        kind: "paragraph",
+        text: "Xal is currently in beta and is developed in public under the MIT License. Read the [Xal documentation](/docs), inspect the [source code](https://github.com/xal-sh/xal), review [developer resources](/developers), or use the [official CLI installation guide](/cli) to get started.",
+      },
     ],
   },
   {
@@ -245,6 +259,128 @@ export const agents: Block[] = [
       {
         kind: "paragraph",
         text: "Sessions persist through all of it: `xal resume` reopens yesterday mid-thought, `/fork` branches an experiment, `/export` writes the whole exchange to markdown.",
+      },
+    ],
+  },
+]
+
+export const contact: Block[] = [
+  {
+    kind: "doc",
+    nodes: [
+      { kind: "title", text: "Contact Xal" },
+      {
+        kind: "paragraph",
+        text: "Xal is an open-source project developed in public. For product questions, installation help, bug reports, and feature requests, use the [Xal GitHub issue tracker](https://github.com/xal-sh/xal/issues). Search existing issues first, then open a new issue with the Xal version, operating system, installation method, expected behavior, and the smallest reproduction you can provide.",
+      },
+      {
+        kind: "paragraph",
+        text: "For implementation questions, include relevant configuration with credentials removed, the command that failed, and the complete error output. Public issues are the preferred support channel because answers remain searchable for other users and maintainers can connect a report directly to code, documentation, or a release milestone.",
+      },
+      {
+        kind: "paragraph",
+        text: "Do not post API keys, access tokens, private repository content, personal data, or unredacted logs in a public issue. If a report describes a security vulnerability, do not publish exploit details. Open an issue that asks the maintainers to establish a private reporting channel, but leave all sensitive technical details out of that issue.",
+      },
+      {
+        kind: "paragraph",
+        text: "Xal does not currently offer paid support, a sales line, or a public telephone number. The canonical website is [xal.sh](https://xal.sh), the source repository is [xal-sh/xal](https://github.com/xal-sh/xal), and project documentation is available at [xal.sh/docs](/docs).",
+      },
+    ],
+  },
+]
+
+export const privacy: Block[] = [
+  {
+    kind: "doc",
+    nodes: [
+      { kind: "title", text: "Xal privacy notice" },
+      {
+        kind: "paragraph",
+        text: "The xal.sh website is a public documentation and download site for Xal. It does not provide user accounts, accept payments, or ask visitors to submit personal information. The interactive terminal demonstration runs in your browser. It stores only your selected light or dark theme in browser localStorage so that the preference can be restored on a later visit.",
+      },
+      {
+        kind: "paragraph",
+        text: "The website does not include first-party analytics, advertising trackers, or marketing cookies in this codebase. Hosting infrastructure may process standard request data such as IP address, user agent, requested URL, timestamp, and security signals to deliver the site, prevent abuse, and operate network logs. Requests for releases, issues, and source code follow links to GitHub and are then governed by GitHub's privacy terms.",
+      },
+      {
+        kind: "paragraph",
+        text: "The Xal command-line application runs on your machine and reads project files only through tools available to the active agent session and its permission rules. When you configure an AI provider, MCP server, or another external integration, data sent to that service is governed by your configuration and that service's terms. Review provider settings before sending private source code or personal data.",
+      },
+      {
+        kind: "paragraph",
+        text: "You can remove the website theme preference at any time by clearing site data for xal.sh. Privacy questions and correction requests can be raised through the [public contact channel](/contact). This notice applies to the xal.sh website and the official Xal project resources it describes; third-party plugins and services may have separate practices.",
+      },
+    ],
+  },
+]
+
+export const developers: Block[] = [
+  {
+    kind: "doc",
+    nodes: [
+      { kind: "title", text: "Xal developer resources" },
+      {
+        kind: "paragraph",
+        text: "Build integrations against Xal using its public website API, OpenAPI schema, terminal CLI, plugin system, and MCP client support. The website API is versioned under `/api/v1` and returns JSON. It currently exposes canonical product and integration metadata through `GET /api/v1/product`, with no account or API key required.",
+      },
+      { kind: "heading", text: "Public API" },
+      {
+        kind: "paragraph",
+        text: "Fetch [the product endpoint](/api/v1/product) for the current Xal version, support status, install command, supported platforms, capabilities, and canonical resource links. Use the machine-readable [Xal OpenAPI specification](/openapi.json) to generate a client or an LLM function definition. API errors use a stable JSON object with an error code, message, and resolution hint.",
+      },
+      { kind: "code", lines: ["curl -s https://xal.sh/api/v1/product", "curl -s https://xal.sh/openapi.json"] },
+      { kind: "heading", text: "Authentication and webhooks" },
+      {
+        kind: "paragraph",
+        text: "The public read-only API does not require authentication. Xal does not currently publish a hosted account API or webhook service, so agents should not invent credentials or webhook endpoints. The API is cacheable public metadata and is subject to normal edge abuse protection.",
+      },
+      { kind: "heading", text: "CLI, plugins, and MCP" },
+      {
+        kind: "paragraph",
+        text: "Install and automate the [official Xal CLI](/cli), read the [plugin guide](/docs/plugins), or configure external Model Context Protocol servers with the [MCP integration guide](/mcp). Xal is an MCP client and can consume tools, resources, and prompts from connected servers; xal.sh does not claim to host a public Xal MCP server.",
+      },
+    ],
+  },
+]
+
+export const cli: Block[] = [
+  {
+    kind: "doc",
+    nodes: [
+      { kind: "title", text: "Official Xal CLI" },
+      {
+        kind: "paragraph",
+        text: "The official Xal command-line tool is the `xal` native binary. It starts the terminal coding harness in the current project and can be scripted from POSIX-compatible shells. The beta installer selects the correct x64 or arm64 build for macOS, Linux, or Windows environments using Git Bash, MSYS2, or Cygwin.",
+      },
+      { kind: "code", lines: [INSTALL_COMMAND, "xal", "xal --mode plan", "xal update"] },
+      {
+        kind: "paragraph",
+        text: "The default install location is `~/.local/bin`. Pass installer options to select another path, and make sure that path is present in `PATH`. Xal ships as one compiled binary, so the installed CLI does not require Node.js, Bun, Python, or a package manager at runtime.",
+      },
+      {
+        kind: "paragraph",
+        text: "Use plan mode when an agent should investigate without modifying files, normal mode for approval-gated development, and yolo mode only when unattended writes are intentional. The [installation guide](/docs/install) documents supported targets, checksums, custom paths, beta channels, and release behavior. Source and release history are available in the [official repository](https://github.com/xal-sh/xal).",
+      },
+    ],
+  },
+]
+
+export const mcp: Block[] = [
+  {
+    kind: "doc",
+    nodes: [
+      { kind: "title", text: "Xal and MCP servers" },
+      {
+        kind: "paragraph",
+        text: "Xal can connect to Model Context Protocol servers and expose their tools, resources, and prompts to an agent session. Configure each server independently in Xal configuration using a local stdio command or a remote streamable HTTP URL. MCP capabilities remain separate from built-in plugins and from every other MCP integration.",
+      },
+      {
+        kind: "paragraph",
+        text: "Use MCP when a coding task needs an external system such as an issue tracker, design tool, cloud platform, database, or internal documentation service. Apply narrow permissions to imported tools, keep credentials outside committed project files, and verify a server's trust boundary before allowing mutating calls.",
+      },
+      {
+        kind: "paragraph",
+        text: "The [Xal integrations documentation](/docs/integrations) contains configuration shapes and transport guidance. Xal acts as an MCP client; the xal.sh domain does not currently host a public MCP endpoint. Agents looking for Xal developer interfaces should use the [public REST API](/developers), the [OpenAPI specification](/openapi.json), or the local plugin API instead of guessing an MCP server URL.",
       },
     ],
   },

--- a/apps/website/src/docs/load.ts
+++ b/apps/website/src/docs/load.ts
@@ -12,6 +12,7 @@ export async function loadDocuments(): Promise<Document[]> {
       "permissions",
       "providers",
       "integrations",
+      "api",
       "plugins",
       "commands-and-skills",
       "goals",

--- a/apps/website/src/docs/render.ts
+++ b/apps/website/src/docs/render.ts
@@ -2,7 +2,14 @@ import { parseBlocks, parseInline, type ListItem, type MarkdownBlock } from "xal
 
 export type Section = { id: string; text: string; level: number }
 
-export type Document = { slug: string; title: string; intro: string; sections: Section[]; html: string }
+export type Document = {
+  slug: string
+  title: string
+  intro: string
+  sections: Section[]
+  html: string
+  markdown: string
+}
 
 export function escape(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
@@ -103,5 +110,6 @@ export function toDocument(slug: string, source: string): Document {
         level: block.kind === "heading" ? block.level : 2,
       })),
     html: body.map(blockHtml).join("\n"),
+    markdown: source.endsWith("\n") ? source : `${source}\n`,
   }
 }

--- a/apps/website/src/index.html
+++ b/apps/website/src/index.html
@@ -3,17 +3,22 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>xal — a terminal coding harness</title>
+    <title>Xal terminal coding harness</title>
     <meta
       name="description"
-      content="xal is a terminal coding harness with a headless agent core, where every capability — including the interface — is a plugin. One compiled binary."
+      content="Xal is an open-source terminal coding harness with a headless agent core and independent plugins for tools, interfaces, providers, language servers, MCP, skills, and workflows."
     />
-    <meta property="og:title" content="xal — a terminal coding harness" />
+    <meta property="og:title" content="Xal terminal coding harness" />
     <meta
       property="og:description"
-      content="A headless agent core with a plugin for everything else. One compiled binary. Your providers, your rules, your terminal."
+      content="An open-source terminal coding harness with a headless agent core. One native binary, your providers, your rules, and your terminal."
     />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://xal.sh/" />
+    <meta property="og:image" content="https://xal.sh/icon-512.png" />
+    <meta property="og:image:alt" content="Xal terminal coding harness logo" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta name="theme-color" content="#0d1117" />
     <link rel="icon" href="../public/icon-light.svg" type="image/svg+xml" media="(prefers-color-scheme: dark)" />
     <link rel="icon" href="../public/icon-light-32.png" sizes="32x32" media="(prefers-color-scheme: dark)" />
@@ -35,18 +40,7 @@
   <body>
     <div id="app"></div>
     <noscript>
-      <div class="noscript">
-        <h1>xal</h1>
-        <p>
-          A terminal coding harness with a headless agent core, where every capability — including the interface — is a
-          plugin. One compiled binary: no runtime, no node_modules.
-        </p>
-        <p>
-          Permissions per tool, plan mode, secret redaction, undo across files and conversation, sub-agents, background
-          jobs, MCP and LSP. Configuration layers a user file with a project file.
-        </p>
-        <p>This page is an emulation of the real terminal interface and needs JavaScript to run.</p>
-      </div>
+      <p class="noscript">The Xal product information and documentation remain available without JavaScript.</p>
     </noscript>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/apps/website/src/navigation.ts
+++ b/apps/website/src/navigation.ts
@@ -1,4 +1,4 @@
-import { REPOSITORY } from "./content/sections.ts"
+import { REPOSITORY } from "./site.ts"
 
 function normalizedPath(pathname: string): string {
   return pathname.replace(/\/+$/, "") || "/"

--- a/apps/website/src/public-api.ts
+++ b/apps/website/src/public-api.ts
@@ -1,0 +1,178 @@
+import { appInfo } from "./app-info.ts"
+import { INSTALL_COMMAND, PRODUCT_DESCRIPTION, REPOSITORY, SITE_URL } from "./site.ts"
+
+export const product = {
+  name: "Xal",
+  command: "xal",
+  version: appInfo.version,
+  status: "beta",
+  description: PRODUCT_DESCRIPTION,
+  url: SITE_URL,
+  repository: REPOSITORY,
+  documentation: `${SITE_URL}/docs`,
+  license: "MIT",
+  installCommand: INSTALL_COMMAND,
+  platforms: ["macOS", "Linux", "Windows"],
+  architectures: ["x64", "arm64"],
+  capabilities: [
+    "repository inspection and editing",
+    "permission-gated shell commands",
+    "language server integration",
+    "Model Context Protocol client integration",
+    "multiple AI providers",
+    "plugins, skills, and custom commands",
+    "persistent sessions and background jobs",
+    "sub-agents and worktree isolation",
+  ],
+  resources: {
+    developers: `${SITE_URL}/developers`,
+    openapi: `${SITE_URL}/openapi.json`,
+    llms: `${SITE_URL}/llms.txt`,
+    cli: `${SITE_URL}/cli`,
+    contact: `${SITE_URL}/contact`,
+    privacy: `${SITE_URL}/privacy`,
+  },
+}
+
+export const openApi = {
+  openapi: "3.1.0",
+  info: {
+    title: "Xal Public API",
+    version: "1.0.0",
+    description:
+      "Public, read-only metadata for Xal, the terminal coding harness. No authentication is required. Every error is returned as JSON with a stable code and a resolution hint.",
+    license: {
+      name: "MIT",
+      identifier: "MIT",
+      url: `${REPOSITORY}/blob/main/LICENSE`,
+    },
+  },
+  servers: [{ url: `${SITE_URL}/api/v1`, description: "Production" }],
+  externalDocs: { description: "Xal developer resources", url: `${SITE_URL}/developers` },
+  paths: {
+    "/product": {
+      get: {
+        operationId: "getXalProduct",
+        summary: "Get Xal product metadata",
+        description:
+          "Returns the current Xal version, beta status, supported platforms, install command, capabilities, and canonical developer resource links. Use this operation when an agent needs to identify Xal or direct a user to an official integration surface.",
+        tags: ["Product"],
+        responses: {
+          "200": {
+            description: "Canonical Xal product metadata.",
+            headers: {
+              "Cache-Control": {
+                description: "Public cache policy for this metadata response.",
+                schema: { type: "string" },
+              },
+            },
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/Product" } },
+            },
+          },
+          "405": {
+            description: "The request uses a method other than GET, HEAD, or OPTIONS.",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
+            },
+          },
+          "406": {
+            description: "The request explicitly rejects application/json.",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Product: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "name",
+          "command",
+          "version",
+          "status",
+          "description",
+          "url",
+          "repository",
+          "documentation",
+          "license",
+          "installCommand",
+          "platforms",
+          "architectures",
+          "capabilities",
+          "resources",
+        ],
+        properties: {
+          name: { type: "string", description: "Official product name.", examples: ["Xal"] },
+          command: { type: "string", description: "Installed CLI command.", examples: ["xal"] },
+          version: { type: "string", description: "Current website build's Xal semantic version." },
+          status: { type: "string", enum: ["beta"], description: "Current release stability channel." },
+          description: { type: "string", description: "Concise canonical product description." },
+          url: { type: "string", format: "uri", description: "Canonical Xal website." },
+          repository: { type: "string", format: "uri", description: "Official source repository." },
+          documentation: { type: "string", format: "uri", description: "Official documentation index." },
+          license: { type: "string", enum: ["MIT"], description: "SPDX license identifier." },
+          installCommand: { type: "string", description: "Official beta installation shell command." },
+          platforms: {
+            type: "array",
+            description: "Supported operating-system families.",
+            items: { type: "string", enum: ["macOS", "Linux", "Windows"] },
+          },
+          architectures: {
+            type: "array",
+            description: "Supported processor architectures.",
+            items: { type: "string", enum: ["x64", "arm64"] },
+          },
+          capabilities: {
+            type: "array",
+            description: "High-level jobs available in the Xal coding harness.",
+            items: { type: "string" },
+          },
+          resources: {
+            type: "object",
+            additionalProperties: false,
+            description: "Canonical machine-readable, developer, support, and policy links.",
+            required: ["developers", "openapi", "llms", "cli", "contact", "privacy"],
+            properties: {
+              developers: { type: "string", format: "uri" },
+              openapi: { type: "string", format: "uri" },
+              llms: { type: "string", format: "uri" },
+              cli: { type: "string", format: "uri" },
+              contact: { type: "string", format: "uri" },
+              privacy: { type: "string", format: "uri" },
+            },
+          },
+        },
+      },
+      Error: {
+        type: "object",
+        additionalProperties: false,
+        required: ["code", "message", "resolution"],
+        properties: {
+          code: { type: "string", description: "Stable machine-readable error code." },
+          message: { type: "string", description: "Human-readable explanation of the error." },
+          resolution: { type: "string", description: "Specific action that can resolve the error." },
+        },
+      },
+      ErrorResponse: {
+        type: "object",
+        additionalProperties: false,
+        required: ["error"],
+        properties: { error: { $ref: "#/components/schemas/Error" } },
+      },
+    },
+  },
+}
+
+export function jsonError(
+  code: string,
+  message: string,
+  resolution: string,
+): { error: { code: string; message: string; resolution: string } } {
+  return { error: { code, message, resolution } }
+}

--- a/apps/website/src/site.ts
+++ b/apps/website/src/site.ts
@@ -1,0 +1,6 @@
+export const SITE_URL = "https://xal.sh"
+export const DOCS_PATH = "/docs"
+export const REPOSITORY = "https://github.com/xal-sh/xal"
+export const INSTALL_COMMAND = "curl -fsSL https://xal.sh/install | sh -s -- --beta"
+export const PRODUCT_DESCRIPTION =
+  "Xal is an open-source terminal coding harness with a headless agent core where every capability, including the interface, is a plugin."

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -384,6 +384,7 @@ a {
   margin-top: 1.55em;
 }
 
+.doc h1,
 .doc h2 {
   font-size: 1em;
   font-weight: 700;

--- a/apps/website/src/tui/blocks.ts
+++ b/apps/website/src/tui/blocks.ts
@@ -3,6 +3,7 @@ import { el, svgEl } from "./dom.ts"
 import { inline } from "./inline.ts"
 
 export type Doc =
+  | { kind: "title"; text: string }
   | { kind: "heading"; text: string }
   | { kind: "paragraph"; text: string }
   | { kind: "list"; items: string[] }
@@ -96,6 +97,8 @@ function doc(nodes: Doc[]): HTMLElement {
 
 function docNode(node: Doc): HTMLElement {
   switch (node.kind) {
+    case "title":
+      return el("h1", undefined, node.text)
     case "heading":
       return el("h2", undefined, node.text)
     case "paragraph":

--- a/apps/website/src/worker.ts
+++ b/apps/website/src/worker.ts
@@ -87,34 +87,64 @@ function bodyFor(request: Request, body: string): string | null {
   return request.method === "HEAD" ? null : body
 }
 
-function markdownResponse(request: Request, body: string, status: number): Response {
-  const headers = new Headers({ "Content-Type": "text/markdown; charset=utf-8" })
+type RecoveryLink = { label: string; url: string }
+
+function pageErrorResponse(
+  request: Request,
+  status: number,
+  title: string,
+  message: string,
+  links: RecoveryLink[] = [],
+): Response {
+  const representation = preferredType(request.headers.get("Accept"), ["text/html", "text/markdown"])
+  const headers = new Headers()
   addNegotiationHeaders(headers)
   headers.set("Link", '</llms.txt>; rel="describedby"')
-  return new Response(bodyFor(request, body), { status, headers })
+
+  if (representation === "text/markdown") {
+    const resources = links.length ? `\n\n${links.map((link) => `- [${link.label}](${link.url})`).join("\n")}` : ""
+    headers.set("Content-Type", "text/markdown; charset=utf-8")
+    return new Response(bodyFor(request, `# ${title}\n\n${message}${resources}\n`), { status, headers })
+  }
+
+  const resources = links.length
+    ? `<ul>${links.map((link) => `<li><a href="${link.url}">${link.label}</a></li>`).join("")}</ul>`
+    : ""
+  headers.set("Content-Type", "text/html; charset=utf-8")
+  return new Response(
+    bodyFor(
+      request,
+      `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${title} | Xal</title></head><body><main><h1>${title}</h1><p>${message}</p>${resources}</main></body></html>`,
+    ),
+    { status, headers },
+  )
 }
 
 function notFound(request: Request): Response {
-  return markdownResponse(
+  return pageErrorResponse(
     request,
-    `# 404: Xal resource not found
-
-No page or file exists at this URL. Continue with one of these official indexes:
-
-- [Xal documentation](https://xal.sh/docs)
-- [Xal developer resources](https://xal.sh/developers)
-- [Xal agent index](https://xal.sh/llms.txt)
-- [Xal sitemap](https://xal.sh/sitemap.xml)
-`,
     404,
+    "404: Xal resource not found",
+    "No page or file exists at this URL. Continue with one of these official indexes:",
+    [
+      { label: "Xal documentation", url: "https://xal.sh/docs" },
+      { label: "Xal developer resources", url: "https://xal.sh/developers" },
+      { label: "Xal agent index", url: "https://xal.sh/llms.txt" },
+      { label: "Xal sitemap", url: "https://xal.sh/sitemap.xml" },
+    ],
   )
 }
 
 function notAcceptable(request: Request): Response {
-  return markdownResponse(
-    request,
-    "# 406: Not Acceptable\n\nThis page is available as `text/html` or `text/markdown`. Update the `Accept` header and retry.\n",
-    406,
+  const headers = new Headers({ "Content-Type": "text/plain; charset=utf-8" })
+  addNegotiationHeaders(headers)
+  headers.set("Link", '</llms.txt>; rel="describedby"')
+  return new Response(
+    bodyFor(
+      request,
+      "406: Not Acceptable\n\nThis page is available as text/html or text/markdown. Update the Accept header and retry.\n",
+    ),
+    { status: 406, headers },
   )
 }
 
@@ -204,10 +234,11 @@ export async function handleRequest(request: Request, env: WorkerEnvironment): P
 
   if (pathname === "/install" || /\.[a-z0-9]+$/i.test(pathname)) return staticResponse(request, env)
   if (request.method !== "GET" && request.method !== "HEAD") {
-    const response = markdownResponse(
+    const response = pageErrorResponse(
       request,
-      "# 405: Method Not Allowed\n\nPublic Xal pages support GET and HEAD. Retry with one of those methods.\n",
       405,
+      "405: Method Not Allowed",
+      "Public Xal pages support GET and HEAD. Retry with one of those methods.",
     )
     response.headers.set("Allow", "GET, HEAD")
     return response

--- a/apps/website/src/worker.ts
+++ b/apps/website/src/worker.ts
@@ -1,0 +1,251 @@
+import { jsonError, product } from "./public-api.ts"
+
+export type AssetFetcher = { fetch(request: Request): Promise<Response> }
+export type WorkerEnvironment = { ASSETS: AssetFetcher }
+
+type AcceptEntry = { type: string; q: number; specificity: number }
+
+function parseAccept(header: string): AcceptEntry[] {
+  const entries: AcceptEntry[] = []
+  for (const raw of header.split(",")) {
+    const parts = raw
+      .trim()
+      .split(";")
+      .map((part) => part.trim())
+    const type = parts[0]?.toLowerCase()
+    if (!type) continue
+    let q = 1
+    for (const parameter of parts.slice(1)) {
+      const [name, value] = parameter.split("=").map((part) => part.trim())
+      if (name !== "q") continue
+      const parsed = Number(value)
+      if (!Number.isNaN(parsed)) q = Math.max(0, Math.min(1, parsed))
+    }
+    entries.push({ type, q, specificity: type === "*/*" ? 0 : type.endsWith("/*") ? 1 : 2 })
+  }
+  return entries
+}
+
+function matches(entry: AcceptEntry, candidate: string): boolean {
+  if (entry.type === "*/*") return true
+  if (entry.type.endsWith("/*")) return candidate.startsWith(entry.type.slice(0, -1))
+  return entry.type === candidate
+}
+
+export function preferredType(header: string | null, produces: string[]): string | null {
+  if (!header) return produces[0] ?? null
+  const entries = parseAccept(header)
+  if (entries.length === 0) return produces[0] ?? null
+
+  let bestType: string | null = null
+  let bestQ = -1
+  let bestPosition = Number.POSITIVE_INFINITY
+
+  for (const candidate of produces) {
+    let matched: AcceptEntry | undefined
+    let matchedPosition = Number.POSITIVE_INFINITY
+    for (const [position, entry] of entries.entries()) {
+      if (!matches(entry, candidate)) continue
+      if (matched && entry.specificity < matched.specificity) continue
+      if (matched && entry.specificity === matched.specificity && position > matchedPosition) continue
+      matched = entry
+      matchedPosition = position
+    }
+    if (!matched || matched.q <= 0) continue
+    if (matched.q < bestQ) continue
+    if (matched.q === bestQ && matchedPosition >= bestPosition) continue
+    bestType = candidate
+    bestQ = matched.q
+    bestPosition = matchedPosition
+  }
+
+  return bestType
+}
+
+function appendVary(headers: Headers, name: string): void {
+  const existing = headers.get("Vary")
+  if (!existing) {
+    headers.set("Vary", name)
+    return
+  }
+  const names = existing.split(",").map((value) => value.trim().toLowerCase())
+  if (!names.includes(name.toLowerCase())) headers.set("Vary", `${existing}, ${name}`)
+}
+
+function addNegotiationHeaders(headers: Headers): void {
+  appendVary(headers, "Accept")
+  appendVary(headers, "Accept-Encoding")
+}
+
+function markdownPath(pathname: string): string {
+  const clean = pathname.replace(/\/+$/, "") || "/"
+  if (clean === "/") return "/index.md"
+  return `${clean}/index.md`
+}
+
+function bodyFor(request: Request, body: string): string | null {
+  return request.method === "HEAD" ? null : body
+}
+
+function markdownResponse(request: Request, body: string, status: number): Response {
+  const headers = new Headers({ "Content-Type": "text/markdown; charset=utf-8" })
+  addNegotiationHeaders(headers)
+  headers.set("Link", '</llms.txt>; rel="describedby"')
+  return new Response(bodyFor(request, body), { status, headers })
+}
+
+function notFound(request: Request): Response {
+  return markdownResponse(
+    request,
+    `# 404: Xal resource not found
+
+No page or file exists at this URL. Continue with one of these official indexes:
+
+- [Xal documentation](https://xal.sh/docs)
+- [Xal developer resources](https://xal.sh/developers)
+- [Xal agent index](https://xal.sh/llms.txt)
+- [Xal sitemap](https://xal.sh/sitemap.xml)
+`,
+    404,
+  )
+}
+
+function notAcceptable(request: Request): Response {
+  return markdownResponse(
+    request,
+    "# 406: Not Acceptable\n\nThis page is available as `text/html` or `text/markdown`. Update the `Accept` header and retry.\n",
+    406,
+  )
+}
+
+function jsonResponse(request: Request, value: unknown, status = 200, extraHeaders?: HeadersInit): Response {
+  const headers = new Headers(extraHeaders)
+  headers.set("Content-Type", "application/json; charset=utf-8")
+  headers.set("Access-Control-Allow-Origin", "*")
+  addNegotiationHeaders(headers)
+  return new Response(bodyFor(request, JSON.stringify(value)), { status, headers })
+}
+
+function apiError(
+  request: Request,
+  status: number,
+  code: string,
+  message: string,
+  resolution: string,
+  headers?: HeadersInit,
+): Response {
+  return jsonResponse(request, jsonError(code, message, resolution), status, headers)
+}
+
+function apiResponse(request: Request, pathname: string): Response {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Headers": "Accept, Content-Type",
+        "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        Allow: "GET, HEAD, OPTIONS",
+      },
+    })
+  }
+
+  if (pathname !== "/api/v1/product") {
+    return apiError(
+      request,
+      404,
+      "api_route_not_found",
+      `No Xal API operation exists at ${pathname}.`,
+      "Read https://xal.sh/openapi.json and call a documented operation.",
+    )
+  }
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return apiError(
+      request,
+      405,
+      "method_not_allowed",
+      "This operation only supports GET and HEAD.",
+      "Retry with GET.",
+      {
+        Allow: "GET, HEAD, OPTIONS",
+      },
+    )
+  }
+
+  if (!preferredType(request.headers.get("Accept"), ["application/json"])) {
+    return apiError(
+      request,
+      406,
+      "not_acceptable",
+      "The Xal API only returns application/json.",
+      "Send Accept: application/json or Accept: */*.",
+    )
+  }
+
+  return jsonResponse(request, product, 200, { "Cache-Control": "public, max-age=300" })
+}
+
+async function staticResponse(request: Request, env: WorkerEnvironment): Promise<Response> {
+  const asset = await env.ASSETS.fetch(request)
+  if (asset.status === 404) return notFound(request)
+  const response = new Response(asset.body, asset)
+  if (new URL(request.url).pathname.endsWith(".md"))
+    response.headers.set("Content-Type", "text/markdown; charset=utf-8")
+  return response
+}
+
+export async function handleRequest(request: Request, env: WorkerEnvironment): Promise<Response> {
+  const url = new URL(request.url)
+  const pathname = url.pathname.replace(/\/+$/, "") || "/"
+
+  if (pathname === "/api") return Response.redirect(`${url.origin}/developers`, 308)
+  if (pathname.startsWith("/api/")) return apiResponse(request, pathname)
+
+  if (pathname === "/install" || /\.[a-z0-9]+$/i.test(pathname)) return staticResponse(request, env)
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    const response = markdownResponse(
+      request,
+      "# 405: Method Not Allowed\n\nPublic Xal pages support GET and HEAD. Retry with one of those methods.\n",
+      405,
+    )
+    response.headers.set("Allow", "GET, HEAD")
+    return response
+  }
+
+  const accept = request.headers.get("Accept")
+  const chosen = preferredType(accept, ["text/html", "text/markdown"])
+  if (!chosen && accept) return notAcceptable(request)
+
+  const markdownUrl = new URL(url)
+  markdownUrl.pathname = markdownPath(pathname)
+
+  if (chosen === "text/markdown") {
+    const markdown = await env.ASSETS.fetch(new Request(markdownUrl, request))
+    if (markdown.status === 200) {
+      const response = new Response(markdown.body, markdown)
+      response.headers.set("Content-Type", "text/markdown; charset=utf-8")
+      addNegotiationHeaders(response.headers)
+      response.headers.set("Link", '</llms.txt>; rel="describedby"')
+      return response
+    }
+  }
+
+  const html = await env.ASSETS.fetch(request)
+  if (html.status === 404) return notFound(request)
+  if (chosen === "text/markdown" && !preferredType(accept, ["text/html"])) return notAcceptable(request)
+
+  const response = new Response(html.body, html)
+  addNegotiationHeaders(response.headers)
+  response.headers.set(
+    "Link",
+    `<${markdownUrl.pathname}>; rel="alternate"; type="text/markdown", </llms.txt>; rel="describedby"`,
+  )
+  return response
+}
+
+export default {
+  fetch(request: Request, env: WorkerEnvironment): Promise<Response> {
+    return handleRequest(request, env)
+  },
+}

--- a/apps/website/test/content.test.ts
+++ b/apps/website/test/content.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test"
 import { GlobalRegistrator } from "@happy-dom/global-registrator"
-import { jsonLd, llmsText } from "../src/agent-resources.ts"
+import { docsIndexMarkdown, jsonLd, llmsText } from "../src/agent-resources.ts"
 import { blocksMarkdown } from "../src/content/markdown.ts"
 import * as content from "../src/content/sections.ts"
 import type { Document } from "../src/docs/render.ts"
@@ -51,7 +51,10 @@ describe("server-rendered content", () => {
 
   test("publishes substantial About, Contact, and Privacy content", () => {
     expect(blocksMarkdown(content.about).length).toBeGreaterThan(500)
-    expect(blocksMarkdown(content.contact).length).toBeGreaterThan(500)
+    const contact = blocksMarkdown(content.contact)
+    expect(contact.length).toBeGreaterThan(500)
+    expect(contact).toContain("https://github.com/xal-sh/xal/security/advisories/new")
+    expect(contact).not.toContain("establish a private reporting channel")
     expect(blocksMarkdown(content.privacy).length).toBeGreaterThan(500)
   })
 })
@@ -65,6 +68,7 @@ describe("agent resources", () => {
     expect(llms).toContain("https://xal.sh/openapi.json")
     expect(llms).toContain("https://xal.sh/docs/install/index.md")
     expect(llms).toContain("webhooks status")
+    expect(docsIndexMarkdown(documents)).toContain("https://xal.sh/docs/install/index.md")
   })
 
   test("publishes SoftwareApplication and Organization JSON-LD", () => {

--- a/apps/website/test/content.test.ts
+++ b/apps/website/test/content.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+import { jsonLd, llmsText } from "../src/agent-resources.ts"
+import { blocksMarkdown } from "../src/content/markdown.ts"
+import * as content from "../src/content/sections.ts"
+import type { Document } from "../src/docs/render.ts"
+
+GlobalRegistrator.register()
+const { renderBlock } = await import("../src/tui/blocks.ts")
+
+afterAll(() => GlobalRegistrator.unregister())
+
+const documents: Document[] = [
+  {
+    slug: "install",
+    title: "Installation and beta releases",
+    intro: "Install Xal and select a supported beta release.",
+    sections: [],
+    html: "<p>Install Xal.</p>",
+    markdown: "# Installation and beta releases\n\nInstall Xal.\n",
+  },
+  {
+    slug: "permissions",
+    title: "Permissions",
+    intro: "Control which tools an agent may use.",
+    sections: [],
+    html: "<p>Control tools.</p>",
+    markdown: "# Permissions\n\nControl tools.\n",
+  },
+  {
+    slug: "plugins",
+    title: "Plugins",
+    intro: "Extend Xal with independent plugins.",
+    sections: [],
+    html: "<p>Extend Xal.</p>",
+    markdown: "# Plugins\n\nExtend Xal.\n",
+  },
+]
+
+describe("server-rendered content", () => {
+  test("renders a semantic homepage with substantial raw text", () => {
+    const root = document.createElement("main")
+    for (const block of content.landing) root.append(renderBlock(block))
+    expect(root.querySelectorAll("h1")).toHaveLength(1)
+    expect(root.querySelector("h1")?.textContent).toBe("Xal terminal coding harness")
+    expect(root.textContent.length).toBeGreaterThan(500)
+    expect(root.textContent).toContain("open-source terminal coding harness")
+    expect(root.textContent).toContain("Everything around it is a plugin")
+    expect(root.textContent).toContain("Built-in features use the same plugin API")
+  })
+
+  test("publishes substantial About, Contact, and Privacy content", () => {
+    expect(blocksMarkdown(content.about).length).toBeGreaterThan(500)
+    expect(blocksMarkdown(content.contact).length).toBeGreaterThan(500)
+    expect(blocksMarkdown(content.privacy).length).toBeGreaterThan(500)
+  })
+})
+
+describe("agent resources", () => {
+  test("follows the llms.txt structure and gives when-to-use guidance", () => {
+    const llms = llmsText(documents)
+    expect(llms).toStartWith("# Xal\n\n> ")
+    expect(llms).toContain("## When to use Xal")
+    expect(llms).toContain("## Agent access")
+    expect(llms).toContain("https://xal.sh/openapi.json")
+    expect(llms).toContain("https://xal.sh/docs/install/index.md")
+    expect(llms).toContain("webhooks status")
+  })
+
+  test("publishes SoftwareApplication and Organization JSON-LD", () => {
+    const value: unknown = JSON.parse(jsonLd())
+    expect(value).toMatchObject({ "@context": "https://schema.org" })
+    if (typeof value !== "object" || value === null || !("@graph" in value) || !Array.isArray(value["@graph"])) {
+      throw new Error("JSON-LD graph is missing")
+    }
+    const software = value["@graph"].find(
+      (entry) => typeof entry === "object" && entry !== null && entry["@type"] === "SoftwareApplication",
+    )
+    const organization = value["@graph"].find(
+      (entry) => typeof entry === "object" && entry !== null && entry["@type"] === "Organization",
+    )
+    expect(software).toMatchObject({
+      name: "Xal",
+      applicationCategory: "DeveloperApplication",
+      isAccessibleForFree: true,
+    })
+    expect(organization).toMatchObject({ name: "Xal", contactPoint: { contactType: "technical support" } })
+  })
+
+  test("includes complete homepage metadata signals in the HTML shell", async () => {
+    const html = await Bun.file(new URL("../src/index.html", import.meta.url)).text()
+    expect(html).toContain('<html lang="en">')
+    expect(html).toContain('<meta property="og:type" content="website"')
+    expect(html).toContain('<meta property="og:image" content="https://xal.sh/icon-512.png"')
+  })
+})

--- a/apps/website/test/worker.test.ts
+++ b/apps/website/test/worker.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test"
+import { openApi, product } from "../src/public-api.ts"
+import { handleRequest, preferredType, type AssetFetcher } from "../src/worker.ts"
+
+const assets = new Map([
+  ["/", { body: "<!doctype html><html><body><h1>Xal</h1></body></html>", type: "text/html; charset=utf-8" }],
+  ["/index.md", { body: "# Xal\n\nTerminal coding harness.\n", type: "text/plain" }],
+  ["/about", { body: "<!doctype html><html><body><h1>About Xal</h1></body></html>", type: "text/html; charset=utf-8" }],
+  ["/about/index.md", { body: "# About Xal\n\nProduct details.\n", type: "text/plain" }],
+  ["/openapi.json", { body: JSON.stringify(openApi), type: "application/json" }],
+  ["/install", { body: "#!/bin/sh\n", type: "text/plain; charset=utf-8" }],
+])
+
+const fetcher: AssetFetcher = {
+  fetch(request) {
+    const asset = assets.get(new URL(request.url).pathname)
+    if (!asset) return Promise.resolve(new Response("asset not found", { status: 404 }))
+    return Promise.resolve(
+      new Response(request.method === "HEAD" ? null : asset.body, {
+        headers: { "Content-Type": asset.type },
+      }),
+    )
+  },
+}
+
+function request(path: string, init?: RequestInit): Promise<Response> {
+  return handleRequest(new Request(`https://xal.sh${path}`, init), { ASSETS: fetcher })
+}
+
+describe("content negotiation", () => {
+  test("honors q-values, specificity, and client order", () => {
+    expect(preferredType("*/*", ["text/html", "text/markdown"])).toBe("text/html")
+    expect(preferredType("text/markdown, text/html", ["text/html", "text/markdown"])).toBe("text/markdown")
+    expect(preferredType("text/markdown;q=0.4, text/html;q=0.8", ["text/html", "text/markdown"])).toBe("text/html")
+    expect(preferredType("text/html;q=0, */*;q=1", ["text/html", "text/markdown"])).toBe("text/markdown")
+    expect(preferredType("text/html;q=0, text/markdown;q=0", ["text/html", "text/markdown"])).toBeNull()
+  })
+
+  test("serves HTML by default with alternate and cache headers", async () => {
+    const response = await request("/")
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("text/html")
+    expect(response.headers.get("vary")).toBe("Accept, Accept-Encoding")
+    expect(response.headers.get("link")).toContain("</index.md>")
+    expect(response.headers.get("link")).toContain("</llms.txt>")
+  })
+
+  test("serves authored Markdown from the same URL", async () => {
+    const response = await request("/about", { headers: { Accept: "text/markdown" } })
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8")
+    expect(response.headers.get("vary")).toBe("Accept, Accept-Encoding")
+    expect(await response.text()).toStartWith("# About Xal")
+  })
+
+  test("returns 406 when no representation is acceptable", async () => {
+    const response = await request("/about", { headers: { Accept: "application/pdf" } })
+    expect(response.status).toBe(406)
+    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8")
+    expect(await response.text()).toContain("Update the `Accept` header")
+  })
+
+  test("passes the extensionless installer through unchanged", async () => {
+    const response = await request("/install", { headers: { Accept: "text/markdown" } })
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8")
+    expect(await response.text()).toBe("#!/bin/sh\n")
+  })
+})
+
+describe("agent-friendly errors", () => {
+  test("returns a real Markdown 404 with recovery links", async () => {
+    const response = await request("/missing-resource")
+    expect(response.status).toBe(404)
+    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8")
+    const body = await response.text()
+    expect(body).toContain("# 404")
+    expect(body).toContain("https://xal.sh/llms.txt")
+    expect(body).toContain("https://xal.sh/sitemap.xml")
+  })
+
+  test("returns structured JSON for unknown API routes", async () => {
+    const response = await request("/api/v1/missing")
+    expect(response.status).toBe(404)
+    expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8")
+    expect(await response.json()).toEqual({
+      error: {
+        code: "api_route_not_found",
+        message: "No Xal API operation exists at /api/v1/missing.",
+        resolution: "Read https://xal.sh/openapi.json and call a documented operation.",
+      },
+    })
+  })
+})
+
+describe("public API", () => {
+  test("returns public product metadata as JSON", async () => {
+    const response = await request("/api/v1/product", { headers: { Accept: "application/json" } })
+    expect(response.status).toBe(200)
+    expect(response.headers.get("access-control-allow-origin")).toBe("*")
+    expect(response.headers.get("cache-control")).toBe("public, max-age=300")
+    expect(await response.json()).toEqual(product)
+  })
+
+  test("returns JSON method and content-type errors", async () => {
+    const method = await request("/api/v1/product", { method: "POST" })
+    expect(method.status).toBe(405)
+    expect(method.headers.get("allow")).toBe("GET, HEAD, OPTIONS")
+    expect(await method.json()).toMatchObject({ error: { code: "method_not_allowed" } })
+
+    const type = await request("/api/v1/product", { headers: { Accept: "text/html" } })
+    expect(type.status).toBe(406)
+    expect(await type.json()).toMatchObject({ error: { code: "not_acceptable" } })
+  })
+
+  test("publishes a function-calling compatible OpenAPI operation", () => {
+    const operation = openApi.paths["/product"].get
+    expect(openApi.openapi).toBe("3.1.0")
+    expect(operation.operationId).toBe("getXalProduct")
+    expect(operation.description.length).toBeGreaterThan(100)
+    expect(operation.responses["200"].content["application/json"].schema.$ref).toBe("#/components/schemas/Product")
+    expect(openApi.components.schemas.Error.required).toEqual(["code", "message", "resolution"])
+  })
+})

--- a/apps/website/test/worker.test.ts
+++ b/apps/website/test/worker.test.ts
@@ -56,8 +56,8 @@ describe("content negotiation", () => {
   test("returns 406 when no representation is acceptable", async () => {
     const response = await request("/about", { headers: { Accept: "application/pdf" } })
     expect(response.status).toBe(406)
-    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8")
-    expect(await response.text()).toContain("Update the `Accept` header")
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8")
+    expect(await response.text()).toContain("Update the Accept header")
   })
 
   test("passes the extensionless installer through unchanged", async () => {
@@ -69,14 +69,38 @@ describe("content negotiation", () => {
 })
 
 describe("agent-friendly errors", () => {
-  test("returns a real Markdown 404 with recovery links", async () => {
-    const response = await request("/missing-resource")
+  test("returns HTML 404s to browsers with recovery links", async () => {
+    for (const init of [undefined, { headers: { Accept: "text/html" } }]) {
+      const response = await request("/missing-resource", init)
+      expect(response.status).toBe(404)
+      expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8")
+      const body = await response.text()
+      expect(body).toContain("<h1>404: Xal resource not found</h1>")
+      expect(body).toContain('href="https://xal.sh/llms.txt"')
+      expect(body).toContain('href="https://xal.sh/sitemap.xml"')
+    }
+  })
+
+  test("returns Markdown 404s to agents with recovery links", async () => {
+    const response = await request("/missing-resource", { headers: { Accept: "text/markdown" } })
     expect(response.status).toBe(404)
     expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8")
     const body = await response.text()
-    expect(body).toContain("# 404")
+    expect(body).toContain("# 404: Xal resource not found")
     expect(body).toContain("https://xal.sh/llms.txt")
     expect(body).toContain("https://xal.sh/sitemap.xml")
+  })
+
+  test("negotiates page method errors", async () => {
+    const html = await request("/about", { method: "POST", headers: { Accept: "text/html" } })
+    expect(html.status).toBe(405)
+    expect(html.headers.get("content-type")).toBe("text/html; charset=utf-8")
+    expect(await html.text()).toContain("<h1>405: Method Not Allowed</h1>")
+
+    const markdown = await request("/about", { method: "POST", headers: { Accept: "text/markdown" } })
+    expect(markdown.status).toBe(405)
+    expect(markdown.headers.get("content-type")).toBe("text/markdown; charset=utf-8")
+    expect(await markdown.text()).toStartWith("# 405: Method Not Allowed")
   })
 
   test("returns structured JSON for unknown API routes", async () => {

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -15,5 +15,5 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apps/website/wrangler.jsonc
+++ b/apps/website/wrangler.jsonc
@@ -2,9 +2,12 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "name": "xal-website",
   "compatibility_date": "2026-08-15",
+  "main": "./src/worker.ts",
   "assets": {
     "directory": "./dist",
+    "binding": "ASSETS",
     "html_handling": "drop-trailing-slash",
+    "run_worker_first": true,
   },
   "routes": [
     {

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,39 @@
+# Xal public website API
+
+The Xal website publishes a small, public REST API for agents and developer tooling that need canonical product metadata. It is separate from the local coding harness and does not provide remote access to a user's terminal, files, sessions, plugins, or configured AI providers.
+
+## Base URL and authentication
+
+The production base URL is `https://xal.sh/api/v1`. The API is read-only and does not require an account, API key, or bearer token. Responses allow cross-origin reads and may be cached. Normal hosting-layer abuse protection still applies.
+
+## Get product metadata
+
+`GET /api/v1/product` returns the current Xal version, beta status, supported platforms and architectures, install command, high-level capabilities, and canonical links for documentation, source, support, policy, and machine-readable resources.
+
+```sh
+curl -sS \
+  -H 'Accept: application/json' \
+  https://xal.sh/api/v1/product
+```
+
+The endpoint also supports `HEAD` and answers CORS preflight requests with `OPTIONS`.
+
+## Errors
+
+API errors always use `application/json` and contain a stable `code`, a human-readable `message`, and a specific `resolution` hint.
+
+```json
+{
+  "error": {
+    "code": "api_route_not_found",
+    "message": "No Xal API operation exists at /api/v1/example.",
+    "resolution": "Read https://xal.sh/openapi.json and call a documented operation."
+  }
+}
+```
+
+Unknown API routes return `404`, unsupported methods return `405`, and an `Accept` header that rejects JSON returns `406`.
+
+## OpenAPI and function calling
+
+The [Xal OpenAPI 3.1 specification](https://xal.sh/openapi.json) describes every published operation and response schema. Each operation has a unique `operationId`, a description, and typed JSON responses suitable for client generation or LLM function-calling adapters. The human-readable [Xal developer resources](https://xal.sh/developers) page records authentication, webhook, CLI, plugin, and MCP availability.


### PR DESCRIPTION
Add a public product API and OpenAPI schema, Markdown content negotiation, llms.txt resources, structured metadata, and expanded developer, CLI, MCP, contact, privacy, and API documentation with worker coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Contact, Privacy, Developer, CLI, and MCP pages.
  - Added Markdown versions of documentation and content-negotiated page delivery.
  - Added a public product API with OpenAPI documentation and structured error responses.
  - Added `llms.txt`, JSON-LD metadata, canonical links, and richer social sharing metadata.
  - Expanded product and platform information across the website.

- **Documentation**
  - Added public API documentation and developer resource links.
  - Improved documentation indexes and Markdown formatting.

- **Tests**
  - Added coverage for website content, metadata, APIs, redirects, caching, and content negotiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->