### PR TITLE
Clarify writable mode after leaving plan mode

### DIFF
--- a/apps/cli/src/permissions/register.test.ts
+++ b/apps/cli/src/permissions/register.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import type { PromptContext } from "../agent/prompt/registry"
+import { composeSystemPrompt } from "../agent/prompt/registry"
+import type { Settings } from "../config/settings"
+import { registerPermissions } from "./register"
+
+function prompt(mode: string): PromptContext {
+  return {
+    sessionId: "session",
+    appName: "Xal",
+    platform: "test",
+    cwd: "/workspace",
+    kind: "primary",
+    tools: [],
+    mode,
+  }
+}
+
+test("makes the current writable mode override stale plan-mode context", () => {
+  registerPermissions({
+    plugins: [],
+    permissions: { allow: [], ask: [], deny: [] },
+    modes: {
+      guarded: {
+        base: "normal",
+        allow: [],
+        ask: [],
+        deny: [],
+        guidance: "Use the guarded workflow.",
+      },
+    },
+    goal: { evaluatorModels: {} },
+    redaction: { values: [], environment: [] },
+    agents: { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 },
+    pluginConfig: {},
+    thinking: {},
+  } satisfies Settings)
+
+  const yolo = composeSystemPrompt(prompt("yolo"))
+  const custom = composeSystemPrompt(prompt("guarded"))
+  const plan = composeSystemPrompt(prompt("plan"))
+
+  expect(yolo).toContain("Current permission mode is `yolo`. Plan mode is not active")
+  expect(yolo).toContain("do not claim that plan-mode restrictions block tools or file writes")
+  expect(custom).toContain("Current permission mode is `guarded`. Plan mode is not active")
+  expect(custom).toContain("Use the guarded workflow.")
+  expect(plan).toContain("Current permission mode is `plan` and it is read-only.")
+  expect(plan).not.toContain("Plan mode is not active")
+})

--- a/apps/cli/src/permissions/register.ts
+++ b/apps/cli/src/permissions/register.ts
@@ -18,7 +18,11 @@ export function registerPermissions(settings: Settings): void {
     id: "permissions",
     text: (prompt) => {
       const definition = modeDefinition(prompt.mode)
-      return prompt.kind === "subagent" ? definition.subagentGuidance : definition.guidance
+      if (prompt.kind === "subagent") return definition.subagentGuidance
+      if (definition.readOnly) {
+        return `Current permission mode is \`${prompt.mode}\` and it is read-only.\n${definition.guidance}`
+      }
+      return `Current permission mode is \`${prompt.mode}\`. Plan mode is not active; do not claim that plan-mode restrictions block tools or file writes.\n${definition.guidance}`
     },
   })
 }

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -54,7 +54,7 @@ The default is `normal` when `mode` is omitted. Override it for one TUI session 
 - **Clear context and build** approves the plan, ends the planning conversation, and starts a new session whose first prompt is the approved plan. Planning transcripts are usually long and the implementation does not need them; the option reports how much of the context window the planning conversation occupies so the tradeoff is visible before choosing.
 - **Request changes** keeps plan mode active so the proposal can be revised.
 
-A dismissed review leaves plan mode active and waits for new direction. User-driven mode changes are refused while a turn, approval, or input request is active so one turn cannot silently cross permission boundaries.
+A dismissed review leaves plan mode active and waits for new direction. User-driven mode changes are refused while a turn, approval, or input request is active so one turn cannot silently cross permission boundaries. After a successful change to a writable mode, the model is explicitly told that plan mode is no longer active so earlier planning context cannot keep blocking writes.
 
 ## Custom modes
 
@@ -69,7 +69,7 @@ Custom modes are defined under `modes` and appear in the TUI mode cycle and `--m
 }
 ```
 
-`base` selects the built-in mode a custom mode behaves like. It defaults to `normal`; `plan` inherits read-only behavior and `yolo` inherits ask-skipping. `allow`, `ask`, and `deny` are mode-scoped rules that apply only while the mode is active. They sit above global `permissions` rules and below approvals remembered from the approval prompt. `guidance` replaces the mode instructions shown to the model.
+`base` selects the built-in mode a custom mode behaves like. It defaults to `normal`; `plan` inherits read-only behavior and `yolo` inherits ask-skipping. `allow`, `ask`, and `deny` are mode-scoped rules that apply only while the mode is active. They sit above global `permissions` rules and below approvals remembered from the approval prompt. `guidance` replaces the mode-specific workflow instructions shown to the primary agent; Xal still identifies the primary agent's current mode and whether it is read-only.
 
 Built-in mode names cannot be redefined. A session restored with a mode that no longer exists falls back to `normal`.
 


### PR DESCRIPTION
Explicitly identifies the primary agent's active permission mode and read-only status so stale planning context cannot block writes after switching modes. Adds coverage for built-in and custom modes and updates the permissions documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission-mode messaging so active modes correctly override outdated plan-mode instructions.
  * Clarified when plan mode is read-only and when writable modes allow tools and file changes.
* **Documentation**
  * Updated permission guidance to explain mode transitions, custom modes, and current read-only status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->