### PR TITLE
Let task agents ask their parent questions

### DIFF
--- a/apps/cli/src/agent/events.ts
+++ b/apps/cli/src/agent/events.ts
@@ -57,6 +57,12 @@ export interface SessionStartedEvent {
   mode: PermissionMode
 }
 
+export interface AgentQuestionEventItem {
+  requestId: string
+  jobId: string
+  question: string
+}
+
 export interface DirectShellResult {
   messageId: string
   callId: string
@@ -99,6 +105,7 @@ export type AgentEvent =
   | { type: "queue_changed"; entries: QueuedEntry[] }
   | { type: "queue_flushed"; inputs: UserInput[] }
   | { type: "background_results"; results: BackgroundResult[] }
+  | { type: "agent_questions"; questions: AgentQuestionEventItem[] }
   | { type: "text_delta"; text: string }
   | { type: "reasoning_summary_delta"; text: string }
   | { type: "reasoning_delta"; text: string }

--- a/apps/cli/src/agent/run.ts
+++ b/apps/cli/src/agent/run.ts
@@ -69,6 +69,7 @@ export function runAgentTurn(
         case "queue_changed":
         case "queue_flushed":
         case "background_results":
+        case "agent_questions":
         case "text_delta":
         case "reasoning_summary_delta":
         case "reasoning_delta":
@@ -171,6 +172,7 @@ export function runAgentGoal(
         case "queue_changed":
         case "queue_flushed":
         case "background_results":
+        case "agent_questions":
         case "text_delta":
         case "reasoning_summary_delta":
         case "reasoning_delta":

--- a/apps/cli/src/agent/session/compose.ts
+++ b/apps/cli/src/agent/session/compose.ts
@@ -159,6 +159,7 @@ function lastState(loaded: LoadedSession): {
       case "queue_changed":
       case "queue_flushed":
       case "background_results":
+      case "agent_questions":
       case "text_delta":
       case "reasoning_summary_delta":
       case "reasoning_delta":

--- a/apps/cli/src/agent/session/session.test.ts
+++ b/apps/cli/src/agent/session/session.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { contributeRules } from "../../permissions/rules"
 import { registerTool, unregisterTool } from "../../tools/registry"
 import type { Tool } from "../../tools/types"
@@ -347,6 +350,180 @@ describe("AgentSession", () => {
     } finally {
       unregisterTool(tool)
     }
+  })
+
+  test("corrects one unanswered child question before releasing it as unavailable", async () => {
+    const provider = new ScriptedProvider([
+      completedRound("I will answer later."),
+      completedRound("Still no tool call."),
+    ])
+    const session = harness.createSession(provider)
+    const unavailable = Promise.withResolvers<string>()
+    const idle = Promise.withResolvers<void>()
+    const observed: AgentEvent[] = []
+    const unsubscribe = session.subscribe((event) => {
+      observed.push(event)
+      if (event.type === "state_changed" && event.state === "idle") idle.resolve()
+    })
+
+    try {
+      expect(
+        session.receiveAgentQuestion({
+          requestId: "question-1",
+          jobId: "child-1",
+          question: "Which target should I use?",
+          unavailable: (reason) => unavailable.resolve(reason),
+        }),
+      ).toBe(true)
+      expect(await unavailable.promise).toBe("the parent did not answer the question")
+      await idle.promise
+
+      expect(provider.requests).toHaveLength(2)
+      expect(provider.requests[0]?.input.at(-1)).toMatchObject({
+        type: "user_message",
+        text: expect.stringContaining("Task agents are blocked"),
+      })
+      expect(provider.requests[1]?.input.at(-1)).toMatchObject({
+        type: "user_message",
+        text: expect.stringContaining("You have not answered"),
+      })
+      expect(observed.filter((event) => event.type === "agent_questions")).toHaveLength(1)
+      expect(session.exportSnapshot().events.filter((event) => event.type === "agent_questions")).toHaveLength(1)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  test("keeps a pending child question visible across an unrelated tool round", async () => {
+    const toolName = `question_read_${crypto.randomUUID().replaceAll("-", "_")}`
+    const tool: Tool = {
+      name: toolName,
+      description: "Read unrelated state",
+      parameters: { type: "object" },
+      title: () => "Read state",
+      readOnly: () => true,
+      execute: async () => ({ output: "state" }),
+    }
+    const provider = new ScriptedProvider([
+      round([
+        { type: "item_done", item: { type: "tool_call", callId: "read-state", name: toolName, args: {} } },
+        { type: "done" },
+      ]),
+      completedRound("The unrelated read is complete."),
+      completedRound("No answer supplied."),
+    ])
+    const session = harness.createSession(provider)
+    const unavailable = Promise.withResolvers<string>()
+
+    registerTool(tool)
+    try {
+      expect(
+        session.receiveAgentQuestion({
+          requestId: "question-tool-round",
+          jobId: "child-tool-round",
+          question: "Which target should I use?",
+          unavailable: (reason) => unavailable.resolve(reason),
+        }),
+      ).toBe(true)
+      expect(await unavailable.promise).toBe("the parent did not answer the question")
+
+      expect(provider.requests).toHaveLength(3)
+      expect(provider.requests[0]?.input.at(-1)).toMatchObject({
+        type: "user_message",
+        text: expect.stringContaining("Task agents are blocked"),
+      })
+      expect(provider.requests[1]?.input.at(-1)).toMatchObject({
+        type: "user_message",
+        text: expect.stringContaining("Task agents are blocked"),
+      })
+      expect(provider.requests[2]?.input.at(-1)).toMatchObject({
+        type: "user_message",
+        text: expect.stringContaining("You have not answered"),
+      })
+    } finally {
+      unregisterTool(tool)
+    }
+  })
+
+  test("replays task-agent questions as history without restoring actionable provider input", async () => {
+    const provider = new ScriptedProvider([completedRound("Continued after resume.")])
+    const session = harness.createSession(provider)
+    const cwd = session.exportSnapshot().meta.cwd
+    const path = join(tmpdir(), `xal-resume-question-${crypto.randomUUID()}.jsonl`)
+    const replayed: AgentEvent[] = []
+    const question: AgentEvent = {
+      type: "agent_questions",
+      questions: [
+        {
+          requestId: "historical-question",
+          jobId: "historical-child",
+          question: "Which historical target should I use?",
+        },
+      ],
+    }
+    const unsubscribe = session.subscribe((event) => replayed.push(event))
+
+    try {
+      expect(
+        session.resume({
+          session: {
+            meta: {
+              version: 2,
+              id: crypto.randomUUID(),
+              cwd,
+              provider: provider.id,
+              profile: "test-profile",
+              model: "test-model",
+              mode: "ask",
+              startedAt: Date.now(),
+            },
+            items: [],
+            checkpoints: [],
+            events: [question],
+          },
+          path,
+          cwd,
+          provider,
+          profileId: "test-profile",
+          model: "test-model",
+          mode: "ask",
+          continueGoal: false,
+        }),
+      ).toBe(true)
+      const outcome = await runSettledTurn(session, { text: "Continue after restart.", images: [] })
+
+      expect(outcome.status).toBe("completed")
+      expect(replayed).toContainEqual(question)
+      expect(replayed).toContainEqual({ type: "session_replay_finished" })
+      expect(provider.requests).toHaveLength(1)
+      const input = JSON.stringify(provider.requests[0]?.input)
+      expect(input).not.toContain("Which historical target should I use?")
+      expect(input).not.toContain("Task agents are blocked")
+      expect(provider.requests[0]?.input).toEqual([
+        { type: "user_message", text: "Continue after restart.", images: [] },
+      ])
+    } finally {
+      unsubscribe()
+      await session.flushPersistence()
+      await rm(path, { force: true })
+    }
+  })
+
+  test("releases queued child questions when the parent turn fails", async () => {
+    const provider = new ScriptedProvider([round([], new Error("parent provider failed"))])
+    const session = harness.createSession(provider)
+    const unavailable = Promise.withResolvers<string>()
+
+    expect(
+      session.receiveAgentQuestion({
+        requestId: "question-2",
+        jobId: "child-2",
+        question: "Need parent context",
+        unavailable: (reason) => unavailable.resolve(reason),
+      }),
+    ).toBe(true)
+
+    expect(await unavailable.promise).toBe("the parent turn failed")
   })
 
   test("retries a retryable provider failure before the stream emits an event", async () => {

--- a/apps/cli/src/agent/session/session.ts
+++ b/apps/cli/src/agent/session/session.ts
@@ -54,6 +54,7 @@ import type { AgentEvent, AgentState, DenialCause, SessionStartedEvent } from ".
 import { activeHistory, type ConversationCheckpoint, type HistoryItem } from "../history"
 import { isMessageId } from "../message-id"
 import { composeSystemPrompt } from "../prompt/registry"
+import type { DeliveredAgentQuestion, ParentQuestionResult } from "../task/questions"
 import type { SessionKind } from "../types"
 import { backgroundResultsMessage, SessionAsyncState } from "./async"
 import { autoCompact, runCompaction, type CompactionHost } from "./compaction"
@@ -78,6 +79,10 @@ import {
   type UndoCheckpoint,
   type UndoOutcome,
 } from "./types"
+
+interface PendingAgentQuestion extends DeliveredAgentQuestion {
+  corrected: boolean
+}
 
 function recordedContext(events: AgentEvent[]): number | undefined {
   for (let index = events.length - 1; index >= 0; index--) {
@@ -114,6 +119,7 @@ export class AgentSession {
   private readonly outputContract: OutputContract | undefined
   private readonly trackUndoPrompts: boolean
   private readonly inheritedDenyMode: PermissionMode | undefined
+  private readonly askParentHandler: AgentSessionDeps["askParent"]
   private readonly asyncState: SessionAsyncState
   private readonly toolRunner: ToolCallRunner
   private readonly interactions: PendingInteractions
@@ -142,6 +148,9 @@ export class AgentSession {
   private promoteOnAbort = false
   private paused = false
   private pauseWaiters: Array<() => void> = []
+  private queuedAgentQuestions: PendingAgentQuestion[] = []
+  private presentedAgentQuestions: PendingAgentQuestion[] = []
+  private transientQuestionInput: string | undefined
   private readonly hookReporter: HookReporter = {
     started: (hook, event) => {
       this.setState("running_hook")
@@ -158,6 +167,7 @@ export class AgentSession {
     this.workspaceUndo = deps.workspaceUndo ?? new WorkspaceUndo(this.cwd)
     this.trackUndoPrompts = deps.trackUndoPrompts ?? true
     this.inheritedDenyMode = deps.inheritedDenyMode
+    this.askParentHandler = deps.askParent
     this.provider = deps.provider
     this.profileId = deps.profileId
     this.model = deps.model
@@ -231,11 +241,15 @@ export class AgentSession {
       requestInput: (callId, request, signal) => this.interactions.requestInput(callId, request, signal),
       requestApproval: (resolve) => this.interactions.awaitApproval(resolve),
       changeWorkspace: (cwd) => this.changeWorkspace(cwd),
+      askParent: (question, signal) => this.askParent(question, signal),
+      receiveAgentQuestion: (question) => this.receiveAgentQuestion(question),
+      settleAgentQuestion: (requestId) => this.settleAgentQuestion(requestId),
       contextUsage: () => this.contextUsage(),
       restartSession: (prompt) => {
         this.pendingRestart = prompt
       },
-      pendingActivity: () => this.queue.first !== undefined || this.asyncState.hasQueued(),
+      pendingActivity: () =>
+        this.queue.first !== undefined || this.asyncState.hasQueued() || this.hasPendingAgentQuestions(),
       activitySignal: () => this.activityController.signal,
     }
   }
@@ -262,6 +276,9 @@ export class AgentSession {
       hookContext: (signal) => this.hookContext(signal),
       streamRound: (usage) => this.streamHost(usage),
       drainBackgroundResults: () => this.drainBackgroundResults(),
+      drainAgentQuestions: () => this.drainAgentQuestions(),
+      agentQuestionsQueued: () => this.queuedAgentQuestions.length > 0,
+      correctUnansweredAgentQuestions: () => this.correctUnansweredAgentQuestions(),
       drainQueue: (signal, interjected) => this.drainQueue(signal, interjected),
       restartRequested: () => this.pendingRestart !== undefined,
       autoCompact: (signal, provider, model) => autoCompact(this.compactionHost(), signal, provider, model),
@@ -491,6 +508,9 @@ export class AgentSession {
     this.plan = undefined
     this.planHandoffActive = false
     this.pendingRestart = undefined
+    this.queuedAgentQuestions = []
+    this.presentedAgentQuestions = []
+    this.transientQuestionInput = undefined
     this.goals.reset()
     this.buffer.reset()
     this.acceptingQueuedInput = false
@@ -580,6 +600,9 @@ export class AgentSession {
     this.modeBeforePlan = meta.mode === "plan" ? meta.modeBeforePlan : undefined
     this.plan = undefined
     this.planHandoffActive = false
+    this.queuedAgentQuestions = []
+    this.presentedAgentQuestions = []
+    this.transientQuestionInput = undefined
     this.goals.reset()
     let recordedCwd = meta.cwd
     let recordedMode = meta.mode
@@ -722,6 +745,120 @@ export class AgentSession {
     this.activityController = new AbortController()
   }
 
+  private askParent(question: string, signal: AbortSignal): Promise<ParentQuestionResult> {
+    if (this.kind !== "subagent" || !this.askParentHandler) {
+      throw new Error("ask_parent is available only to running task agents")
+    }
+    return this.askParentHandler(question, signal)
+  }
+
+  receiveAgentQuestion(question: DeliveredAgentQuestion): boolean {
+    if (this.kind !== "primary" || this.movingHistory) return false
+    if (
+      this.queuedAgentQuestions.some((candidate) => candidate.requestId === question.requestId) ||
+      this.presentedAgentQuestions.some((candidate) => candidate.requestId === question.requestId)
+    ) {
+      return false
+    }
+    const pending: PendingAgentQuestion = {
+      requestId: question.requestId,
+      jobId: question.jobId,
+      question: question.question,
+      unavailable: question.unavailable,
+      corrected: false,
+    }
+    this.queuedAgentQuestions.push(pending)
+    this.emit({
+      type: "agent_questions",
+      questions: [{ requestId: pending.requestId, jobId: pending.jobId, question: pending.question }],
+    })
+    this.noteActivity()
+    queueMicrotask(() => this.startAgentQuestionTurn())
+    return true
+  }
+
+  settleAgentQuestion(requestId: string): void {
+    this.queuedAgentQuestions = this.queuedAgentQuestions.filter((question) => question.requestId !== requestId)
+    this.presentedAgentQuestions = this.presentedAgentQuestions.filter((question) => question.requestId !== requestId)
+    this.refreshAgentQuestionInput()
+  }
+
+  private hasPendingAgentQuestions(): boolean {
+    return this.queuedAgentQuestions.length > 0 || this.presentedAgentQuestions.length > 0
+  }
+
+  private startAgentQuestionTurn(): boolean {
+    if (
+      this.paused ||
+      this.queuedAgentQuestions.length === 0 ||
+      this.movingHistory ||
+      this.turnActive ||
+      this.state !== "idle"
+    ) {
+      return false
+    }
+    this.startPreparedTurn(() => Promise.resolve())
+    return true
+  }
+
+  private drainAgentQuestions(): boolean {
+    if (this.queuedAgentQuestions.length === 0) return false
+    this.presentedAgentQuestions.push(...this.queuedAgentQuestions.splice(0))
+    this.refreshAgentQuestionInput()
+    return true
+  }
+
+  private refreshAgentQuestionInput(): void {
+    if (this.presentedAgentQuestions.length === 0) {
+      this.transientQuestionInput = undefined
+      return
+    }
+    const fresh = this.presentedAgentQuestions.filter((question) => !question.corrected)
+    const corrected = this.presentedAgentQuestions.filter((question) => question.corrected)
+    const lines = ["<system-notice>"]
+    if (fresh.length > 0) {
+      lines.push(
+        "Task agents are blocked waiting for answers to these parent-only questions:",
+        fresh
+          .map((question) => `- Request ${question.requestId} from task agent ${question.jobId}:\n${question.question}`)
+          .join("\n\n"),
+      )
+    }
+    if (corrected.length > 0) {
+      lines.push(
+        "You have not answered these pending task-agent questions. If you finish again without answering, the blocked children will be told that the parent is unavailable:",
+        corrected.map((question) => `- ${question.jobId}: ${question.question}`).join("\n"),
+      )
+    }
+    lines.push(
+      "Answer each question with job_send using its task agent id. A job_send message answers a pending question before it acts as ordinary guidance. Do not merely narrate the answer.",
+      "</system-notice>",
+    )
+    this.transientQuestionInput = lines.join("\n")
+  }
+
+  private correctUnansweredAgentQuestions(): boolean {
+    if (this.presentedAgentQuestions.length === 0) return false
+    const unavailable = this.presentedAgentQuestions.filter((question) => question.corrected)
+    for (const question of unavailable) {
+      question.unavailable("the parent did not answer the question")
+    }
+    const unanswered = this.presentedAgentQuestions.filter((question) => !question.corrected)
+    if (unanswered.length === 0) return false
+    for (const question of unanswered) question.corrected = true
+    this.refreshAgentQuestionInput()
+    return true
+  }
+
+  private failAgentQuestions(reason: string): void {
+    for (const question of [...this.queuedAgentQuestions, ...this.presentedAgentQuestions]) {
+      question.unavailable(reason)
+    }
+    this.queuedAgentQuestions = []
+    this.presentedAgentQuestions = []
+    this.transientQuestionInput = undefined
+  }
+
   send(input: UserInput): boolean {
     const redacted = redactUserInput(input)
     if (redacted.images.length > 0 && !this.supportsImageInput) {
@@ -814,6 +951,7 @@ export class AgentSession {
     if (this.settlePause()) return
 
     if (controller.signal.aborted) {
+      this.failAgentQuestions("the parent turn was interrupted")
       const active = this.goals.active()
       if (active) this.goals.suspend(active.id, "interruption", "Goal automation was interrupted")
       this.setState("idle")
@@ -824,6 +962,7 @@ export class AgentSession {
     }
 
     if (failure) {
+      this.failAgentQuestions("the parent turn failed")
       const active = this.goals.active()
       if (active) this.goals.suspend(active.id, "turn_failure", failure)
       this.setState("idle")
@@ -834,14 +973,27 @@ export class AgentSession {
 
     if (restart !== undefined && this.startRestartedTurn(restart)) return
 
+    if (this.queuedAgentQuestions.length > 0) {
+      this.setState("idle")
+      if (this.startAgentQuestionTurn()) return
+    }
+
     if (this.queue.first !== undefined) {
       this.setState("idle")
       if (this.startNextQueued()) return
     }
 
-    if (summary && !this.asyncState.hasPendingAsyncWork() && this.startGoalEvaluation(summary)) return
+    if (
+      summary &&
+      !this.hasPendingAgentQuestions() &&
+      !this.asyncState.hasPendingAsyncWork() &&
+      this.startGoalEvaluation(summary)
+    ) {
+      return
+    }
 
     this.setState("idle")
+    if (this.startAgentQuestionTurn()) return
     if (this.settleBackgroundAgents()) return
     this.queue.flush()
   }
@@ -930,6 +1082,7 @@ export class AgentSession {
   private finishGoalEvaluationIdle(): void {
     this.setState("idle")
     if (this.settlePause()) return
+    if (this.startAgentQuestionTurn()) return
     if (this.queue.first !== undefined && this.startNextQueued()) return
     this.settleBackgroundAgents()
   }
@@ -980,6 +1133,9 @@ export class AgentSession {
         this.abortController = undefined
         this.setState("idle")
         if (this.settlePause()) return
+        if (errored) this.failAgentQuestions("the parent turn failed")
+        else if (controller.signal.aborted) this.failAgentQuestions("the parent turn was interrupted")
+        if (this.startAgentQuestionTurn()) return
         if (!errored && (!controller.signal.aborted || this.promoteOnAbort) && this.startNextQueued()) return
         if (controller.signal.aborted) {
           this.queue.flush()
@@ -1361,11 +1517,15 @@ export class AgentSession {
     thinking: ThinkingEffort | undefined,
     signal: AbortSignal,
   ): StreamRequest {
+    const input = prepareConversation(activeHistory(this.items), { provider: provider.id, model })
+    if (this.transientQuestionInput) {
+      input.push({ type: "user_message", text: this.transientQuestionInput, images: [] })
+    }
     return redactStreamRequest({
       model,
       thinking,
       ...this.providerPrompt(model),
-      input: prepareConversation(activeHistory(this.items), { provider: provider.id, model }),
+      input,
       toolChoice: "auto",
       sessionId: this.id,
       signal,

--- a/apps/cli/src/agent/session/tool-runner.ts
+++ b/apps/cli/src/agent/session/tool-runner.ts
@@ -24,6 +24,7 @@ import type { AgentEvent, AgentState, DenialCause } from "../events"
 import type { ToolLoopDetector, ToolLoopAction } from "./loop-detection"
 import type { OutputContract } from "./output-contract"
 import { isAbortError } from "./types"
+import type { DeliveredAgentQuestion, ParentQuestionResult } from "../task/questions"
 import type { SessionKind } from "../types"
 
 export interface ApprovalResult {
@@ -100,6 +101,9 @@ export interface ToolRunnerHost {
   requestInput(callId: string, request: ElicitationRequest, signal: AbortSignal): Promise<ElicitationResult>
   requestApproval(resolve: (result: ApprovalResult) => void): void
   changeWorkspace(cwd: string): void
+  askParent(question: string, signal: AbortSignal): Promise<ParentQuestionResult>
+  receiveAgentQuestion(question: DeliveredAgentQuestion): boolean
+  settleAgentQuestion(requestId: string): void
   contextUsage(): Promise<ContextUsage | undefined>
   restartSession(prompt: string): void
   pendingActivity(): boolean
@@ -376,6 +380,9 @@ export class ToolCallRunner {
                   mode: this.host.mode(),
                   workspaceUndo: this.host.workspaceUndo(),
                   changeWorkspace: (cwd) => this.host.changeWorkspace(cwd),
+                  askParent: (question, askSignal) => this.host.askParent(question, askSignal),
+                  receiveAgentQuestion: (question) => this.host.receiveAgentQuestion(question),
+                  settleAgentQuestion: (requestId) => this.host.settleAgentQuestion(requestId),
                 },
                 activity: {
                   pending: this.host.pendingActivity(),

--- a/apps/cli/src/agent/session/turn.ts
+++ b/apps/cli/src/agent/session/turn.ts
@@ -27,6 +27,9 @@ export interface TurnHost {
   hookContext(signal: AbortSignal): HookContext
   streamRound(usage: TurnUsage): StreamRoundHost
   drainBackgroundResults(): boolean
+  drainAgentQuestions(): boolean
+  agentQuestionsQueued(): boolean
+  correctUnansweredAgentQuestions(): boolean
   drainQueue(signal: AbortSignal, interjected: boolean): Promise<boolean>
   restartRequested(): boolean
   autoCompact(signal: AbortSignal, provider: Provider, model: string): Promise<void>
@@ -58,6 +61,7 @@ export async function runTurn(
     if (host.paused()) return
     if (host.drainBackgroundResults()) toolLoops.reset()
     await host.autoCompact(signal, provider, model)
+    if (host.drainAgentQuestions()) toolLoops.reset()
     if (signal.aborted) {
       host.emit({ type: "turn_interrupted" })
       return
@@ -88,11 +92,13 @@ export async function runTurn(
         continue
       }
       if (host.asyncResultsQueued()) continue
+      if (host.agentQuestionsQueued()) continue
       if (interjected) {
         interjected = false
         host.pushItem({ type: "user_message", text: interjectionResumeMessage(), images: [] })
         continue
       }
+      if (host.correctUnansweredAgentQuestions()) continue
       const contract = host.outputContract()
       if (contract) {
         const correction = contract.missing()
@@ -142,7 +148,11 @@ export async function runTurn(
     if (loopError) throw loopError
     const contract = host.outputContract()
     if (contract?.output) {
-      if (host.queuedPromptNext() || host.asyncResultsQueued()) {
+      if (host.correctUnansweredAgentQuestions()) {
+        contract.reset()
+        continue
+      }
+      if (host.queuedPromptNext() || host.asyncResultsQueued() || host.agentQuestionsQueued()) {
         contract.reset()
         continue
       }

--- a/apps/cli/src/agent/session/types.ts
+++ b/apps/cli/src/agent/session/types.ts
@@ -6,6 +6,7 @@ import type { AgentState } from "../events"
 import type { ConversationState } from "../history"
 import type { OutputSchema } from "./output-contract"
 import type { SessionKind } from "../types"
+import type { ParentQuestionResult } from "../task/questions"
 
 export interface AgentSessionDeps {
   kind?: SessionKind
@@ -22,6 +23,7 @@ export interface AgentSessionDeps {
   workspaceUndo?: WorkspaceUndo
   trackUndoPrompts?: boolean
   inheritedDenyMode?: PermissionMode
+  askParent?(question: string, signal: AbortSignal): Promise<ParentQuestionResult>
 }
 
 export interface ResumeTarget {

--- a/apps/cli/src/agent/task/activity.ts
+++ b/apps/cli/src/agent/task/activity.ts
@@ -106,6 +106,7 @@ export function activity(
     case "task_list_updated":
     case "session_started":
     case "session_replay_finished":
+    case "agent_questions":
     case "session_title_changed":
     case "workspace_changed":
     case "mode_changed":

--- a/apps/cli/src/agent/task/drive.ts
+++ b/apps/cli/src/agent/task/drive.ts
@@ -88,6 +88,7 @@ export async function driveTaskToQuiescence(
       case "task_list_updated":
       case "session_started":
       case "session_replay_finished":
+      case "agent_questions":
       case "session_title_changed":
       case "workspace_changed":
       case "mode_changed":

--- a/apps/cli/src/agent/task/questions.test.ts
+++ b/apps/cli/src/agent/task/questions.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { createParentQuestionChannel, type AgentQuestion, type ParentQuestionResult } from "./questions"
+
+function channelHarness() {
+  const delivered: AgentQuestion[] = []
+  const settled: string[] = []
+  const resumed: ParentQuestionResult[] = []
+  const channel = createParentQuestionChannel({
+    jobId: () => "child-1",
+    deliver: (question) => {
+      delivered.push(question)
+      return true
+    },
+    settled: (requestId) => settled.push(requestId),
+    waiting: () => {},
+    resumed: (result) => resumed.push(result),
+  })
+  return { channel, delivered, settled, resumed }
+}
+
+test("blocks one parent question until it is answered exactly once", async () => {
+  const harness = channelHarness()
+  const pending = harness.channel.ask("Which target should I use?", new AbortController().signal)
+
+  expect(harness.channel.pending()).toBe(true)
+  expect(harness.delivered).toHaveLength(1)
+  const requestId = harness.delivered[0]?.requestId
+  if (!requestId) throw new Error("question was not delivered")
+  expect(harness.channel.answer("Use the release target.")).toBe(requestId)
+  expect(harness.channel.answer("duplicate")).toBeUndefined()
+
+  expect(await pending).toEqual({ status: "answered", answer: "Use the release target." })
+  expect(harness.settled).toEqual([requestId])
+  expect(harness.resumed).toEqual([{ status: "answered", answer: "Use the release target." }])
+})
+
+test("rejects a second pending question and releases the first on cancellation", async () => {
+  const harness = channelHarness()
+  const controller = new AbortController()
+  const pending = harness.channel.ask("Need a decision", controller.signal)
+
+  await expect(harness.channel.ask("Another decision", new AbortController().signal)).rejects.toThrow("already pending")
+  controller.abort()
+
+  expect(await pending).toEqual({ status: "unavailable", reason: "the task was canceled" })
+  expect(harness.channel.pending()).toBe(false)
+  expect(harness.settled).toHaveLength(1)
+})
+
+test("settles unavailable when the parent rejects delivery", async () => {
+  const channel = createParentQuestionChannel({
+    jobId: () => "child-1",
+    deliver: () => false,
+    settled: () => {},
+    waiting: () => {},
+    resumed: () => {},
+  })
+
+  await expect(channel.ask("Need context", new AbortController().signal)).resolves.toEqual({
+    status: "unavailable",
+    reason: "the parent is unavailable",
+  })
+})

--- a/apps/cli/src/agent/task/questions.ts
+++ b/apps/cli/src/agent/task/questions.ts
@@ -1,0 +1,94 @@
+export const MAX_AGENT_MESSAGE_LENGTH = 20_000
+
+export type ParentQuestionResult = { status: "answered"; answer: string } | { status: "unavailable"; reason: string }
+
+export interface AgentQuestion {
+  requestId: string
+  jobId: string
+  question: string
+}
+
+export interface DeliveredAgentQuestion extends AgentQuestion {
+  unavailable(reason: string): void
+}
+
+export interface ParentQuestionChannel {
+  ask(question: string, signal: AbortSignal): Promise<ParentQuestionResult>
+  answer(message: string): string | undefined
+  close(reason: string): void
+  pending(): boolean
+}
+
+interface QuestionChannelOptions {
+  jobId(): string
+  deliver(question: DeliveredAgentQuestion): boolean
+  settled(requestId: string): void
+  waiting(question: string): void
+  resumed(result: ParentQuestionResult): void
+}
+
+interface PendingQuestion {
+  requestId: string
+  resolve(result: ParentQuestionResult): void
+  signal: AbortSignal
+  abort(): void
+}
+
+export function createParentQuestionChannel(options: QuestionChannelOptions): ParentQuestionChannel {
+  let pending: PendingQuestion | undefined
+
+  const settle = (requestId: string, result: ParentQuestionResult): boolean => {
+    if (!pending || pending.requestId !== requestId) return false
+    const current = pending
+    pending = undefined
+    current.signal.removeEventListener("abort", current.abort)
+    options.settled(requestId)
+    options.resumed(result)
+    current.resolve(result)
+    return true
+  }
+
+  return {
+    async ask(question, signal) {
+      if (pending) throw new Error("a parent question is already pending")
+      if (signal.aborted) return { status: "unavailable", reason: "the task was canceled" }
+
+      const requestId = crypto.randomUUID()
+      const { promise, resolve } = Promise.withResolvers<ParentQuestionResult>()
+      const abort = (): void => {
+        settle(requestId, { status: "unavailable", reason: "the task was canceled" })
+      }
+      pending = { requestId, resolve, signal, abort }
+      signal.addEventListener("abort", abort, { once: true })
+      options.waiting(question)
+
+      let accepted: boolean
+      try {
+        accepted = options.deliver({
+          requestId,
+          jobId: options.jobId(),
+          question,
+          unavailable: (reason) => settle(requestId, { status: "unavailable", reason }),
+        })
+      } catch (error) {
+        settle(requestId, { status: "unavailable", reason: "the parent could not receive the question" })
+        throw error
+      }
+      if (!accepted) {
+        settle(requestId, { status: "unavailable", reason: "the parent is unavailable" })
+      }
+      return promise
+    },
+    answer(message) {
+      if (!pending) return undefined
+      const requestId = pending.requestId
+      return settle(requestId, { status: "answered", answer: message }) ? requestId : undefined
+    },
+    close(reason) {
+      if (pending) settle(pending.requestId, { status: "unavailable", reason })
+    },
+    pending() {
+      return pending !== undefined
+    },
+  }
+}

--- a/apps/cli/src/agent/task/spawn.ts
+++ b/apps/cli/src/agent/task/spawn.ts
@@ -23,6 +23,7 @@ import { AgentSession } from "../session/session"
 import { activity, type ActivityState } from "./activity"
 import { driveTaskToQuiescence, type TaskDriveOutcome } from "./drive"
 import type { TaskAccess, TaskItem } from "./parse"
+import { createParentQuestionChannel, type ParentQuestionChannel } from "./questions"
 import { finishTask, taskOutput, type TaskTerminal } from "./record"
 
 interface Waiter {
@@ -105,7 +106,7 @@ function registerTask(
       return cwd()
     },
     childSessionId: () => child()?.id,
-    send: (message) => sendAgentGuidance(job, message, "user"),
+    send: (message) => sendAgentGuidance(job, message, "user") !== false,
     state: () =>
       job.done
         ? {
@@ -146,6 +147,7 @@ async function runTask(
   ctx: SessionToolContext,
   controller: AbortController,
   state: ActivityState,
+  questions: ParentQuestionChannel,
   setChild: (child: AgentSession) => void,
   setCwd: (cwd: string) => void,
 ): Promise<void> {
@@ -215,6 +217,7 @@ async function runTask(
       interactive: false,
       persist: false,
       inheritedDenyMode: ctx.session.mode,
+      askParent: (question, signal) => questions.ask(question, signal),
       ...(item.access === "write" && !worktree
         ? { workspaceUndo: ctx.session.workspaceUndo, trackUndoPrompts: false }
         : {}),
@@ -274,6 +277,7 @@ async function runTask(
     }
   } finally {
     beginAgentStop(job)
+    questions.close("the task ended before the parent answered")
     if (deadline) clearTimeout(deadline)
     if (child) {
       try {
@@ -316,7 +320,21 @@ export function spawnTask(item: TaskItem, context: string, ctx: SessionToolConte
       child?.suppressAsyncDeliveries()
       child?.interrupt()
     },
-    send: (message, source) => child?.steer(`${source === "user" ? "User" : "Parent"} guidance:\n${message}`) ?? false,
+    send: (message, source) => {
+      const requestId = questions.answer(message)
+      if (requestId) return { status: "answered", requestId }
+      const accepted = child?.steer(`${source === "user" ? "User" : "Parent"} guidance:\n${message}`) ?? false
+      return accepted ? { status: "guided" } : false
+    },
+  })
+  const questions = createParentQuestionChannel({
+    jobId: () => job.id,
+    deliver: (question) => ctx.session.receiveAgentQuestion(question),
+    settled: (requestId) => ctx.session.settleAgentQuestion(requestId),
+    waiting: () => setAgentActivity(job, "Waiting for parent…"),
+    resumed: (result) => {
+      if (result.status === "unavailable") setAgentActivity(job, "Parent unavailable; resuming…")
+    },
   })
   attachJobLog(job, createJobLog(ctx.session.directory, `agent-${job.id}`))
   const state: ActivityState = {
@@ -341,6 +359,7 @@ export function spawnTask(item: TaskItem, context: string, ctx: SessionToolConte
     ctx,
     controller,
     state,
+    questions,
     (value) => {
       child = value
     },

--- a/apps/cli/src/agent/task/task.test.ts
+++ b/apps/cli/src/agent/task/task.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, expect, test } from "bun:test"
 import { readFile } from "node:fs/promises"
 import { getJob, stopJob } from "../../background/jobs"
+import { registerJobTools } from "../../background/register"
 import { configureModes } from "../../permissions/modes"
 import type { ModelCatalog, Provider, StreamRequest } from "../../providers/types"
 import { bashTool } from "../../plugins/shell/bash/tool"
@@ -24,6 +25,7 @@ let harness: AgentSessionTestHarness
 beforeAll(async () => {
   harness = await setupAgentSessionTests("sub-agent-test-")
   registerBasePrompt()
+  registerJobTools()
   registerTaskAgents()
 })
 
@@ -53,6 +55,154 @@ test("keeps task mechanics in the tool contract and delegation policy in instruc
   expect(request.instructions).toContain("explicitly request delegation")
   expect(request.instructions).toContain("Depth, research, or thoroughness alone is not authorization.")
   expect(request.instructions).not.toContain("Use the smallest useful batch")
+})
+
+test("lets a child ask its parent, consume the answer, and finish in the same session", async () => {
+  let parentSessionId = ""
+  let parentRounds = 0
+  let childRounds = 0
+  let childSawFirstAnswer = false
+  let childSawSecondAnswer = false
+  let firstWaitOutput = ""
+  let secondWaitOutput = ""
+  const questionObserved = Promise.withResolvers<void>()
+  const secondWaitStarted = Promise.withResolvers<void>()
+  const provider: Provider = {
+    id: `sub-agent-question-test-${crypto.randomUUID()}`,
+    name: "Sub-agent question test provider",
+    aliases: [],
+    capabilities: { imageInput: false },
+    async listModels() {
+      return modelCatalog()
+    },
+    async defaultModel() {
+      return "test-model"
+    },
+    async *stream(_profileId: string, request: StreamRequest) {
+      let response: ProviderRound
+      if (request.sessionId === parentSessionId) {
+        parentRounds += 1
+        const transient = request.input.findLast(
+          (item) => item.type === "user_message" && item.text.includes("Task agents are blocked"),
+        )
+        const dispatched = request.input.some((item) => item.type === "tool_call" && item.name === "task")
+        const answerCount = request.input.filter((item) => item.type === "tool_call" && item.name === "job_send").length
+        const waited = request.input.some((item) => item.type === "tool_call" && item.callId === "wait-question")
+        const secondWaited = request.input.some(
+          (item) => item.type === "tool_call" && item.callId === "wait-second-question",
+        )
+        const delivered = request.input.some(
+          (item) => item.type === "user_message" && item.text.includes("question-child final report"),
+        )
+        if (!dispatched) {
+          response = toolRound("dispatch-question", "task", {
+            context: "Resolve one parent-only target decision.",
+            tasks: [
+              {
+                name: "question_child",
+                task: "Ask which target to use, then include the answer in the final report.",
+                access: "read",
+                isolation: "shared",
+              },
+            ],
+          })
+        } else if (transient && answerCount === 0) {
+          const result = request.input.findLast(
+            (item) => item.type === "tool_result" && item.callId === "wait-question",
+          )
+          firstWaitOutput = result?.type === "tool_result" ? result.output : ""
+          response = toolRound("answer-question", "job_send", {
+            id: "question_child",
+            message: "Use target beta.",
+          })
+        } else if (transient) {
+          const result = request.input.findLast(
+            (item) => item.type === "tool_result" && item.callId === "wait-second-question",
+          )
+          secondWaitOutput = result?.type === "tool_result" ? result.output : ""
+          response = toolRound("answer-second-question", "job_send", {
+            id: "question_child",
+            message: "Use format compact.",
+          })
+        } else if (delivered) {
+          response = completedRound("Integrated the child report.")
+        } else if (answerCount === 2) {
+          response = completedRound("Both child questions were answered.")
+        } else if (answerCount === 1 && !secondWaited) {
+          response = toolRound("wait-second-question", "job_output", { id: "question_child", wait: 60 })
+        } else if (!waited) {
+          await questionObserved.promise
+          response = toolRound("wait-question", "job_output", { id: "question_child", wait: 60 })
+        } else {
+          response = completedRound("The child question still needs an answer.")
+        }
+      } else {
+        childRounds += 1
+        const answers = request.input.filter(
+          (item) => item.type === "tool_result" && item.output.includes("Parent answered:"),
+        )
+        if (answers.length === 0) {
+          expect(request.tools.some((tool) => tool.name === "ask_parent")).toBe(true)
+          response = toolRound("ask-target", "ask_parent", { question: "Which target should I use?" })
+        } else if (answers.length === 1) {
+          childSawFirstAnswer = answers[0]?.type === "tool_result" && answers[0].output.includes("Use target beta.")
+          await secondWaitStarted.promise
+          response = toolRound("ask-format", "ask_parent", { question: "Which format should I use?" })
+        } else {
+          childSawSecondAnswer = answers[1]?.type === "tool_result" && answers[1].output.includes("Use format compact.")
+          response = completedRound("question-child final report: used target beta and compact format")
+        }
+      }
+      yield* response(request)
+    },
+  }
+
+  const session = harness.createSession(provider, { interactive: true })
+  parentSessionId = session.id
+  const questions: Extract<AgentEvent, { type: "agent_questions" }>[] = []
+  const deliveries: BackgroundResult[] = []
+  const settled = Promise.withResolvers<void>()
+  const unsubscribe = session.subscribe((event) => {
+    if (event.type === "agent_questions") {
+      questions.push(event)
+      questionObserved.resolve()
+    }
+    if (event.type === "tool_started" && event.callId === "wait-second-question") secondWaitStarted.resolve()
+    if (event.type === "background_results") deliveries.push(...event.results)
+    if (event.type === "state_changed" && event.state === "idle" && deliveries.length > 0) settled.resolve()
+  })
+
+  try {
+    await runSettledTurn(session, { text: "Dispatch the question task.", images: [] })
+    await settled.promise
+
+    expect(questions).toHaveLength(2)
+    expect(questions[0]?.questions[0]?.jobId).toBe("question_child")
+    expect(questions[0]?.questions[0]?.question).toBe("Which target should I use?")
+    expect(questions[1]?.questions[0]?.question).toBe("Which format should I use?")
+    expect(childSawFirstAnswer).toBe(true)
+    expect(childSawSecondAnswer).toBe(true)
+    expect(firstWaitOutput).toContain("[running]")
+    expect(firstWaitOutput).not.toContain("Supervision checkpoint reached")
+    expect(secondWaitOutput).toContain("[running]")
+    expect(secondWaitOutput).not.toContain("Supervision checkpoint reached")
+    expect(childRounds).toBe(3)
+    expect(deliveries).toHaveLength(1)
+    expect(deliveries[0]?.output).toContain("question-child final report: used target beta and compact format")
+    expect(parentRounds).toBeLessThanOrEqual(7)
+
+    const recordMatch = /^Full task record: (.+)$/m.exec(deliveries[0]?.output ?? "")
+    const recordPath = recordMatch?.[1]
+    if (!recordPath) throw new Error("question task did not include its durable record path")
+    const record = await readFile(recordPath, "utf8")
+    expect(record).toContain("Which target should I use?")
+    expect(record).toContain("Use target beta.")
+    expect(record).toContain("Which format should I use?")
+    expect(record).toContain("Use format compact.")
+  } finally {
+    unsubscribe()
+    session.disposeToolResources()
+  }
 })
 
 test("inherits deny rules and durably delivers a bounded task report", async () => {
@@ -282,10 +432,12 @@ test("holds the task open across nested background Bash and delivers only the fr
   }
 })
 
-test("does not wake the parent after a running task is cancelled", async () => {
-  const childStarted = Promise.withResolvers<void>()
+test("releases a child cancelled while ask_parent is pending without restoring the notice", async () => {
+  const releaseChildQuestion = Promise.withResolvers<void>()
+  const questionObserved = Promise.withResolvers<void>()
   let parentSessionId = ""
   let parentRound = 0
+  let followupInput = ""
   const provider: Provider = {
     id: `sub-agent-cancel-test-${crypto.randomUUID()}`,
     name: "Sub-agent cancellation test provider",
@@ -300,33 +452,27 @@ test("does not wake the parent after a running task is cancelled", async () => {
     async *stream(_profileId: string, request: StreamRequest) {
       if (request.sessionId === parentSessionId) {
         parentRound += 1
-        const response =
-          parentRound === 1
-            ? toolRound("dispatch-cancel", "task", {
-                context: "Wait until cancelled.",
-                tasks: [
-                  {
-                    name: "cancel_child",
-                    task: "Wait for cancellation.",
-                    access: "read",
-                    isolation: "shared",
-                  },
-                ],
-              })
-            : completedRound("Waiting for cancellation.")
-        yield* response(request)
+        if (parentRound >= 3) followupInput = JSON.stringify(request.input)
+        if (parentRound === 1) {
+          yield* toolRound("dispatch-cancel", "task", {
+            context: "Ask one question and wait until cancelled.",
+            tasks: [
+              {
+                name: "cancel_child",
+                task: "Ask the parent which target to use, then wait for the answer.",
+                access: "read",
+                isolation: "shared",
+              },
+            ],
+          })(request)
+          return
+        }
+        yield* completedRound(parentRound === 2 ? "Waiting for the child question." : "Parent turn completed.")(request)
         return
       }
 
-      childStarted.resolve()
-      const signal = request.signal
-      if (!signal) throw new Error("task request had no abort signal")
-      if (!signal.aborted) {
-        await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }))
-      }
-      const error = new Error("task cancelled")
-      error.name = "AbortError"
-      throw error
+      await releaseChildQuestion.promise
+      yield* toolRound("cancelled-question", "ask_parent", { question: "Which target should I use?" })(request)
     },
   }
 
@@ -334,27 +480,33 @@ test("does not wake the parent after a running task is cancelled", async () => {
   parentSessionId = session.id
   let deliveries = 0
   const unsubscribe = session.subscribe((event) => {
+    if (event.type === "agent_questions") questionObserved.resolve()
     if (event.type === "background_results") deliveries += 1
   })
 
   try {
     const initial = await runSettledTurn(session, { text: "Dispatch a cancellable task.", images: [] })
     expect(initial.status).toBe("completed")
-    expect(initial.response).toBe("Waiting for cancellation.")
-    await childStarted.promise
+    expect(initial.response).toBe("Waiting for the child question.")
+    releaseChildQuestion.resolve()
+    await questionObserved.promise
     const job = getJob("cancel_child")
     if (!job || job.kind !== "agent") throw new Error("cancellable task job was not registered")
+    expect(job.activity).toBe("Waiting for parent…")
 
     await stopJob(job, "model")
     await job.completion
-    await Promise.resolve()
+    await runSettledTurn(session, { text: "Continue after cancellation.", images: [] })
 
     expect(job.outcome?.status).toBe("interrupted")
     expect(job.delivery).toBe("suppressed")
     expect(deliveries).toBe(0)
-    expect(parentRound).toBe(2)
+    expect(parentRound).toBe(3)
+    expect(followupInput).not.toContain("Which target should I use?")
+    expect(followupInput).not.toContain("Task agents are blocked")
     expect(session.currentState).toBe("idle")
   } finally {
+    releaseChildQuestion.resolve()
     unsubscribe()
     session.disposeToolResources()
   }

--- a/apps/cli/src/agent/task/tool.ts
+++ b/apps/cli/src/agent/task/tool.ts
@@ -8,6 +8,7 @@ import { registerToolRenderer } from "../../ui/extension"
 import { registerPrompt } from "../prompt/registry"
 import { settings } from "../../config/settings"
 import { MAX_BATCH_TASKS, MAX_CONTEXT_LENGTH, MAX_TASK_LENGTH, prepareTaskBatch } from "./parse"
+import { MAX_AGENT_MESSAGE_LENGTH } from "./questions"
 import { spawnTask } from "./spawn"
 
 export function compactTaskToolTitle(title: string): string {
@@ -26,6 +27,49 @@ function taskToolTitle(args: Record<string, unknown>): string {
   const preview = assignments.slice(0, 2).join("; ")
   const remaining = assignments.length > 2 ? `; +${assignments.length - 2} more` : ""
   return `Dispatch ${args.tasks.length} ${args.tasks.length === 1 ? "task" : "tasks"}${preview ? ` · ${preview}${remaining}` : ""}`
+}
+
+export const askParentTool: SessionTool = {
+  name: "ask_parent",
+  description:
+    "Ask the owning parent agent a blocking question when a parent-only decision or missing context prevents useful progress. The current tool call waits for the answer. Do not use this for status updates or questions you can resolve independently.",
+  parameters: {
+    type: "object",
+    properties: {
+      question: {
+        type: "string",
+        minLength: 1,
+        maxLength: MAX_AGENT_MESSAGE_LENGTH,
+        description: "The specific decision or missing context required from the parent",
+      },
+    },
+    required: ["question"],
+    additionalProperties: false,
+  },
+  sessionAware: true,
+  available(ctx) {
+    return ctx.kind === "subagent"
+  },
+  title() {
+    return "Ask parent"
+  },
+  readOnly() {
+    return true
+  },
+  async execute(args, ctx) {
+    if (ctx.session.kind !== "subagent") throw new Error("ask_parent is available only to task agents")
+    const question = asString(args.question)?.trim()
+    if (!question) throw new Error("question must be a non-empty string")
+    if (question.length > MAX_AGENT_MESSAGE_LENGTH) {
+      throw new Error(`question must be at most ${MAX_AGENT_MESSAGE_LENGTH} characters`)
+    }
+    ctx.update(`${question}\n`)
+    const result = await ctx.session.askParent(question, ctx.signal)
+    if (result.status === "answered") return { output: `Parent answered:\n${result.answer}` }
+    return {
+      output: `Parent unavailable: ${result.reason}. Continue independently where possible or report the blocker clearly.`,
+    }
+  },
 }
 
 export const taskTool: SessionTool = {
@@ -139,14 +183,19 @@ export function registerTaskAgents(): void {
       if (prompt.kind !== "subagent") return ""
       return [
         "You are a one-shot task agent working for a primary coding agent. Your first user message contains all shared context and your complete assignment.",
-        "Complete only that assignment, work independently with the available tools, and do not ask the user or attempt further delegation.",
+        "Complete only that assignment, work independently with the available tools, never ask the user, and do not attempt further delegation. Call ask_parent only when a parent-only decision or missing context truly blocks useful progress.",
         "You may be one of several agents running concurrently; other agents may be editing other files, so stay within your assignment's scope.",
         "Managed background Bash (background:true) is available for long commands; keep working while they run, and their results are delivered back into this conversation automatically. Your task cannot finish while a managed job is running, so stop every long-lived server or watcher with job_kill before your final report. Never detach processes with nohup, setsid, or a trailing &.",
         "Return a concise, self-contained final report with the result and changed files relevant to the assignment. A report produced before a background result arrives is discarded, so account for every delivered result. Report failures clearly.",
       ].join("\n")
     },
   })
+  registerTool(askParentTool)
   registerTool(taskTool)
+  registerToolRenderer({
+    tool: askParentTool.name,
+    summarize: (output) => (output.startsWith("Parent answered:") ? "answered" : "unavailable"),
+  })
   registerToolRenderer({
     tool: taskTool.name,
     compactTitle: compactTaskToolTitle,

--- a/apps/cli/src/background/jobs.test.ts
+++ b/apps/cli/src/background/jobs.test.ts
@@ -18,6 +18,7 @@ import {
   readProcessOutput,
   reapOwnerJobs,
   registerDeliverySink,
+  sendAgentGuidance,
   startAgentJob,
   stopJob,
   suppressDelivery,
@@ -43,7 +44,7 @@ function agentJob(prefix: string): BackgroundAgentJob {
     timeoutMs: 60_000,
     maxTurns: 24,
     stop: () => {},
-    send: () => true,
+    send: () => ({ status: "guided" }),
   })
   agentJobs.add(job)
   return job
@@ -129,6 +130,31 @@ test("agent completion and abort wake completion waiters", async () => {
   expect(aborted.done).toBe(false)
 })
 
+test("distinguishes pending-question answers from ordinary guidance", () => {
+  let pending = true
+  const job = createAgentJob("test-agent-answer-routing", {
+    ownerId: "background-jobs-test",
+    task: "ask a question",
+    timeoutMs: 60_000,
+    maxTurns: 24,
+    stop: () => {},
+    send: () => {
+      if (!pending) return { status: "guided" }
+      pending = false
+      return { status: "answered", requestId: "question-1" }
+    },
+  })
+  agentJobs.add(job)
+
+  expect(sendAgentGuidance(job, "the answer", "parent")).toEqual({
+    status: "answered",
+    requestId: "question-1",
+  })
+  expect(sendAgentGuidance(job, "more context", "parent")).toEqual({ status: "guided" })
+  expect(job.transcript.text()).toContain("answered pending question question-1")
+  expect(job.transcript.text()).toContain("Parent guidance")
+})
+
 test("reserves a supervision window before a queued agent starts", () => {
   const job = agentJob("test-queued-agent-supervision-window")
 
@@ -212,7 +238,7 @@ test("suppresses agent delivery before invoking a racing stop callback", async (
       if (!current) throw new Error("agent job was not initialized")
       finishAgentJob(current, { status: "completed", report: "too late" }, "completed during stop")
     },
-    send: () => true,
+    send: () => ({ status: "guided" }),
   })
   holder.job = job
   agentJobs.add(job)
@@ -244,7 +270,7 @@ test("a user stop delivers the interrupted outcome to the owner sink", async () 
       if (!current) throw new Error("agent job was not initialized")
       finishAgentJob(current, { status: "interrupted" }, "interrupted")
     },
-    send: () => true,
+    send: () => ({ status: "guided" }),
   })
   holder.job = job
   agentJobs.add(job)

--- a/apps/cli/src/background/jobs.ts
+++ b/apps/cli/src/background/jobs.ts
@@ -56,6 +56,7 @@ export type BackgroundAgentOutcome =
   { status: "completed"; report: string } | { status: "failed" } | { status: "interrupted" } | { status: "timed_out" }
 
 export type JobSendSource = "parent" | "user"
+export type JobSendDisposition = { status: "answered"; requestId: string } | { status: "guided" }
 
 export interface BackgroundAgentControls {
   id?: string
@@ -64,7 +65,7 @@ export interface BackgroundAgentControls {
   timeoutMs: number
   maxTurns: number
   stop(): void
-  send(message: string, source: JobSendSource): boolean
+  send(message: string, source: JobSendSource): JobSendDisposition | false
 }
 
 export interface BackgroundScheduleJob extends BackgroundJobBase {
@@ -89,7 +90,7 @@ export interface BackgroundAgentJob extends BackgroundJobBase {
   activity: string
   outcome?: BackgroundAgentOutcome
   record?: BackgroundJobRecord
-  send(message: string, source: JobSendSource): boolean
+  send(message: string, source: JobSendSource): JobSendDisposition | false
 }
 
 export type BackgroundJob = BackgroundProcessJob | BackgroundAgentJob | BackgroundScheduleJob
@@ -723,17 +724,21 @@ export async function waitForAgentCompletion(
   job: BackgroundAgentJob,
   waitMs: number,
   signal?: AbortSignal,
+  activitySignal?: AbortSignal,
 ): Promise<void> {
-  if (waitMs <= 0 || job.done || signal?.aborted) return
+  if (waitMs <= 0 || job.done || signal?.aborted || activitySignal?.aborted) return
   const { promise, resolve } = Promise.withResolvers<void>()
   const timer = setTimeout(resolve, waitMs)
   const abort = (): void => resolve()
   signal?.addEventListener("abort", abort)
+  activitySignal?.addEventListener("abort", abort)
+  if (signal?.aborted || activitySignal?.aborted) resolve()
   try {
     await Promise.race([job.completion, promise])
   } finally {
     clearTimeout(timer)
     signal?.removeEventListener("abort", abort)
+    activitySignal?.removeEventListener("abort", abort)
   }
 }
 
@@ -770,11 +775,21 @@ export function jobStatus(job: BackgroundJob): string {
   return job.done ? job.detail : "still running"
 }
 
-export function sendAgentGuidance(job: BackgroundAgentJob, message: string, source: JobSendSource): boolean {
+export function sendAgentGuidance(
+  job: BackgroundAgentJob,
+  message: string,
+  source: JobSendSource,
+): JobSendDisposition | false {
   if (job.done) return false
-  if (!job.send(message, source)) return false
+  const disposition = job.send(message, source)
+  if (!disposition) return false
   const label = source === "user" ? "User" : "Parent"
+  if (disposition.status === "answered") {
+    appendAgentTranscript(job, `\n> ${label} answered pending question ${disposition.requestId}\n${message}\n`)
+    setAgentActivity(job, "Resuming with parent answer…")
+    return disposition
+  }
   appendAgentTranscript(job, `\n> ${label} guidance\n${message}\n`)
   setAgentActivity(job, `${label} guidance queued…`)
-  return true
+  return disposition
 }

--- a/apps/cli/src/background/register.ts
+++ b/apps/cli/src/background/register.ts
@@ -30,5 +30,8 @@ export function registerJobTools(): void {
   registerToolRenderer({ tool: jobKillTool.name, summarize: summarizeKill })
   registerToolRenderer({ tool: jobStatusTool.name, summarize: summarizeStatus })
   registerToolRenderer({ tool: jobExtendTool.name, summarize: () => "extended" })
-  registerToolRenderer({ tool: jobSendTool.name, summarize: () => "queued" })
+  registerToolRenderer({
+    tool: jobSendTool.name,
+    summarize: (output) => (output.startsWith("Answered ") ? "answered" : "queued"),
+  })
 }

--- a/apps/cli/src/background/tools.test.ts
+++ b/apps/cli/src/background/tools.test.ts
@@ -19,7 +19,7 @@ function agentJob(prefix: string): BackgroundAgentJob {
     timeoutMs: 60_000,
     maxTurns: 24,
     stop: () => {},
-    send: () => true,
+    send: () => ({ status: "guided" }),
   })
   jobs.add(job)
   return job
@@ -43,6 +43,39 @@ test("returns before the deadline with an actionable supervision checkpoint", as
   expect(output).toContain("turn cycles 0/24")
   expect(output).toContain("Supervision checkpoint reached before the task deadline")
   expect(output).toContain("job_extend")
+  expect(job.delivery).toBe("none")
+})
+
+test("returns immediately when parent activity predates an agent wait", async () => {
+  const job = agentJob("test-agent-output-preexisting-activity")
+  startAgentJob(job)
+  const activity = new AbortController()
+  activity.abort()
+
+  const output = await collectAgentOutput(job, 60, new AbortController().signal, {
+    pending: true,
+    signal: activity.signal,
+  })
+
+  expect(output).toContain("[running]")
+  expect(output).not.toContain("Supervision checkpoint reached")
+  expect(job.delivery).toBe("none")
+})
+
+test("releases an in-progress agent wait when parent activity arrives", async () => {
+  const job = agentJob("test-agent-output-later-activity")
+  startAgentJob(job)
+  const activity = new AbortController()
+  const output = collectAgentOutput(job, 60, new AbortController().signal, {
+    pending: false,
+    signal: activity.signal,
+  })
+  await Promise.resolve()
+  expect(job.delivery).toBe("reserved")
+
+  activity.abort()
+
+  expect(await output).toContain("[running]")
   expect(job.delivery).toBe("none")
 })
 

--- a/apps/cli/src/background/tools.ts
+++ b/apps/cli/src/background/tools.ts
@@ -22,6 +22,7 @@ import {
   type BackgroundScheduleJob,
 } from "./jobs"
 import { listBackgroundTasks, type BackgroundAgentSnapshot } from "./registry"
+import { MAX_AGENT_MESSAGE_LENGTH } from "../agent/task/questions"
 import { asNumber, asString } from "../lib/json"
 import { nativeToolRecord, nativeToolString } from "../native/tool-runtime"
 import type { SessionTool } from "../tools/types"
@@ -29,7 +30,6 @@ import type { SessionTool } from "../tools/types"
 const MAX_WAIT_S = 600
 const MAX_EXTENSION_MINUTES = 60
 const MAX_EXTENSION_TURNS = 100
-const MAX_MESSAGE_LENGTH = 20_000
 
 function jobOf(args: Record<string, unknown>, ownerId: string): BackgroundJob {
   const id = asString(args.id)?.trim() ?? ""
@@ -66,12 +66,19 @@ async function processOutput(job: BackgroundProcessJob, wait: number, signal: Ab
   return output
 }
 
-export async function collectAgentOutput(job: BackgroundAgentJob, wait: number, signal: AbortSignal): Promise<string> {
+export async function collectAgentOutput(
+  job: BackgroundAgentJob,
+  wait: number,
+  signal: AbortSignal,
+  activity?: { pending: boolean; signal: AbortSignal },
+): Promise<string> {
   const requestedWaitMs = wait * 1_000
   const waitMs = agentSupervisionWaitMs(job, requestedWaitMs)
-  const supervisionCheckpoint = waitMs < requestedWaitMs
-  const reservation = wait > 0 && !job.done ? reserveDelivery(job) : undefined
-  await waitForAgentCompletion(job, waitMs, signal)
+  const activityAlreadyPending = activity?.pending === true || activity?.signal.aborted === true
+  const reservation = wait > 0 && !job.done && !activityAlreadyPending ? reserveDelivery(job) : undefined
+  if (!activityAlreadyPending) await waitForAgentCompletion(job, waitMs, signal, activity?.signal)
+  const wokeForActivity = activityAlreadyPending || activity?.signal.aborted === true
+  const supervisionCheckpoint = waitMs < requestedWaitMs && !wokeForActivity
   if (!job.done) {
     if (reservation !== undefined) releaseDelivery(job, reservation)
     const result = nativeToolRecord("job_agent_output", {
@@ -203,7 +210,7 @@ export const jobOutputTool: SessionTool = {
       case "process":
         return { output: await processOutput(job, request.wait, ctx.signal) }
       case "agent":
-        return { output: await collectAgentOutput(job, request.wait, ctx.signal) }
+        return { output: await collectAgentOutput(job, request.wait, ctx.signal, ctx.activity) }
       case "schedule":
         return { output: nativeStatusOutput(job.id, ctx.session.id) }
     }
@@ -353,7 +360,7 @@ export const jobExtendTool: SessionTool = {
 export const jobSendTool: SessionTool = {
   name: "job_send",
   description:
-    "Send additional context or a correction to a running task agent. The message is queued into its current turn and does not restart or extend its deadline.",
+    "Answer a running task agent's pending parent question, or send additional context or a correction when no question is pending. The message does not restart or extend the task deadline.",
   parameters: {
     type: "object",
     properties: {
@@ -361,7 +368,7 @@ export const jobSendTool: SessionTool = {
       message: {
         type: "string",
         minLength: 1,
-        maxLength: MAX_MESSAGE_LENGTH,
+        maxLength: MAX_AGENT_MESSAGE_LENGTH,
         description: "Additional context or corrected direction for the task agent",
       },
     },
@@ -386,12 +393,17 @@ export const jobSendTool: SessionTool = {
     const job = jobOf({ id }, ctx.session.id)
     if (job.kind !== "agent") throw new Error(`${job.id} is not a task agent`)
     if (job.done) throw new Error(`${job.id} has already finished (${jobStatus(job)})`)
-    if (!sendAgentGuidance(job, message, "parent")) throw new Error(`${job.id} did not accept the message`)
+    const disposition = sendAgentGuidance(job, message, "parent")
+    if (!disposition) throw new Error(`${job.id} did not accept the message`)
     try {
-      const finalized = nativeToolRecord("job_send_finalize", { id: job.id, accepted: true })
+      const finalized = nativeToolRecord("job_send_finalize", {
+        id: job.id,
+        disposition: disposition.status,
+        ...(disposition.status === "answered" ? { requestId: disposition.requestId } : {}),
+      })
       return { output: nativeToolString(finalized, "output", "job_send") }
     } catch (error) {
-      throw new Error(`Guidance for ${job.id} may already be queued; inspect the job before sending it again`, {
+      throw new Error(`Message for ${job.id} may already be accepted; inspect the job before sending it again`, {
         cause: error,
       })
     }

--- a/apps/cli/src/plugins/tui/controllers/agent-events.test.ts
+++ b/apps/cli/src/plugins/tui/controllers/agent-events.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { agentQuestionNotice } from "./agent-events"
+
+const question = {
+  requestId: "question-1",
+  jobId: "child-1",
+  question: "Which target should I use?",
+}
+
+test("renders live task-agent questions as actionable notices", () => {
+  expect(agentQuestionNotice(question, false)).toEqual({
+    kind: "notice",
+    summary: "task agent child-1 is waiting for an answer",
+    details: ["Which target should I use?", "Reply with job_send to child-1."],
+  })
+})
+
+test("renders replayed task-agent questions as historical notices", () => {
+  expect(agentQuestionNotice(question, true)).toEqual({
+    kind: "notice",
+    summary: "historical task-agent question from child-1",
+    details: ["Which target should I use?", "This historical question is no longer actionable."],
+  })
+})

--- a/apps/cli/src/plugins/tui/controllers/agent-events.ts
+++ b/apps/cli/src/plugins/tui/controllers/agent-events.ts
@@ -1,11 +1,12 @@
+import type { AgentQuestionEventItem, AgentEvent } from "../../../agent/events"
 import type { AgentSession } from "../../../agent/session/session"
-import type { AgentEvent } from "../../../agent/events"
 import { historyMoveNotice } from "../../../agent/history"
 import type { GoalSnapshot, GoalSuspensionCause } from "../../../goals/types"
 import { describeError } from "../../../lib/error"
 import { compactPath } from "../../../lib/path"
 import { contextWindow } from "../../../providers/catalog"
 import type { Screen } from "../screen"
+import type { NoticeBlock } from "../scrollback/blocks"
 
 function suspensionLabel(cause: GoalSuspensionCause): string {
   switch (cause) {
@@ -42,6 +43,21 @@ function goalTranscript(goal: GoalSnapshot, previousEvaluatedTurns: number): str
   }
   const exhaustive: never = goal
   return exhaustive
+}
+
+export function agentQuestionNotice(question: AgentQuestionEventItem, replaying: boolean): NoticeBlock {
+  if (replaying) {
+    return {
+      kind: "notice",
+      summary: `historical task-agent question from ${question.jobId}`,
+      details: [question.question, "This historical question is no longer actionable."],
+    }
+  }
+  return {
+    kind: "notice",
+    summary: `task agent ${question.jobId} is waiting for an answer`,
+    details: [question.question, `Reply with job_send to ${question.jobId}.`],
+  }
 }
 
 export class AgentEventController {
@@ -183,6 +199,9 @@ export class AgentEventController {
               : {}),
           })
         }
+        break
+      case "agent_questions":
+        for (const question of event.questions) scrollback.append(agentQuestionNotice(question, this.replaying))
         break
       case "text_delta":
         this.assistantStreamed = true

--- a/apps/cli/src/plugins/tui/controllers/attention.ts
+++ b/apps/cli/src/plugins/tui/controllers/attention.ts
@@ -96,6 +96,7 @@ export class AttentionController {
       case "queue_changed":
       case "queue_flushed":
       case "background_results":
+      case "agent_questions":
       case "reasoning_summary_delta":
       case "reasoning_delta":
       case "reasoning_summary":

--- a/apps/cli/src/profiler/profiler.ts
+++ b/apps/cli/src/profiler/profiler.ts
@@ -65,6 +65,7 @@ type AnonymousAgentEvent =
   | { type: "queue_changed"; count: number; imageCount: number }
   | { type: "queue_flushed"; count: number; imageCount: number }
   | { type: "background_results"; results: AnonymousBackgroundResult[] }
+  | { type: "agent_questions"; questionCount: number }
   | { type: "assistant_message" }
   | { type: "reasoning_summary" }
   | { type: "retry_scheduled"; attempt: number; maxAttempts: number; delayMs: number }
@@ -340,6 +341,8 @@ function anonymousAgentEvent(event: AgentEvent): AnonymousAgentEvent | undefined
       }
     case "background_results":
       return { type: event.type, results: event.results.map(anonymousBackgroundResult) }
+    case "agent_questions":
+      return { type: event.type, questionCount: event.questions.length }
     case "retry_scheduled":
       return { type: event.type, attempt: event.attempt, maxAttempts: event.maxAttempts, delayMs: event.delayMs }
     case "approval_requested":

--- a/apps/cli/src/secrets/data.test.ts
+++ b/apps/cli/src/secrets/data.test.ts
@@ -132,6 +132,10 @@ test("redacts secrets from every agent event that carries content", () => {
       results: [{ kind: "agent", id: "b1", task: `task ${SECRET}`, status: "completed", output: `out ${SECRET}` }],
     },
     {
+      type: "agent_questions",
+      questions: [{ requestId: `request-${SECRET}`, jobId: `job-${SECRET}`, question: `question ${SECRET}` }],
+    },
+    {
       type: "background_results",
       results: [
         {

--- a/apps/cli/src/secrets/data.ts
+++ b/apps/cli/src/secrets/data.ts
@@ -251,6 +251,15 @@ export function redactAgentEvent(event: AgentEvent): AgentEvent {
       return { ...event, inputs: event.inputs.map(redactUserInput) }
     case "background_results":
       return { ...event, results: event.results.map(redactBackgroundResult) }
+    case "agent_questions":
+      return {
+        ...event,
+        questions: event.questions.map((question) => ({
+          requestId: redactText(question.requestId),
+          jobId: redactText(question.jobId),
+          question: redactText(question.question),
+        })),
+      }
     case "text_delta":
     case "reasoning_summary_delta":
     case "reasoning_delta":

--- a/apps/cli/src/sessions/export.ts
+++ b/apps/cli/src/sessions/export.ts
@@ -86,6 +86,13 @@ function renderEvent(event: AgentEvent): string | undefined {
       return `## Shell\n\n${indented(`$ ${event.command}\n${event.output}`)}`
     case "background_results":
       return `## ${appInfo.displayName} context\n\n${event.results.map(backgroundResult).join("\n\n")}`
+    case "agent_questions":
+      return event.questions
+        .map(
+          (question) =>
+            `## Task agent question: ${question.jobId}\n\nRequest: \`${question.requestId}\`\n\n${indented(question.question)}`,
+        )
+        .join("\n\n")
     case "compacted":
       return `## Compaction\n\n${event.summary}`
     case "conversation_rewound":

--- a/apps/cli/src/sessions/records.ts
+++ b/apps/cli/src/sessions/records.ts
@@ -1,4 +1,10 @@
-import type { AgentEvent, BackgroundResult, DenialCause, DirectShellResult } from "../agent/events"
+import type {
+  AgentEvent,
+  AgentQuestionEventItem,
+  BackgroundResult,
+  DenialCause,
+  DirectShellResult,
+} from "../agent/events"
 import type { CompactionItem, HistoryItem } from "../agent/history"
 import { isMessageId } from "../agent/message-id"
 import { parseGoalSnapshot } from "../goals/types"
@@ -177,6 +183,15 @@ function parseBackgroundResult(value: unknown): BackgroundResult | undefined {
   return undefined
 }
 
+function parseAgentQuestion(value: unknown): AgentQuestionEventItem | undefined {
+  if (!isRecord(value)) return undefined
+  const requestId = asString(value.requestId)
+  const jobId = asString(value.jobId)
+  const question = asString(value.question)
+  if (!requestId || !jobId || !question) return undefined
+  return { requestId, jobId, question }
+}
+
 function parseEvent(raw: unknown): AgentEvent | undefined {
   if (!isRecord(raw)) return undefined
 
@@ -225,6 +240,14 @@ function parseEvent(raw: unknown): AgentEvent | undefined {
         return result ? [result] : []
       })
       return results.length === raw.results.length ? { type: "background_results", results } : undefined
+    }
+    case "agent_questions": {
+      if (!Array.isArray(raw.questions) || raw.questions.length === 0) return undefined
+      const questions = raw.questions.flatMap((value) => {
+        const question = parseAgentQuestion(value)
+        return question ? [question] : []
+      })
+      return questions.length === raw.questions.length ? { type: "agent_questions", questions } : undefined
     }
     case "conversation_rewound": {
       const movement = parseConversationMove(raw)

--- a/apps/cli/src/sessions/store.test.ts
+++ b/apps/cli/src/sessions/store.test.ts
@@ -76,6 +76,39 @@ test("reconstructs history and checkpoints from paired user event and item recor
   })
 })
 
+test("reloads historical task-agent questions without adding provider history", async () => {
+  await withSessionFile(async (path) => {
+    const question: AgentEvent = {
+      type: "agent_questions",
+      questions: [
+        {
+          requestId: "question-1",
+          jobId: "child-1",
+          question: "Which release target should I use?",
+        },
+      ],
+    }
+    await writeFile(path, record({ type: "meta", meta }) + record({ type: "event", event: question }))
+
+    const loaded = await loadSession(path)
+
+    expect(loaded?.events).toEqual([question])
+    expect(loaded?.items).toEqual([])
+  })
+})
+
+test("rejects malformed task-agent question events", async () => {
+  await withSessionFile(async (path) => {
+    await writeFile(
+      path,
+      record({ type: "meta", meta }) +
+        record({ type: "event", event: { type: "agent_questions", questions: [{ jobId: "child-1" }] } }),
+    )
+
+    expect(await loadSession(path)).toBeUndefined()
+  })
+})
+
 test("replays records written through the serialized recorder queue", async () => {
   await withSessionFile(async (path) => {
     const messageId = "33333333-3333-4333-8333-333333333333"

--- a/apps/cli/src/tools/types.ts
+++ b/apps/cli/src/tools/types.ts
@@ -1,3 +1,4 @@
+import type { DeliveredAgentQuestion, ParentQuestionResult } from "../agent/task/questions"
 import type { SessionKind } from "../agent/types"
 import type { PermissionMode } from "../permissions/types"
 import type { PlanUpdatedEvent } from "../plans/types"
@@ -107,6 +108,9 @@ export interface SessionToolContext {
     mode: PermissionMode
     workspaceUndo: WorkspaceUndo
     changeWorkspace(cwd: string): void
+    askParent(question: string, signal: AbortSignal): Promise<ParentQuestionResult>
+    receiveAgentQuestion(question: DeliveredAgentQuestion): boolean
+    settleAgentQuestion(requestId: string): void
   }
   activity: {
     pending: boolean

--- a/crates/xal-native/src/tool_runtime/job.rs
+++ b/crates/xal-native/src/tool_runtime/job.rs
@@ -448,14 +448,23 @@ pub(super) fn job_send_prepare(value: &Value) -> napi::Result<Value> {
 }
 
 pub(super) fn job_send_finalize(value: &Value) -> napi::Result<Value> {
-    Ok(
-        json!({ "output": format!("Queued guidance for {}.", required_string(object(value)?, "id")?) }),
-    )
+    let request = object(value)?;
+    let id = required_string(request, "id")?;
+    match required_string(request, "disposition")?.as_str() {
+        "answered" => Ok(json!({
+            "output": format!(
+                "Answered {id}'s pending question {}.",
+                required_string(request, "requestId")?
+            )
+        })),
+        "guided" => Ok(json!({ "output": format!("Queued guidance for {id}.") })),
+        _ => Err(invalid("disposition must be answered or guided")),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{job_kill, job_status, run};
+    use super::{job_kill, job_send_finalize, job_status, run};
 
     #[test]
     fn formats_scheduled_job_status() {
@@ -471,5 +480,22 @@ mod tests {
         )
         .unwrap();
         assert!(stopped.contains("finished after stop was requested"));
+    }
+
+    #[test]
+    fn distinguishes_question_answers_from_guidance() {
+        let answered = run(
+            r#"{"id":"child-1","disposition":"answered","requestId":"question-1"}"#.to_owned(),
+            job_send_finalize,
+        )
+        .unwrap();
+        assert!(answered.contains("Answered child-1's pending question question-1."));
+
+        let guided = run(
+            r#"{"id":"child-1","disposition":"guided"}"#.to_owned(),
+            job_send_finalize,
+        )
+        .unwrap();
+        assert!(guided.contains("Queued guidance for child-1."));
     }
 }

--- a/docs/background-work.md
+++ b/docs/background-work.md
@@ -47,6 +47,10 @@ Each task declares its `access`:
 
 Dispatching any `write` task asks for approval. Sub-agents cannot ask for approval themselves; any action that would need it is denied automatically. Each agent runs until it produces a final report, reaches the `agents.timeoutMinutes` deadline, or exceeds its turn budget: after `agents.maxTurns` completed turns the agent is told to wrap up, and at 1.5× the budget its last report is returned as-is instead of running forever. The primary agent can inspect both budgets while the task runs and extend its deadline, soft turn budget, or both before either limit is reached.
 
+A task agent should work independently, but it can call `ask_parent` when a parent-only decision or missing context truly blocks useful progress. The tool suspends that child tool call and shows `Waiting for parent…` without starting another provider turn or polling. Each child can have one pending question. The existing task deadline bounds the wait, and cancellation or parent failure releases it with an unavailable result. Questions are process-local live state and are not resumed after teardown.
+
+The parent receives a persisted, expandable question notice in the transcript and TUI plus a transient model instruction. It answers with `job_send`; while a question is pending, the next accepted `job_send` or TUI agent message is the answer rather than ordinary guidance. If the parent finishes without answering, it gets one transient correction. Finishing again releases the child as parent-unavailable. A question also wakes an explicit `job_output(wait)` so the parent cannot deadlock while waiting for the blocked child. Historical question events remain visible after restart, but no actionable instruction is restored into provider history. Assignments should still be self-contained, and agents should not use this path for status questions.
+
 A finished agent's report is delivered into the parent conversation automatically as a system notice, with no polling needed. Alongside the in-conversation result, every agent writes two durable files into the session directory:
 
 - a Markdown task record (`agent-<id>-….md`) with the assignment, workspace, final report, and buffered transcript
@@ -66,7 +70,7 @@ The model manages jobs with five tools:
 | ------------ | -------------------------------------------------------------------------------------------------------------------- |
 | `job_output` | Read process output, collect an agent report, or inspect a schedule; agent waits return at a supervision checkpoint. |
 | `job_status` | Inspect processes, task agents, and schedules without consuming output.                                              |
-| `job_send`   | Queue guidance into a running task agent's current turn.                                                             |
+| `job_send`   | Answer a pending task-agent question, or queue guidance when no question is pending.                                 |
 | `job_extend` | Add up to 60 runtime minutes, 100 soft-budget turns, or both to a queued or running task agent per call.             |
 | `job_kill`   | Stop a process, task agent, or schedule. A process that ignores the graceful stop is hard-killed after 2 seconds.    |
 


### PR DESCRIPTION
## Summary

- add a child-only `ask_parent` tool that blocks and resumes within the same task-agent session
- wake the owning parent, route pending answers through `job_send`, and prevent `job_output(wait)` deadlocks
- persist safe historical question events with TUI, export, profiler, redaction, restart, cancellation, and lifecycle coverage

## Testing

- `bun checks:fix`
- focused request/reply, scheduling, cancellation, restart, persistence, TUI, and redaction tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task agents can ask parent agents questions and receive answers or unavailable responses.
  * Parent sessions display actionable question notices and support answering pending requests.
  * Question exchanges are preserved in session history and Markdown exports.
  * Added safeguards for cancellation, duplicate requests, unanswered questions, and message length.

* **Bug Fixes**
  * Improved handling of pending agent activity to prevent unnecessary waiting and stale requests.

* **Documentation**
  * Documented parent-agent questions, responses, persistence, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->