### PR TITLE
fix: preserve IME input across prompt, question, search, and secret fields

### DIFF
--- a/apps/cli/src/plugins/tui/components/composer.test.ts
+++ b/apps/cli/src/plugins/tui/components/composer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { ImeCommitBarrier, isImeCommit } from "./composer"
+import { ImeCommitBarrier, isImeCommit } from "../lib/ime"
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))

--- a/apps/cli/src/plugins/tui/components/composer.ts
+++ b/apps/cli/src/plugins/tui/components/composer.ts
@@ -6,7 +6,6 @@ import {
   SyntaxStyle,
   TextareaRenderable,
   TextAttributes,
-  type KeyEvent,
   type PasteEvent,
   type RenderContext,
   type TextRenderable,
@@ -17,6 +16,7 @@ import type { ImageInput, UserInput } from "../../../providers/types"
 import { findSkillReferences, type SkillQuery } from "../../../skills/references"
 import { fileMention, type FileQuery } from "../file-search"
 import { FOOTER_ICON_WIDTH } from "../lib/footer-grid"
+import { ImeCommitBarrier, imeKeyDown } from "../lib/ime"
 import { label, row } from "../lib/renderables"
 import type { MessageHistory } from "../message-history"
 import { COLORS, resolveColor } from "../theme/colors"
@@ -41,50 +41,6 @@ interface PastedImage {
   kind: "pasted-image"
   number: number
   image: ImageInput
-}
-
-const IME_COMMIT_SETTLE_MS = 20
-
-export class ImeCommitBarrier {
-  private readonly settleMs: number
-  private actions: (() => void)[] = []
-  private timer: ReturnType<typeof setTimeout> | undefined
-
-  constructor(settleMs = IME_COMMIT_SETTLE_MS) {
-    this.settleMs = settleMs
-  }
-
-  get pending(): boolean {
-    return this.actions.length > 0
-  }
-
-  enqueue(action: () => void): void {
-    this.actions.push(action)
-    this.arm()
-  }
-
-  observeCommit(): void {
-    if (!this.pending) return
-    this.arm()
-  }
-
-  clear(): void {
-    if (this.timer !== undefined) clearTimeout(this.timer)
-    this.timer = undefined
-    this.actions = []
-  }
-
-  private arm(): void {
-    if (this.timer !== undefined) clearTimeout(this.timer)
-    this.timer = setTimeout(() => {
-      this.timer = undefined
-      for (const action of this.actions.splice(0)) action()
-    }, this.settleMs)
-  }
-}
-
-export function isImeCommit(key: Pick<KeyEvent, "sequence" | "ctrl" | "meta" | "super" | "hyper">): boolean {
-  return !key.ctrl && !key.meta && !key.super && !key.hyper && /[^\u0000-\u007f]/.test(key.sequence)
 }
 
 function sameInput(left: UserInput, right: UserInput): boolean {
@@ -198,28 +154,14 @@ export class Composer {
       onContentChange: () => this.change(),
       onCursorChange: () => this.notifyCompletion(),
       onKeyDown: (key) => {
-        if (key.name === "space" && !key.ctrl && !key.meta && !key.super && !key.hyper) {
-          key.preventDefault()
-          this.imeCommit.enqueue(() => {
-            if (!this.input.isDestroyed) this.input.insertText(key.sequence)
-          })
-          return
-        }
-        if (isImeCommit(key)) {
-          this.imeCommit.observeCommit()
-          return
-        }
-        if (key.name === "space" && !key.ctrl && !key.meta && !key.super && !key.hyper) {
-          key.preventDefault()
-          this.imeCommit.enqueue(() => {
-            if (!this.input.isDestroyed) this.input.insertText(" ")
-          })
-          return
-        }
-        if (!this.imeCommit.pending) return
-        key.preventDefault()
-        this.imeCommit.enqueue(() => {
-          if (!this.input.isDestroyed) this.input.handleKeyPress(key)
+        imeKeyDown(key, {
+          barrier: this.imeCommit,
+          insert: (text) => {
+            if (!this.input.isDestroyed) this.input.insertText(text)
+          },
+          fallback: (event) => {
+            if (!this.input.isDestroyed) this.input.handleKeyPress(event)
+          },
         })
       },
       onSubmit: () =>

--- a/apps/cli/src/plugins/tui/components/elicitation-popover.ts
+++ b/apps/cli/src/plugins/tui/components/elicitation-popover.ts
@@ -11,6 +11,7 @@ import {
   type TextRenderable,
 } from "@opentui/core"
 import type { ElicitationAnswer, ElicitationQuestion } from "../../../tools/types"
+import { ImeCommitBarrier, imeKeyDown } from "../lib/ime"
 import { column, label, paragraph, row } from "../lib/renderables"
 import { terminalGlyph } from "../lib/text"
 import { COLORS } from "../theme/colors"
@@ -82,6 +83,7 @@ export class ElicitationPopover {
   private readonly choiceRows: ChoiceRow[] = []
   private readonly inputRow: BoxRenderable
   private readonly input: InputRenderable
+  private readonly imeCommit = new ImeCommitBarrier()
   private readonly review: ScrollBoxRenderable
   private readonly reviewRows: ReviewRow[] = []
   private readonly submitRow: TextRenderable
@@ -174,6 +176,17 @@ export class ElicitationPopover {
       flexGrow: 1,
       flexShrink: 1,
       minWidth: 1,
+      onKeyDown: (key) => {
+        imeKeyDown(key, {
+          barrier: this.imeCommit,
+          insert: (text) => {
+            if (!this.input.isDestroyed) this.input.insertText(text)
+          },
+          fallback: (event) => {
+            if (!this.input.isDestroyed) this.input.handleKeyPress(event)
+          },
+        })
+      },
       ...inputColors(),
     })
     inputLine.add(this.input)
@@ -348,6 +361,12 @@ export class ElicitationPopover {
 
   private handleTextKey(name: string): boolean {
     if (name === "escape") {
+      if (this.imeCommit.pending) {
+        this.imeCommit.enqueue(() => {
+          this.handleTextKey(name)
+        })
+        return true
+      }
       this.enteringText = false
       this.input.value = ""
       this.input.blur()
@@ -357,6 +376,12 @@ export class ElicitationPopover {
       return true
     }
     if (name === "return" || name === "enter") {
+      if (this.imeCommit.pending) {
+        this.imeCommit.enqueue(() => {
+          this.handleTextKey(name)
+        })
+        return true
+      }
       const value = this.input.value.trim()
       if (value) this.save(value)
       return true
@@ -544,6 +569,7 @@ export class ElicitationPopover {
 
   private close(): void {
     const changed = this.view.visible
+    this.imeCommit.clear()
     this.view.visible = false
     this.input.blur()
     this.input.value = ""

--- a/apps/cli/src/plugins/tui/components/picker.ts
+++ b/apps/cli/src/plugins/tui/components/picker.ts
@@ -9,6 +9,7 @@ import {
 } from "@opentui/core"
 import type { SelectOption } from "../../../commands/types"
 import { fuzzyScores } from "../lib/fuzzy"
+import { ImeCommitBarrier, imeKeyDown } from "../lib/ime"
 import { column, label, row } from "../lib/renderables"
 import { displayWidth, terminalGlyph, truncateToWidth } from "../lib/text"
 import { COLORS } from "../theme/colors"
@@ -40,6 +41,7 @@ export class Picker {
   readonly view: BoxRenderable
   private readonly list: BoxRenderable
   private readonly input: InputRenderable
+  private readonly imeCommit = new ImeCommitBarrier()
   private readonly marker: TextRenderable
   private readonly cursors: TextRenderable[] = []
   private readonly rows: TextRenderable[] = []
@@ -80,7 +82,20 @@ export class Picker {
     })
     const gutter = column(ctx, { width: 2, flexShrink: 0 })
     this.list = column(ctx, { flexGrow: 1, flexShrink: 1, minWidth: 1 })
-    this.input = new InputRenderable(ctx, { ...inputColors() })
+    this.input = new InputRenderable(ctx, {
+      ...inputColors(),
+      onKeyDown: (key) => {
+        imeKeyDown(key, {
+          barrier: this.imeCommit,
+          insert: (text) => {
+            if (!this.input.isDestroyed) this.input.insertText(text)
+          },
+          fallback: (event) => {
+            if (!this.input.isDestroyed) this.input.handleKeyPress(event)
+          },
+        })
+      },
+    })
     this.marker = label(ctx, {
       content: terminalGlyph("◆", "*"),
       width: 2,
@@ -149,10 +164,18 @@ export class Picker {
       return true
     }
     if (name === "escape") {
+      if (this.imeCommit.pending) {
+        this.imeCommit.enqueue(() => this.handleKey(name))
+        return true
+      }
       this.hide()
       return true
     }
     if (name === "return" || name === "enter") {
+      if (this.imeCommit.pending) {
+        this.imeCommit.enqueue(() => this.handleKey(name))
+        return true
+      }
       this.confirm()
       return true
     }
@@ -160,6 +183,7 @@ export class Picker {
   }
 
   private close(): void {
+    this.imeCommit.clear()
     this.view.visible = false
     this.input.blur()
   }

--- a/apps/cli/src/plugins/tui/components/secret-input.ts
+++ b/apps/cli/src/plugins/tui/components/secret-input.ts
@@ -7,6 +7,7 @@ import {
   type TextRenderable,
 } from "@opentui/core"
 import { label, row } from "../lib/renderables"
+import { ImeCommitBarrier, isImeCommit } from "../lib/ime"
 import { COLORS } from "../theme/colors"
 import { background, border, muted, paint } from "../theme/styles"
 
@@ -17,6 +18,7 @@ export class SecretInput {
   private readonly masked: TextRenderable
   private value = ""
   private maskedValue = true
+  private readonly imeCommit = new ImeCommitBarrier()
   private settle: ((value: string | undefined) => void) | undefined
 
   get visible(): boolean {
@@ -67,10 +69,18 @@ export class SecretInput {
   handleKey(key: KeyEvent): boolean {
     if (!this.visible) return false
     if (key.name === "escape") {
+      if (this.imeCommit.pending) {
+        this.imeCommit.enqueue(() => this.handleKey(key))
+        return true
+      }
       this.close(undefined)
       return true
     }
     if (key.name === "return" || key.name === "enter") {
+      if (this.imeCommit.pending) {
+        this.imeCommit.enqueue(() => this.handleKey(key))
+        return true
+      }
       this.close(this.value)
       return true
     }
@@ -80,11 +90,35 @@ export class SecretInput {
       return true
     }
     if (key.name === "backspace" || key.name === "delete") {
+      if (this.imeCommit.pending) {
+        this.imeCommit.enqueue(() => this.handleKey(key))
+        return true
+      }
       this.value = Array.from(this.value).slice(0, -1).join("")
       this.render()
       return true
     }
     if (key.ctrl || key.meta || !key.sequence || /[\u0000-\u001f\u007f]/.test(key.sequence)) return true
+    if (key.name === "space") {
+      this.imeCommit.enqueue(() => {
+        this.value += key.sequence
+        this.render()
+      })
+      return true
+    }
+    if (isImeCommit(key)) {
+      this.imeCommit.observeCommit()
+      this.value += key.sequence
+      this.render()
+      return true
+    }
+    if (this.imeCommit.pending) {
+      this.imeCommit.enqueue(() => {
+        this.value += key.sequence
+        this.render()
+      })
+      return true
+    }
     this.value += key.sequence
     this.render()
     return true
@@ -100,6 +134,7 @@ export class SecretInput {
   private close(value: string | undefined): void {
     const settle = this.settle
     this.settle = undefined
+    this.imeCommit.clear()
     this.value = ""
     this.masked.content = ""
     if (this.view.visible) {

--- a/apps/cli/src/plugins/tui/lib/ime.ts
+++ b/apps/cli/src/plugins/tui/lib/ime.ts
@@ -1,0 +1,67 @@
+import type { KeyEvent } from "@opentui/core"
+
+const IME_COMMIT_SETTLE_MS = 20
+
+export class ImeCommitBarrier {
+  private readonly settleMs: number
+  private actions: (() => void)[] = []
+  private timer: ReturnType<typeof setTimeout> | undefined
+
+  constructor(settleMs = IME_COMMIT_SETTLE_MS) {
+    this.settleMs = settleMs
+  }
+
+  get pending(): boolean {
+    return this.actions.length > 0
+  }
+
+  enqueue(action: () => void): void {
+    this.actions.push(action)
+    this.arm()
+  }
+
+  observeCommit(): void {
+    if (!this.pending) return
+    this.arm()
+  }
+
+  clear(): void {
+    if (this.timer !== undefined) clearTimeout(this.timer)
+    this.timer = undefined
+    this.actions = []
+  }
+
+  private arm(): void {
+    if (this.timer !== undefined) clearTimeout(this.timer)
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      for (const action of this.actions.splice(0)) action()
+    }, this.settleMs)
+  }
+}
+
+export function isImeCommit(key: Pick<KeyEvent, "sequence" | "ctrl" | "meta" | "super" | "hyper">): boolean {
+  return !key.ctrl && !key.meta && !key.super && !key.hyper && /[^\u0000-\u007f]/.test(key.sequence)
+}
+
+export interface ImeKeyDownDeps {
+  barrier: ImeCommitBarrier
+  insert(text: string): void
+  fallback(key: KeyEvent): void
+}
+
+export function imeKeyDown(key: KeyEvent, deps: ImeKeyDownDeps): boolean {
+  if (key.name === "space" && !key.ctrl && !key.meta && !key.super && !key.hyper) {
+    key.preventDefault()
+    deps.barrier.enqueue(() => deps.insert(key.sequence))
+    return true
+  }
+  if (isImeCommit(key)) {
+    deps.barrier.observeCommit()
+    return false
+  }
+  if (!deps.barrier.pending) return false
+  key.preventDefault()
+  deps.barrier.enqueue(() => deps.fallback(key))
+  return true
+}


### PR DESCRIPTION
## Summary

When typing Korean (or other CJK / European scripts), the IME composition sequence could cause a following **space to delete the previously composed character**. The composer (main prompt input) already handled this with an IME commit barrier, but the same bug remained in every other text input surface.

This PR extracts the composer's IME barrier logic into a shared module and applies it to the **question dialog (elicitation)**, the **search picker**, and the **secret input**, so Korean IME input is preserved everywhere.

## What changed

- New `lib/ime.ts`: shared `ImeCommitBarrier` (defers boundary actions until the IME composition commits), `isImeCommit`, and an `imeKeyDown` helper.
- `composer.ts`: replaced the inline implementation with the shared module (behavior unchanged).
- **`elicitation-popover.ts`** (question dialog — the main target of this PR): wires `imeKeyDown` into the `InputRenderable` and flushes the barrier before reading the value on Enter/Escape.
- **`picker.ts`** (search picker): same `imeKeyDown` handling, plus flush before confirm/dismiss.
- **`secret-input.ts`** (secret input): synchronized its direct `value += sequence` insertion path with the barrier.
- Each component clears the barrier in its `close()` path.

## Why

Fixing only the composer left Korean input broken in surfaces where users actually type, such as the question dialog. Extracting the logic to one shared place removes duplication and keeps all input fields consistent.

## Verification

- `typecheck` and `lint` pass.
- All 9 `ImeCommitBarrier` unit tests pass (Korean `한`, CJK `日/你`, European `é`, Devanagari `क`).

> Note: in the full test suite, 2 tests in `render.test.ts` fail due to an unrelated OpenTUI render library initialization issue (they fail on `main` too).