### PR TITLE
Show context compaction progress in the transcript

### DIFF
--- a/apps/cli/src/plugins/tui/controllers/agent-events.ts
+++ b/apps/cli/src/plugins/tui/controllers/agent-events.ts
@@ -129,6 +129,9 @@ export class AgentEventController {
         break
       case "state_changed":
         statusBar.setState(event.state)
+        if (event.state === "compacting" && !this.replaying) {
+          scrollback.append({ kind: "compaction", state: "compacting" })
+        }
         if (event.state !== "idle") break
         this.screen.dismissApproval()
         this.screen.dismissElicitation()
@@ -276,6 +279,7 @@ export class AgentEventController {
       case "compacted":
         scrollback.append({
           kind: "compaction",
+          state: "compacted",
           summary: event.summary,
           replaced: event.replaced,
           tokensBefore: event.tokensBefore,

--- a/apps/cli/src/plugins/tui/scrollback/blocks.ts
+++ b/apps/cli/src/plugins/tui/scrollback/blocks.ts
@@ -35,12 +35,18 @@ export interface NoticeBlock {
   details: string[]
 }
 
-export interface CompactionBlock {
-  kind: "compaction"
-  summary: string
-  replaced: number
-  tokensBefore: number | undefined
-}
+export type CompactionBlock =
+  | {
+      kind: "compaction"
+      state: "compacting"
+    }
+  | {
+      kind: "compaction"
+      state: "compacted"
+      summary: string
+      replaced: number
+      tokensBefore: number | undefined
+    }
 
 export interface BackgroundBlock {
   kind: "background"

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -41,6 +41,32 @@ test("normal background results keep failures visible and stay on one row", () =
   expect(displayWidth(narrow)).toBeLessThanOrEqual(30)
 })
 
+test("compaction state is visible in the transcript as soon as it starts", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 24,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false },
+      undefined,
+    )
+    scrollback.append({ kind: "compaction", state: "compacting" })
+
+    const rows = setup.externalOutput.take().flatMap((commit) => commit.rows)
+    expect(rows).toEqual(["", "  Compacting context..."])
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+
 test("assistant markdown commits only its visible columns", async () => {
   const setup = await createTestRenderer({
     width: 80,

--- a/apps/cli/src/plugins/tui/scrollback/render.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.ts
@@ -164,6 +164,10 @@ function compaction(
   detailsShortcut: string | undefined,
 ): Renderable {
   const box = column(ctx)
+  if (block.state === "compacting") {
+    box.add(paragraph(ctx, { content: "Compacting context...", color: COLORS.warning }))
+    return box
+  }
   const before = block.tokensBefore === undefined ? "" : ` · was ${formatTokens(block.tokensBefore)} tokens`
   const hint = expanded || !detailsShortcut ? "" : ` · ${detailsShortcut} to read it`
   box.add(

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -46,7 +46,7 @@ function redactBlock(block: Block): Block {
         details: block.details.map(redactText),
       }
     case "compaction":
-      return { ...block, summary: redactText(block.summary) }
+      return block.state === "compacting" ? block : { ...block, summary: redactText(block.summary) }
     case "background":
       return {
         ...block,

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -24,7 +24,7 @@ These values live under `pluginConfig.tui`:
 }
 ```
 
-The `display.toggle-details` shortcut, Ctrl+O by default, temporarily toggles transcript details for the current session without changing `showOutputs`. Normal mode keeps task dispatches compact and shows completed background work as its ID plus the first report line. Expanded mode adds assignment metadata, status and line counts, spawned-agent details, and report output. Task plans are optional and created at the model's discretion for non-trivial, multi-phase work. Xal does not inject reminders to create or update a plan. A fully completed plan is dismissed when the session returns to idle, while plans with pending or in-progress work remain visible.
+The `display.toggle-details` shortcut, Ctrl+O by default, temporarily toggles transcript details for the current session without changing `showOutputs`. Normal mode keeps task dispatches compact and shows completed background work as its ID plus the first report line. Expanded mode adds assignment metadata, status and line counts, spawned-agent details, and report output. Context compaction appears in the transcript as soon as it starts, followed by the completed compaction summary. Task plans are optional and created at the model's discretion for non-trivial, multi-phase work. Xal does not inject reminders to create or update a plan. A fully completed plan is dismissed when the session returns to idle, while plans with pending or in-progress work remain visible.
 
 ## Keybindings
 


### PR DESCRIPTION
Add a transcript entry when context compaction starts, distinguish in-progress and completed compaction blocks, and update rendering, redaction, tests, and TUI documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-progress “Compacting context…” status to the transcript.
  * Completed compaction now displays its summary after processing finishes.

* **Documentation**
  * Updated display-details documentation to describe compaction status and completion messages.

* **Bug Fixes**
  * Improved transcript handling so active compaction details remain visible until completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->