### PR TITLE
Show hook events only in expanded output

### DIFF
--- a/apps/cli/src/plugins/tui/controllers/agent-events.ts
+++ b/apps/cli/src/plugins/tui/controllers/agent-events.ts
@@ -157,7 +157,7 @@ export class AgentEventController {
         break
       case "hook_finished":
         scrollback.append({
-          kind: "info",
+          kind: "hook",
           text: `hook: ${event.hook} · ${event.event} · ${event.action} · ${event.elapsedMs}ms`,
         })
         break

--- a/apps/cli/src/plugins/tui/scrollback/blocks.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/blocks.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import { blockVisible, type Block } from "./blocks"
+
+const hook: Block = { kind: "hook", text: "hook: muxy/notify · prompt · continued · 14ms" }
+
+test("hooks are visible only in output view", () => {
+  expect(blockVisible(hook, false, false)).toBe(false)
+  expect(blockVisible(hook, true, false)).toBe(true)
+})
+
+test("normal transcript blocks remain visible outside output view", () => {
+  expect(blockVisible({ kind: "info", text: "workspace changed" }, false, false)).toBe(true)
+})

--- a/apps/cli/src/plugins/tui/scrollback/blocks.ts
+++ b/apps/cli/src/plugins/tui/scrollback/blocks.ts
@@ -19,6 +19,11 @@ export interface InfoBlock {
   text: string
 }
 
+export interface HookBlock {
+  kind: "hook"
+  text: string
+}
+
 export interface ErrorBlock {
   kind: "error"
   text: string
@@ -84,6 +89,7 @@ export type Block =
   | BannerBlock
   | UserBlock
   | InfoBlock
+  | HookBlock
   | ErrorBlock
   | NoticeBlock
   | CompactionBlock
@@ -91,3 +97,25 @@ export type Block =
   | PlanBlock
   | StreamBlock
   | ToolBlock
+
+export function blockVisible(block: Block, expanded: boolean, reasoningVisible: boolean): boolean {
+  switch (block.kind) {
+    case "hook":
+      return expanded
+    case "reasoning":
+      return reasoningVisible
+    case "banner":
+    case "user":
+    case "info":
+    case "error":
+    case "notice":
+    case "compaction":
+    case "background":
+    case "plan":
+    case "text":
+    case "tool":
+      return true
+  }
+  const exhaustive: never = block
+  return exhaustive
+}

--- a/apps/cli/src/plugins/tui/scrollback/render.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.ts
@@ -70,6 +70,7 @@ export function renderBlock(
     case "user":
       return frame(ctx, bubble(ctx, block, userBackground))
     case "info":
+    case "hook":
       return frame(ctx, paragraph(ctx, { content: block.text, attributes: TextAttributes.DIM }))
     case "error":
       return frame(ctx, paragraph(ctx, { content: `x ${block.text}`, color: COLORS.error }))

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -2,7 +2,7 @@ import type { CliRenderer, RGBA, ScrollbackSurface, TextRenderable } from "@open
 import { createRedactedStream, redactText, type RedactedStream } from "../../../secrets/redactor"
 import type { TuiPreferences } from "../config"
 import { COLORS, userMessageBackground } from "../theme/colors"
-import type { Block, HeaderBlock, StreamBlock, StreamKind } from "./blocks"
+import { blockVisible, type Block, type HeaderBlock, type StreamBlock, type StreamKind } from "./blocks"
 import { contentWidth, renderBlock, streamContent, streamView } from "./render"
 
 const FLUSH_MS = 50
@@ -33,6 +33,7 @@ function redactBlock(block: Block): Block {
       return { ...block, model: redactText(block.model), cwd: redactText(block.cwd) }
     case "user":
     case "info":
+    case "hook":
     case "error":
     case "text":
     case "reasoning":
@@ -317,6 +318,6 @@ export class Scrollback {
   }
 
   private visible(block: Block): boolean {
-    return block.kind !== "reasoning" || this.reasoningVisible
+    return blockVisible(block, this.expanded, this.reasoningVisible)
   }
 }


### PR DESCRIPTION
Classify completed hook events as dedicated scrollback blocks and hide them from the normal transcript unless output view is expanded. Add visibility tests while preserving existing rendering and redaction behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hook completion messages now appear as dimmed, expandable entries in the output view.
  - Hook messages are hidden from the standard transcript view to reduce visual clutter.
  - Reasoning and transcript visibility continue to follow their existing display settings.

- **Bug Fixes**
  - Improved scrollback filtering so hook messages display consistently based on the selected view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->