### PR TITLE
Add local provider usage ledger

### DIFF
--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -25,6 +25,7 @@ import { startProfiler, stopProfiler } from "./profiler/profiler"
 import { registerProviderClis } from "./providers/cli"
 import { refreshModelCatalogs } from "./providers/catalog"
 import { registerProviderCommands } from "./providers/commands"
+import { flushProviderUsage, startProviderUsageRecording } from "./usage/recorder"
 import { registerTrustClis } from "./project/cli"
 import { findProjectRoot } from "./project/root"
 import { ensureWorkspaceTrust } from "./project/trust"
@@ -89,6 +90,7 @@ async function initializeApp(args: string[], profile: boolean) {
     choose: args.length === 0 && process.stdin.isTTY ? chooseOption : undefined,
   })
   if (!trusted) return
+  startProviderUsageRecording()
   const root = await findProjectRoot(process.cwd())
   let settings = await loadSettings()
   settings = await prepareProjectMcp(root, settings, {
@@ -166,6 +168,12 @@ export async function finishApp(): Promise<void> {
   for (const failure of stopped.failures) {
     if (failure.phase !== "shutdown") continue
     console.error(redactText(`plugin shutdown failed: ${failure.plugin}: ${failure.reason}`))
+    if (process.exitCode === undefined || process.exitCode === 0) process.exitCode = 1
+  }
+  try {
+    await flushProviderUsage()
+  } catch (error) {
+    console.error(redactText(`usage not saved: ${describeError(error)}`))
     if (process.exitCode === undefined || process.exitCode === 0) process.exitCode = 1
   }
   const profile = await stopProfiler()

--- a/apps/cli/src/config/paths.ts
+++ b/apps/cli/src/config/paths.ts
@@ -55,6 +55,10 @@ export function profilerDir(): string {
   return join(agentHome(), "profiler")
 }
 
+export function usageDir(): string {
+  return join(agentHome(), "usage")
+}
+
 function projectSlug(cwd: string): string {
   const redacted = redactText(cwd)
   const slug = redacted.replace(/[^a-zA-Z0-9]+/g, "-")

--- a/apps/cli/src/profiler/profiler.ts
+++ b/apps/cli/src/profiler/profiler.ts
@@ -9,6 +9,7 @@ import { describeError } from "../lib/error"
 import type { StreamEvent, ThinkingEffort, Usage } from "../providers/types"
 import { redactText } from "../secrets/redactor"
 import type { ProcessExecution } from "../tools/types"
+import { recordProviderUsage, type UsageOutcome, type UsagePhase } from "../usage/recorder"
 
 type AnonymousExecution =
   | { status: "exited"; exitCode: number; sandbox?: "read" | "workspace" }
@@ -139,14 +140,17 @@ type ProfileRecord =
   | { type: "job_created"; job: string }
   | { type: "job_finished"; job: string; outcome: JobOutcome }
 
-export type ProviderPhase = "turn" | "compaction" | "goal_evaluation"
-type ProfileOutcome = "completed" | "failed" | "interrupted"
+export type ProviderPhase = UsagePhase
+type ProfileOutcome = UsageOutcome
 type JobOutcome = "completed" | "failed" | "interrupted" | "timed_out"
 type ToolConcurrency = "shared" | "exclusive"
 
 export interface ProviderRequestProfile {
   requestId: string
   startedAt: number
+  phase: ProviderPhase
+  provider: string
+  model: string
 }
 
 export interface ToolBatchProfile {
@@ -460,7 +464,7 @@ export function profileProviderRequestStarted(
   thinking: ThinkingEffort | undefined,
   attempt: number,
 ): ProviderRequestProfile {
-  const profile = { requestId: nextLabel("request"), startedAt: Date.now() }
+  const profile = { requestId: nextLabel("request"), startedAt: Date.now(), phase, provider, model }
   record({
     type: "provider_request_started",
     request: profile.requestId,
@@ -489,6 +493,15 @@ export function profileProviderRequestFinished(
   outcome: ProfileOutcome,
   usage?: Usage,
 ): void {
+  if (usage) {
+    recordProviderUsage({
+      provider: profile.provider,
+      model: profile.model,
+      phase: profile.phase,
+      outcome,
+      usage,
+    })
+  }
   record({
     type: "provider_request_finished",
     request: profile.requestId,

--- a/apps/cli/src/usage/recorder.test.ts
+++ b/apps/cli/src/usage/recorder.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { chmod, mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { UsageRecorder } from "./recorder"
+
+let directory: string | undefined
+
+afterEach(async () => {
+  if (directory) await rm(directory, { recursive: true, force: true })
+  directory = undefined
+})
+
+describe("usage recorder", () => {
+  test("writes prompt-free provider request usage as secure JSONL", async () => {
+    directory = await mkdtemp(join(tmpdir(), "xal-usage-"))
+    await chmod(directory, 0o700)
+    const recorder = new UsageRecorder(
+      directory,
+      "run-id",
+      () => new Date("2026-08-22T12:34:56.000Z"),
+      () => "request-id",
+    )
+
+    recorder.record({
+      provider: "openai-chatgpt",
+      model: "gpt-5.6-sol",
+      phase: "turn",
+      outcome: "completed",
+      usage: {
+        totalInputTokens: 120,
+        cacheReadInputTokens: 80,
+        cacheWriteInputTokens: 0,
+        outputTokens: 15,
+      },
+    })
+    await recorder.flush()
+
+    expect(await readdir(directory)).toEqual(["run-id.jsonl"])
+    const path = join(directory, "run-id.jsonl")
+    expect(JSON.parse((await readFile(path, "utf8")).trim())).toEqual({
+      type: "provider_usage",
+      version: 1,
+      id: "request-id",
+      timestamp: "2026-08-22T12:34:56.000Z",
+      provider: "openai-chatgpt",
+      model: "gpt-5.6-sol",
+      phase: "turn",
+      outcome: "completed",
+      usage: {
+        totalInputTokens: 120,
+        cacheReadInputTokens: 80,
+        cacheWriteInputTokens: 0,
+        outputTokens: 15,
+      },
+    })
+    expect((await stat(path)).mode & 0o777).toBe(0o600)
+  })
+})

--- a/apps/cli/src/usage/recorder.ts
+++ b/apps/cli/src/usage/recorder.ts
@@ -1,0 +1,102 @@
+import { appendFile, mkdir } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { usageDir } from "../config/paths"
+import type { Usage } from "../providers/types"
+
+export type UsagePhase = "turn" | "compaction" | "goal_evaluation"
+export type UsageOutcome = "completed" | "failed" | "interrupted"
+
+export interface ProviderUsageInput {
+  provider: string
+  model: string
+  phase: UsagePhase
+  outcome: UsageOutcome
+  usage: Usage
+}
+
+export interface ProviderUsageTokens {
+  totalInputTokens: number
+  cacheReadInputTokens: number
+  cacheWriteInputTokens: number
+  outputTokens: number
+}
+
+export interface ProviderUsageRecord {
+  type: "provider_usage"
+  version: 1
+  id: string
+  timestamp: string
+  provider: string
+  model: string
+  phase: UsagePhase
+  outcome: UsageOutcome
+  usage: ProviderUsageTokens
+}
+
+export class UsageRecorder {
+  private readonly path: string
+  private queue = Promise.resolve()
+  private failure: unknown
+
+  constructor(
+    directory: string,
+    runId: string = crypto.randomUUID(),
+    private readonly now: () => Date = () => new Date(),
+    private readonly nextId: () => string = () => crypto.randomUUID(),
+  ) {
+    this.path = join(directory, `${runId}.jsonl`)
+  }
+
+  record(input: ProviderUsageInput): void {
+    if (this.failure) return
+    const cacheReadInputTokens = input.usage.cacheReadInputTokens ?? 0
+    const cacheWriteInputTokens = input.usage.cacheWriteInputTokens ?? 0
+    const record: ProviderUsageRecord = {
+      type: "provider_usage",
+      version: 1,
+      id: this.nextId(),
+      timestamp: this.now().toISOString(),
+      provider: input.provider,
+      model: input.model,
+      phase: input.phase,
+      outcome: input.outcome,
+      usage: {
+        totalInputTokens: input.usage.totalInputTokens ?? cacheReadInputTokens + cacheWriteInputTokens,
+        cacheReadInputTokens,
+        cacheWriteInputTokens,
+        outputTokens: input.usage.outputTokens ?? 0,
+      },
+    }
+    const writing = this.queue.then(() => {
+      if (this.failure) throw new Error("usage recorder is unavailable", { cause: this.failure })
+      return this.write(record)
+    })
+    this.queue = writing.catch((error: unknown) => {
+      this.failure = error
+    })
+  }
+
+  async flush(): Promise<void> {
+    await this.queue
+    if (this.failure) throw new Error("usage recorder is unavailable", { cause: this.failure })
+  }
+
+  private async write(record: ProviderUsageRecord): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true, mode: 0o700 })
+    await appendFile(this.path, `${JSON.stringify(record)}\n`, { encoding: "utf8", mode: 0o600 })
+  }
+}
+
+let recorder: UsageRecorder | undefined
+
+export function startProviderUsageRecording(): void {
+  recorder ??= new UsageRecorder(usageDir())
+}
+
+export function recordProviderUsage(input: ProviderUsageInput): void {
+  recorder?.record(input)
+}
+
+export function flushProviderUsage(): Promise<void> {
+  return recorder?.flush() ?? Promise.resolve()
+}

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,6 +1,30 @@
 # Integrations
 
-Connect Xal to language servers for semantic code intelligence and MCP servers for external tools, resources, and prompts.
+Connect Xal to local usage dashboards, language servers for semantic code intelligence, and MCP servers for external tools, resources, and prompts.
+
+## Local usage dashboards
+
+Xal writes one prompt-free usage record after each provider request that reports token counts. Records are JSONL files under `$XAL_HOME/usage/`, or `~/.xal/usage/` by default. Each Xal process owns a separate file so concurrent sessions never contend for the same log.
+
+```json
+{
+  "type": "provider_usage",
+  "version": 1,
+  "id": "…",
+  "timestamp": "2026-08-22T12:34:56.000Z",
+  "provider": "openai-chatgpt",
+  "model": "gpt-5.6-sol",
+  "phase": "turn",
+  "outcome": "completed",
+  "usage": { "totalInputTokens": 120, "cacheReadInputTokens": 80, "cacheWriteInputTokens": 0, "outputTokens": 15 }
+}
+```
+
+`totalInputTokens` includes cached input. The cache-read and cache-write fields identify the subsets that may be priced differently. `outputTokens` is the provider-reported output total. `phase` distinguishes normal turns from compaction and goal-evaluation requests, while `outcome` preserves requests that reported billable usage before failing or being interrupted.
+
+The ledger contains no prompts, responses, working directories, profile names, credentials, or account identifiers. Files and directories are created with user-only permissions. Xal flushes pending records during shutdown and exits with an error if the ledger could not be written. Existing session transcripts are not backfilled, so collection starts with the first run of a Xal version that supports the ledger.
+
+Usage dashboards should read this native ledger instead of treating Xal as Codex or asking Xal to write into another tool's home directory. The `provider` field lets a dashboard attribute ChatGPT usage to Codex, Anthropic usage to Claude, xAI usage to Grok, and other supported providers without coupling to Xal's full session format.
 
 ## Language servers
 


### PR DESCRIPTION
Record prompt-free provider token usage in per-process secure JSONL files, flush pending records during shutdown, add critical recorder coverage, and document the ledger for local usage dashboards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local provider usage tracking for requests, including provider, model, phase, outcome, and token totals.
  * Usage data is securely saved locally and flushed when the CLI exits.
  * Added guidance for building local usage dashboards.

* **Bug Fixes**
  * Usage flush failures are reported with sensitive details redacted and produce a nonzero exit status when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->