### PR TITLE
Add event-driven task agent waiting

### DIFF
--- a/apps/cli/src/agent/session/async.ts
+++ b/apps/cli/src/agent/session/async.ts
@@ -141,7 +141,7 @@ export function backgroundResultsMessage(results: BackgroundResult[], ownerId: s
 
 interface SessionAsyncHost {
   ownerId(): string
-  onResultsQueued(): void
+  onResultsQueued(kind: BackgroundResult["kind"]): void
   onAgentWorkSettled(): void
   onAsyncWorkSettled(): void
 }
@@ -197,12 +197,16 @@ export class SessionAsyncState {
     const result = formatBackgroundResult(job)
     if (epoch !== this.epoch || job.delivery !== "in_flight") return false
     this.queue.push(result)
-    this.host.onResultsQueued()
+    this.host.onResultsQueued(result.kind)
     return true
   }
 
   hasQueued(): boolean {
     return this.queue.length > 0
+  }
+
+  hasQueuedAgentResult(): boolean {
+    return this.queue.some((result) => result.kind === "agent")
   }
 
   drainQueued(): BackgroundResult[] {

--- a/apps/cli/src/agent/session/session.ts
+++ b/apps/cli/src/agent/session/session.ts
@@ -127,6 +127,7 @@ export class AgentSession {
   private readonly queue = new InputQueue((event) => this.emit(event))
   private readonly goals = new GoalRuntime({ emit: (event) => this.emit(event), evaluate: evaluateGoal })
   private activityController = new AbortController()
+  private agentActivityController = new AbortController()
   private outputDirectory: string
   private cwd: string
   private workspaceUndo: WorkspaceUndo
@@ -185,8 +186,9 @@ export class AgentSession {
     }
     this.asyncState = new SessionAsyncState({
       ownerId: () => this.sessionId,
-      onResultsQueued: () => {
-        this.noteActivity()
+      onResultsQueued: (kind) => {
+        if (kind === "agent") this.noteAgentActivity()
+        else this.noteActivity()
         queueMicrotask(() => this.startBackgroundResultTurn())
       },
       onAgentWorkSettled: () => {
@@ -251,6 +253,9 @@ export class AgentSession {
       pendingActivity: () =>
         this.queue.first !== undefined || this.asyncState.hasQueued() || this.hasPendingAgentQuestions(),
       activitySignal: () => this.activityController.signal,
+      pendingAgentActivity: () =>
+        this.queue.first !== undefined || this.asyncState.hasQueuedAgentResult() || this.hasPendingAgentQuestions(),
+      agentActivitySignal: () => this.agentActivityController.signal,
     }
   }
 
@@ -745,6 +750,12 @@ export class AgentSession {
     this.activityController = new AbortController()
   }
 
+  private noteAgentActivity(): void {
+    this.noteActivity()
+    this.agentActivityController.abort()
+    this.agentActivityController = new AbortController()
+  }
+
   private askParent(question: string, signal: AbortSignal): Promise<ParentQuestionResult> {
     if (this.kind !== "subagent" || !this.askParentHandler) {
       throw new Error("ask_parent is available only to running task agents")
@@ -772,7 +783,7 @@ export class AgentSession {
       type: "agent_questions",
       questions: [{ requestId: pending.requestId, jobId: pending.jobId, question: pending.question }],
     })
-    this.noteActivity()
+    this.noteAgentActivity()
     queueMicrotask(() => this.startAgentQuestionTurn())
     return true
   }
@@ -868,7 +879,7 @@ export class AgentSession {
     if (this.movingHistory) return false
     if (this.turnActive || this.state === "evaluating_goal") {
       if (!isDirectShellInput(redacted)) this.goals.rearm()
-      this.noteActivity()
+      this.noteAgentActivity()
       this.queue.push(redacted)
       return true
     }
@@ -885,7 +896,7 @@ export class AgentSession {
 
   steer(text: string): boolean {
     if (this.movingHistory || !this.turnActive || !this.acceptingQueuedInput) return false
-    this.noteActivity()
+    this.noteAgentActivity()
     this.queue.push(redactUserInput({ text, images: [] }))
     return true
   }

--- a/apps/cli/src/agent/session/tool-runner.ts
+++ b/apps/cli/src/agent/session/tool-runner.ts
@@ -108,6 +108,8 @@ export interface ToolRunnerHost {
   restartSession(prompt: string): void
   pendingActivity(): boolean
   activitySignal(): AbortSignal
+  pendingAgentActivity(): boolean
+  agentActivitySignal(): AbortSignal
 }
 
 export class ToolCallRunner {
@@ -387,6 +389,10 @@ export class ToolCallRunner {
                 activity: {
                   pending: this.host.pendingActivity(),
                   signal: this.host.activitySignal(),
+                },
+                agentActivity: {
+                  pending: this.host.pendingAgentActivity(),
+                  signal: this.host.agentActivitySignal(),
                 },
                 signal,
                 update,

--- a/apps/cli/src/agent/task/task.test.ts
+++ b/apps/cli/src/agent/task/task.test.ts
@@ -19,6 +19,7 @@ import {
   type ProviderRound,
 } from "../session/test-support"
 import { registerTaskAgents } from "./tool"
+import { MAX_AGENT_WAIT_MS } from "./wait"
 
 let harness: AgentSessionTestHarness
 
@@ -38,6 +39,20 @@ function modelCatalog(): ModelCatalog {
     models: [{ id: "test-model", name: "Test model", inputModalities: ["text"] }],
     source: "runtime",
   }
+}
+
+function createWaitingAgent(ownerId: string) {
+  return createAgentJob("wait-agent-test", {
+    id: `wait_agent_${crypto.randomUUID()}`,
+    ownerId,
+    task: "Inspect the target.",
+    timeoutMs: 60_000,
+    maxTurns: 10,
+    stop() {},
+    send() {
+      return false
+    },
+  })
 }
 
 test("keeps task mechanics in the tool contract and delegation policy in instructions", async () => {
@@ -63,17 +78,7 @@ test("wait_agent resumes on automatic agent delivery without collecting the resu
     completedRound("Integrated the task-agent result."),
   ])
   const session = harness.createSession(provider, { interactive: true })
-  const job = createAgentJob("wait-agent-test", {
-    id: `wait_agent_${crypto.randomUUID()}`,
-    ownerId: session.id,
-    task: "Inspect the target.",
-    timeoutMs: 60_000,
-    maxTurns: 10,
-    stop() {},
-    send() {
-      return false
-    },
-  })
+  const job = createWaitingAgent(session.id)
   let finished = false
   const unsubscribe = session.subscribe((event) => {
     if (event.type !== "tool_started" || event.tool !== "wait_agent" || finished) return
@@ -99,6 +104,29 @@ test("wait_agent resumes on automatic agent delivery without collecting the resu
     expect(job.delivery).toBe("delivered")
   } finally {
     unsubscribe()
+    if (!job.done) finishAgentJob(job, { status: "interrupted" }, "test cleanup")
+    suppressDelivery(job)
+  }
+})
+
+test("wait_agent returns invalid timeout input as a recoverable tool failure", async () => {
+  const provider = new ScriptedProvider([
+    toolRound("invalid-wait-agent", "wait_agent", { timeout_ms: 0 }),
+    completedRound("Recovered from the invalid wait."),
+  ])
+  const session = harness.createSession(provider, { interactive: true })
+  const job = createWaitingAgent(session.id)
+
+  try {
+    const outcome = await runSettledTurn(session, { text: "Wait with an invalid timeout.", images: [] })
+
+    expect(outcome.status).toBe("completed")
+    expect(provider.requests[1]?.input.at(-1)).toEqual({
+      type: "tool_result",
+      callId: "invalid-wait-agent",
+      output: `Tool failed: timeout_ms must be a positive integer no greater than ${MAX_AGENT_WAIT_MS}`,
+    })
+  } finally {
     if (!job.done) finishAgentJob(job, { status: "interrupted" }, "test cleanup")
     suppressDelivery(job)
   }

--- a/apps/cli/src/agent/task/task.test.ts
+++ b/apps/cli/src/agent/task/task.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, expect, test } from "bun:test"
 import { readFile } from "node:fs/promises"
-import { getJob, stopJob } from "../../background/jobs"
+import { createAgentJob, finishAgentJob, getJob, stopJob, suppressDelivery } from "../../background/jobs"
 import { registerJobTools } from "../../background/register"
 import { configureModes } from "../../permissions/modes"
 import type { ModelCatalog, Provider, StreamRequest } from "../../providers/types"
@@ -55,6 +55,53 @@ test("keeps task mechanics in the tool contract and delegation policy in instruc
   expect(request.instructions).toContain("explicitly request delegation")
   expect(request.instructions).toContain("Depth, research, or thoroughness alone is not authorization.")
   expect(request.instructions).not.toContain("Use the smallest useful batch")
+})
+
+test("wait_agent resumes on automatic agent delivery without collecting the result", async () => {
+  const provider = new ScriptedProvider([
+    toolRound("wait-agent", "wait_agent", { timeout_ms: 10_000 }),
+    completedRound("Integrated the task-agent result."),
+  ])
+  const session = harness.createSession(provider, { interactive: true })
+  const job = createAgentJob("wait-agent-test", {
+    id: `wait_agent_${crypto.randomUUID()}`,
+    ownerId: session.id,
+    task: "Inspect the target.",
+    timeoutMs: 60_000,
+    maxTurns: 10,
+    stop() {},
+    send() {
+      return false
+    },
+  })
+  let finished = false
+  const unsubscribe = session.subscribe((event) => {
+    if (event.type !== "tool_started" || event.tool !== "wait_agent" || finished) return
+    finished = true
+    queueMicrotask(() => {
+      finishAgentJob(job, { status: "completed", report: "event-driven task-agent report" }, "completed")
+    })
+  })
+  const started = performance.now()
+
+  try {
+    const outcome = await runSettledTurn(session, { text: "Wait for the running task agent.", images: [] })
+    const followUp = provider.requests[1]
+    if (!followUp) throw new Error("provider follow-up request was not recorded")
+
+    expect(outcome.status).toBe("completed")
+    expect(performance.now() - started).toBeLessThan(2_000)
+    expect(
+      followUp.input.some(
+        (item) => item.type === "user_message" && item.text.includes("event-driven task-agent report"),
+      ),
+    ).toBe(true)
+    expect(job.delivery).toBe("delivered")
+  } finally {
+    unsubscribe()
+    if (!job.done) finishAgentJob(job, { status: "interrupted" }, "test cleanup")
+    suppressDelivery(job)
+  }
 })
 
 test("lets a child ask its parent, consume the answer, and finish in the same session", async () => {

--- a/apps/cli/src/agent/task/tool.ts
+++ b/apps/cli/src/agent/task/tool.ts
@@ -10,6 +10,7 @@ import { settings } from "../../config/settings"
 import { MAX_BATCH_TASKS, MAX_CONTEXT_LENGTH, MAX_TASK_LENGTH, prepareTaskBatch } from "./parse"
 import { MAX_AGENT_MESSAGE_LENGTH } from "./questions"
 import { spawnTask } from "./spawn"
+import { waitAgentTool } from "./wait"
 
 export function compactTaskToolTitle(title: string): string {
   return title.split(" · ", 1)[0] ?? title
@@ -75,7 +76,7 @@ export const askParentTool: SessionTool = {
 export const taskTool: SessionTool = {
   name: "task",
   get description() {
-    return `Dispatch a batch of independent assignments to background agents. The call returns agent ids immediately, runs up to ${settings().agents.maxConcurrent} agents at once, queues the rest, and automatically delivers each result to this session. Agents start without conversation history. Read agents cannot modify files; write agents use the shared checkout or an isolated Git worktree.`
+    return `Dispatch a batch of independent assignments to background agents. The call returns agent ids immediately, runs up to ${settings().agents.maxConcurrent} agents at once, queues the rest, and automatically delivers each result to this session. wait_agent blocks on task-agent activity without collecting the delivered result. Agents start without conversation history. Read agents cannot modify files; write agents use the shared checkout or an isolated Git worktree.`
   },
   parameters: {
     type: "object",
@@ -192,6 +193,7 @@ export function registerTaskAgents(): void {
   })
   registerTool(askParentTool)
   registerTool(taskTool)
+  registerTool(waitAgentTool)
   registerToolRenderer({
     tool: askParentTool.name,
     summarize: (output) => (output.startsWith("Parent answered:") ? "answered" : "unavailable"),
@@ -204,5 +206,9 @@ export function registerTaskAgents(): void {
       if (!spawned) return "dispatched"
       return `${spawned[1]} ${spawned[1] === "1" ? "agent" : "agents"}`
     },
+  })
+  registerToolRenderer({
+    tool: waitAgentTool.name,
+    summarize: (output) => (output.startsWith("Task-agent activity") ? "activity arrived" : "wait ended"),
   })
 }

--- a/apps/cli/src/agent/task/wait.ts
+++ b/apps/cli/src/agent/task/wait.ts
@@ -1,0 +1,68 @@
+import { unsettledAgentJobs } from "../../background/jobs"
+import { asNumber } from "../../lib/json"
+import type { SessionTool } from "../../tools/types"
+import { waitForActivity } from "../../tools/wait"
+
+export const MIN_AGENT_WAIT_MS = 10_000
+export const DEFAULT_AGENT_WAIT_MS = 30_000
+export const MAX_AGENT_WAIT_MS = 60 * 60 * 1_000
+
+function timeoutOf(args: Record<string, unknown>): number {
+  if (!("timeout_ms" in args)) return DEFAULT_AGENT_WAIT_MS
+  const timeout = asNumber(args.timeout_ms)
+  if (timeout === undefined || !Number.isSafeInteger(timeout) || timeout <= 0 || timeout > MAX_AGENT_WAIT_MS) {
+    throw new Error(`timeout_ms must be a positive integer no greater than ${MAX_AGENT_WAIT_MS}`)
+  }
+  return Math.max(timeout, MIN_AGENT_WAIT_MS)
+}
+
+function seconds(milliseconds: number): string {
+  return `${(milliseconds / 1_000).toFixed(1).replace(/\.0$/, "")}s`
+}
+
+export const waitAgentTool: SessionTool = {
+  name: "wait_agent",
+  sessionAware: true,
+  description:
+    "Wait for activity from any running task agent. Returns when an agent result or question is queued, new user input arrives, or the timeout expires. Agent messages are delivered separately into the conversation.",
+  parameters: {
+    type: "object",
+    properties: {
+      timeout_ms: {
+        type: "integer",
+        minimum: 1,
+        maximum: MAX_AGENT_WAIT_MS,
+        description: `Maximum wait in milliseconds. Defaults to ${DEFAULT_AGENT_WAIT_MS}; values below ${MIN_AGENT_WAIT_MS} are clamped to ${MIN_AGENT_WAIT_MS}.`,
+      },
+    },
+    required: [],
+  },
+  available(ctx) {
+    return ctx.kind === "primary" && ctx.interactive
+  },
+  title(args) {
+    return `Wait for task-agent activity for up to ${seconds(timeoutOf(args))}`
+  },
+  readOnly() {
+    return true
+  },
+  async execute(args, ctx) {
+    if (unsettledAgentJobs(ctx.session.id).length === 0 && !ctx.agentActivity.pending) {
+      throw new Error("no running task agents or queued task-agent activity")
+    }
+    const timeout = timeoutOf(args)
+    const started = performance.now()
+    const outcome = await waitForActivity(timeout, ctx.signal, ctx.agentActivity)
+    const elapsed = seconds(performance.now() - started)
+    switch (outcome) {
+      case "activity":
+        return { output: `Task-agent activity arrived after ${elapsed}.` }
+      case "completed":
+        return { output: `Wait timed out after ${elapsed}; task agents are still running.` }
+      case "interrupted":
+        return { output: `Wait was interrupted after ${elapsed}.` }
+      case "canceled":
+        return { output: `Wait was canceled after ${elapsed}.` }
+    }
+  },
+}

--- a/apps/cli/src/agent/task/wait.ts
+++ b/apps/cli/src/agent/task/wait.ts
@@ -40,8 +40,8 @@ export const waitAgentTool: SessionTool = {
   available(ctx) {
     return ctx.kind === "primary" && ctx.interactive
   },
-  title(args) {
-    return `Wait for task-agent activity for up to ${seconds(timeoutOf(args))}`
+  title() {
+    return "Wait for task-agent activity"
   },
   readOnly() {
     return true

--- a/apps/cli/src/scheduler/tool.ts
+++ b/apps/cli/src/scheduler/tool.ts
@@ -3,13 +3,12 @@ import { registerBackgroundTask } from "../background/registry"
 import { asNumber } from "../lib/json"
 import { nativeToolRecord, nativeToolString } from "../native/tool-runtime"
 import type { SessionTool, SessionToolContext } from "../tools/types"
+import { waitForActivity } from "../tools/wait"
 
 export const MAX_SCHEDULER_DURATION_MS = 12 * 60 * 60 * 1_000
 
 const DESCRIPTION =
   "Wait for a specified duration before continuing. The wait ends early when new session activity arrives. Returns the elapsed wall-clock time."
-
-type WaitOutcome = "completed" | "activity" | "canceled" | "interrupted"
 
 function durationOf(args: Record<string, unknown>): number {
   const value = nativeToolRecord("scheduler_prepare", args)
@@ -18,32 +17,6 @@ function durationOf(args: Record<string, unknown>): number {
     throw new Error("native scheduler_prepare returned an invalid value")
   }
   return duration
-}
-
-function wait(duration: number, canceled: AbortSignal, ctx: SessionToolContext): Promise<WaitOutcome> {
-  if (ctx.signal.aborted) return Promise.resolve("interrupted")
-  if (ctx.activity.pending || ctx.activity.signal.aborted) return Promise.resolve("activity")
-  if (canceled.aborted) return Promise.resolve("canceled")
-
-  return new Promise((resolve) => {
-    let settled = false
-    const finish = (outcome: WaitOutcome): void => {
-      if (settled) return
-      settled = true
-      clearTimeout(timer)
-      ctx.signal.removeEventListener("abort", interrupted)
-      ctx.activity.signal.removeEventListener("abort", activity)
-      canceled.removeEventListener("abort", cancel)
-      resolve(outcome)
-    }
-    const interrupted = (): void => finish("interrupted")
-    const activity = (): void => finish("activity")
-    const cancel = (): void => finish("canceled")
-    const timer = setTimeout(() => finish("completed"), duration)
-    ctx.signal.addEventListener("abort", interrupted, { once: true })
-    ctx.activity.signal.addEventListener("abort", activity, { once: true })
-    canceled.addEventListener("abort", cancel, { once: true })
-  })
 }
 
 function registerScheduleTask(job: BackgroundScheduleJob, ctx: SessionToolContext): void {
@@ -101,7 +74,7 @@ export const schedulerTool: SessionTool = {
     const job = createScheduleJob(ctx.session.id, duration, () => controller.abort())
     registerScheduleTask(job, ctx)
     const started = performance.now()
-    const outcome = await wait(duration, controller.signal, ctx)
+    const outcome = await waitForActivity(duration, ctx.signal, ctx.activity, controller.signal)
     finishScheduleJob(job, outcome)
     const result = nativeToolRecord("scheduler_finalize", {
       elapsedSeconds: (performance.now() - started) / 1_000,

--- a/apps/cli/src/tools/types.ts
+++ b/apps/cli/src/tools/types.ts
@@ -116,6 +116,10 @@ export interface SessionToolContext {
     pending: boolean
     signal: AbortSignal
   }
+  agentActivity: {
+    pending: boolean
+    signal: AbortSignal
+  }
   signal: AbortSignal
   update(text: string): void
 }

--- a/apps/cli/src/tools/wait.ts
+++ b/apps/cli/src/tools/wait.ts
@@ -1,0 +1,37 @@
+export type ActivityWaitOutcome = "completed" | "activity" | "canceled" | "interrupted"
+
+export interface ActivitySource {
+  pending: boolean
+  signal: AbortSignal
+}
+
+export function waitForActivity(
+  duration: number,
+  interrupted: AbortSignal,
+  activity: ActivitySource,
+  canceled?: AbortSignal,
+): Promise<ActivityWaitOutcome> {
+  if (interrupted.aborted) return Promise.resolve("interrupted")
+  if (activity.pending || activity.signal.aborted) return Promise.resolve("activity")
+  if (canceled?.aborted) return Promise.resolve("canceled")
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (outcome: ActivityWaitOutcome): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      interrupted.removeEventListener("abort", interrupt)
+      activity.signal.removeEventListener("abort", activate)
+      canceled?.removeEventListener("abort", cancel)
+      resolve(outcome)
+    }
+    const interrupt = (): void => finish("interrupted")
+    const activate = (): void => finish("activity")
+    const cancel = (): void => finish("canceled")
+    const timer = setTimeout(() => finish("completed"), duration)
+    interrupted.addEventListener("abort", interrupt, { once: true })
+    activity.signal.addEventListener("abort", activate, { once: true })
+    canceled?.addEventListener("abort", cancel, { once: true })
+  })
+}

--- a/docs/background-work.md
+++ b/docs/background-work.md
@@ -49,9 +49,9 @@ Dispatching any `write` task asks for approval. Sub-agents cannot ask for approv
 
 A task agent should work independently, but it can call `ask_parent` when a parent-only decision or missing context truly blocks useful progress. The tool suspends that child tool call and shows `Waiting for parent…` without starting another provider turn or polling. Each child can have one pending question. The existing task deadline bounds the wait, and cancellation or parent failure releases it with an unavailable result. Questions are process-local live state and are not resumed after teardown.
 
-The parent receives a persisted, expandable question notice in the transcript and TUI plus a transient model instruction. It answers with `job_send`; while a question is pending, the next accepted `job_send` or TUI agent message is the answer rather than ordinary guidance. If the parent finishes without answering, it gets one transient correction. Finishing again releases the child as parent-unavailable. A question also wakes an explicit `job_output(wait)` so the parent cannot deadlock while waiting for the blocked child. Historical question events remain visible after restart, but no actionable instruction is restored into provider history. Assignments should still be self-contained, and agents should not use this path for status questions.
+The parent receives a persisted, expandable question notice in the transcript and TUI plus a transient model instruction. It answers with `job_send`; while a question is pending, the next accepted `job_send` or TUI agent message is the answer rather than ordinary guidance. If the parent finishes without answering, it gets one transient correction. Finishing again releases the child as parent-unavailable. A question wakes `wait_agent` and an explicit `job_output(wait)` so the parent cannot deadlock while waiting for the blocked child. Historical question events remain visible after restart, but no actionable instruction is restored into provider history. Assignments should still be self-contained, and agents should not use this path for status questions.
 
-A finished agent's report is delivered into the parent conversation automatically as a system notice, with no polling needed. Alongside the in-conversation result, every agent writes two durable files into the session directory:
+A finished agent's report is delivered into the parent conversation automatically as a system notice, with no polling needed. If the active turn is blocked on agent work, `wait_agent` subscribes to task-agent activity and returns when a result or question is queued, new user input arrives, or its timeout expires. It does not collect or suppress the automatic report delivery. Alongside the in-conversation result, every agent writes two durable files into the session directory:
 
 - a Markdown task record (`agent-<id>-….md`) with the assignment, workspace, final report, and buffered transcript
 - a full transcript log (`agent-<id>-….log`) written incrementally while the agent runs, so nothing is lost even if the process dies; logs cap at 64 MB and are marked `(capped)` past that
@@ -64,17 +64,18 @@ A running foreground `bash` command can be promoted to a background job at any m
 
 ## Job tools
 
-The model manages jobs with five tools:
+The model coordinates jobs with six tools:
 
 | Tool         | Purpose                                                                                                              |
 | ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `wait_agent` | Wait for task-agent activity without collecting or consuming the automatically delivered report.                     |
 | `job_output` | Read process output, collect an agent report, or inspect a schedule; agent waits return at a supervision checkpoint. |
 | `job_status` | Inspect processes, task agents, and schedules without consuming output.                                              |
 | `job_send`   | Answer a pending task-agent question, or queue guidance when no question is pending.                                 |
 | `job_extend` | Add up to 60 runtime minutes, 100 soft-budget turns, or both to a queued or running task agent per call.             |
 | `job_kill`   | Stop a process, task agent, or schedule. A process that ignores the graceful stop is hard-killed after 2 seconds.    |
 
-An explicit `job_output` wait cannot consume a task agent's whole runtime budget. It reserves a supervision window of up to one minute and returns with live status so the parent can inspect, extend, steer, or stop the task; a wait started while queued may return earlier because its runtime deadline has not started. If an agent still times out, collection includes a bounded transcript tail labeled as incomplete alongside the durable task-record path.
+`wait_agent` defaults to 30 seconds, clamps shorter requests to 10 seconds, and accepts waits up to one hour. It ends early for queued task-agent results, task-agent questions, or new user input. An explicit `job_output` wait cannot consume a task agent's whole runtime budget. It reserves a supervision window of up to one minute and returns with live status so the parent can inspect, extend, steer, or stop the task; a wait started while queued may return earlier because its runtime deadline has not started. If an agent still times out, collection includes a bounded transcript tail labeled as incomplete alongside the durable task-record path.
 
 Stopping a job from the TUI is never silent: the result is marked `stopped by the user` and still delivered so the model knows what happened. A task agent remains unsettled until its runner has finished cleanup and saved its task record.
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -2,7 +2,7 @@
 
 The built-in `scheduler` tool waits for a model-selected duration. When the wait completes, the tool returns to the same turn and the model receives another inference opportunity with the elapsed wall-clock time.
 
-This supports delayed checks without running a shell sleep command. Repeating behavior remains model-driven: after each wait, the model can inspect current state, finish, or call `scheduler` again.
+This supports time-based delays without running a shell sleep command. Repeating behavior remains model-driven: after each wait, the model can inspect current state, finish, or call `scheduler` again. Task-agent coordination uses the event-driven `wait_agent` tool described in [Background work](/docs/background-work).
 
 ## Arguments
 


### PR DESCRIPTION
Add a `wait_agent` tool that resumes on task-agent results, questions, user input, or timeout without consuming automatic result delivery. Introduce shared activity-waiting logic, track agent-specific session activity, add coverage for automatic delivery, and update background-work and scheduler documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `wait_agent` tool to wait for task-agent results, questions, user input, cancellation, or timeouts.
  * Agent activity is surfaced to session tools for event-driven responses without consuming automatic reports.
  * Wait durations are validated and constrained to supported limits.

* **Bug Fixes**
  * Improved continuation when agent results become available.
  * Invalid wait requests now fail safely and allow sessions to complete.

* **Documentation**
  * Updated guidance on agent activity handling, `wait_agent`, and scheduler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->