### PR TITLE
Commit only visible columns for streamed markdown

### DIFF
--- a/apps/cli/src/plugins/tui/markdown/render.ts
+++ b/apps/cli/src/plugins/tui/markdown/render.ts
@@ -8,6 +8,7 @@ import { highlightCode, type CodeToken, type CodeTokenKind } from "./syntax"
 
 export interface RenderedMarkdown {
   content: StyledText
+  widths: number[]
   rows: number
   stable: number
   flowing: boolean
@@ -53,6 +54,7 @@ export function renderMarkdown(source: string, width: number, muted = false): Re
 
   return {
     content: new StyledText(chunks),
+    widths: lines.map(lineWidth),
     rows: Math.max(1, lines.length),
     stable,
     flowing: blocks[blocks.length - 1]?.kind !== "table",

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
 import { displayWidth, terminalGlyph } from "../lib/text"
 import type { BackgroundBlock } from "./blocks"
 import { backgroundResultHeading } from "./render"
+import { Scrollback } from "./scrollback"
 
 const completed: BackgroundBlock = {
   kind: "background",
@@ -37,4 +39,43 @@ test("normal background results keep failures visible and stay on one row", () =
   expect(longId).toEndWith(" · failed")
   expect([heading, narrow, longId].every((value) => displayWidth(value) <= 48)).toBe(true)
   expect(displayWidth(narrow)).toBeLessThanOrEqual(30)
+})
+
+test("assistant markdown commits only its visible columns", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 24,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false },
+      undefined,
+    )
+    scrollback.appendStream(
+      "text",
+      "```sh\n./benchmark.sh \\\n    --attempts 5 \\\n    --model gpt-5.6-luna \\\n    --job-name xal-gpt-5.6-luna-xhigh-k5\n```",
+    )
+    scrollback.endStream()
+
+    const commits = setup.externalOutput.take()
+    const rows = commits.flatMap((commit) => commit.rows)
+    expect(rows).toEqual([
+      "",
+      "  ./benchmark.sh \\",
+      "      --attempts 5 \\",
+      "      --model gpt-5.6-luna \\",
+      "      --job-name xal-gpt-5.6-luna-xhigh-k5",
+    ])
+    expect(commits.every((commit) => commit.height === 1)).toBe(true)
+    expect(commits.map((commit) => commit.rowColumns)).toEqual(rows.map(displayWidth))
+  } finally {
+    setup.renderer.destroy()
+  }
 })

--- a/apps/cli/src/plugins/tui/scrollback/render.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.ts
@@ -39,6 +39,7 @@ const GUTTER = 2
 interface StreamView {
   view: Renderable
   text: TextRenderable
+  rendered: RenderedMarkdown
 }
 
 export function contentWidth(ctx: RenderContext): number {
@@ -49,11 +50,19 @@ export function streamContent(block: StreamBlock, width: number): RenderedMarkdo
   return renderMarkdown(block.text, width, block.kind === "reasoning")
 }
 
+export function streamRowColumns(rendered: RenderedMarkdown, height: number): number[] {
+  const contentStart = height - rendered.rows
+  return Array.from({ length: height }, (_, row) => {
+    const width = rendered.widths[row - contentStart]
+    return width ? GUTTER + width : 0
+  })
+}
+
 export function streamView(ctx: RenderContext, block: StreamBlock): StreamView {
   const rendered = streamContent(block, contentWidth(ctx))
   const text = paragraph(ctx, { content: rendered.content, height: rendered.rows, wrapMode: "none" })
   text.truncate = false
-  return { view: frame(ctx, text), text }
+  return { view: frame(ctx, text), text, rendered }
 }
 
 export function renderBlock(

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -1,9 +1,10 @@
 import type { CliRenderer, RGBA, ScrollbackSurface, TextRenderable } from "@opentui/core"
 import { createRedactedStream, redactText, type RedactedStream } from "../../../secrets/redactor"
 import type { TuiPreferences } from "../config"
+import type { RenderedMarkdown } from "../markdown/render"
 import { COLORS, userMessageBackground } from "../theme/colors"
 import { blockVisible, type Block, type HeaderBlock, type StreamBlock, type StreamKind } from "./blocks"
-import { contentWidth, renderBlock, streamContent, streamView } from "./render"
+import { contentWidth, renderBlock, streamContent, streamRowColumns, streamView } from "./render"
 
 const FLUSH_MS = 50
 
@@ -296,13 +297,17 @@ export class Scrollback {
     if (target <= stream.committed) return
     const rows = target - stream.committed
     this.onCommit(rows)
-    stream.surface.commitRows(stream.committed, target)
+    this.commitStreamRows(stream.surface, rendered, stream.committed, target)
     this.committed += rows
     stream.committed = target
   }
 
   private emit(block: Block, previous: Block | undefined): void {
     if (!this.visible(block)) return
+    if (block.kind === "text" || block.kind === "reasoning") {
+      this.emitStream(block)
+      return
+    }
     const surface = this.renderer.createScrollbackSurface()
     try {
       surface.root.add(
@@ -314,6 +319,32 @@ export class Scrollback {
       this.committed += surface.height
     } finally {
       surface.destroy()
+    }
+  }
+
+  private emitStream(block: StreamBlock): void {
+    const surface = this.renderer.createScrollbackSurface()
+    try {
+      const { view, rendered } = streamView(surface.renderContext, block)
+      surface.root.add(view)
+      surface.render()
+      this.onCommit(surface.height)
+      this.commitStreamRows(surface, rendered, 0, surface.height)
+      this.committed += surface.height
+    } finally {
+      surface.destroy()
+    }
+  }
+
+  private commitStreamRows(
+    surface: ScrollbackSurface,
+    rendered: RenderedMarkdown,
+    startRow: number,
+    endRowExclusive: number,
+  ): void {
+    const columns = streamRowColumns(rendered, surface.height)
+    for (let row = startRow; row < endRowExclusive; row += 1) {
+      surface.commitRows(row, row + 1, { rowColumns: columns[row] })
     }
   }
 


### PR DESCRIPTION
Track rendered markdown line widths and use them when committing streamed scrollback rows, preventing trailing blank columns from being emitted. Add coverage for multiline assistant code blocks and per-row commit widths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed Markdown rendering in the terminal interface.
  * Ensured streamed content commits only visible terminal columns.
  * Preserved command rows and accurate row heights during streaming.
  * Improved display-width tracking for streamed text and reasoning content.
* **Tests**
  * Added integration coverage for streamed Markdown rendering, row commits, and display widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->