### PR TITLE
Keep live tools attached to TUI scrollback

### DIFF
--- a/apps/cli/src/plugins/tui/components/live-tools.test.ts
+++ b/apps/cli/src/plugins/tui/components/live-tools.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+import { LiveTools } from "./live-tools"
+
+test("live tools remove their leading row when grouped with completed tools", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24 })
+  const live = new LiveTools(setup.renderer, () => {}, undefined)
+
+  try {
+    live.setGrouped(false)
+    live.request("call-1", "read", "Read a file", true)
+    expect(live.height).toBe(2)
+
+    live.setGrouped(true)
+    expect(live.height).toBe(1)
+    expect(live.view.marginTop).toBe(0)
+  } finally {
+    live.clear()
+    setup.renderer.destroy()
+  }
+})

--- a/apps/cli/src/plugins/tui/components/live-tools.ts
+++ b/apps/cli/src/plugins/tui/components/live-tools.ts
@@ -26,6 +26,7 @@ export class LiveTools {
   readonly view: BoxRenderable
   private readonly rows = new Map<string, LiveRow>()
   private readonly spinner = spinnerHandle(() => this.render())
+  private grouped = false
 
   constructor(
     private readonly ctx: RenderContext,
@@ -37,9 +38,14 @@ export class LiveTools {
 
   get height(): number {
     if (this.rows.size === 0) return 0
-    let height = 1
+    let height = this.grouped ? 0 : 1
     for (const entry of this.rows.values()) height += 1 + entry.previewLabels.length
     return height
+  }
+
+  setGrouped(grouped: boolean): void {
+    this.grouped = grouped
+    this.view.marginTop = grouped ? 0 : 1
   }
 
   request(callId: string, tool: string, title: string, readOnly: boolean): void {
@@ -177,7 +183,6 @@ export class LiveTools {
 
   private sync(): void {
     this.view.visible = this.rows.size > 0
-    this.view.marginTop = this.rows.size > 0 ? 1 : 0
     this.onChange()
   }
 

--- a/apps/cli/src/plugins/tui/screen.test.ts
+++ b/apps/cli/src/plugins/tui/screen.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { mainFooterHeight } from "./screen"
+
+test("live tools fill the gap between scrollback and the fixed footer", () => {
+  expect(mainFooterHeight(40, 12, 8, 1)).toBe(28)
+})
+
+test("live tools stay attached as completed rows enter scrollback", () => {
+  expect(mainFooterHeight(40, 13, 8, 1)).toBe(27)
+})
+
+test("the footer returns to its content height without live tools", () => {
+  expect(mainFooterHeight(40, 12, 8, 0)).toBe(8)
+})

--- a/apps/cli/src/plugins/tui/screen.ts
+++ b/apps/cli/src/plugins/tui/screen.ts
@@ -38,6 +38,16 @@ const SCROLLBACK_GAP_ROWS = 1
 
 type ScreenPage = { kind: "main" } | { kind: "job" }
 
+export function mainFooterHeight(
+  terminalHeight: number,
+  scrollbackRows: number,
+  contentRows: number,
+  liveRows: number,
+): number {
+  if (liveRows === 0) return contentRows
+  return Math.max(contentRows, terminalHeight - scrollbackRows)
+}
+
 export class Screen {
   readonly view: BoxRenderable
   private readonly mainPanel: BoxRenderable
@@ -58,6 +68,7 @@ export class Screen {
   private readonly shortcutHelp: ShortcutHelp
   private overlaid = false
   private paletteBelow = true
+  private pendingScrollbackRows = 0
   private reserved = 0
   private page: ScreenPage = { kind: "main" }
   private sessionTitle: string | undefined
@@ -80,7 +91,7 @@ export class Screen {
       preferences,
       shortcuts.help("display.toggle-details"),
     )
-    this.view = column(renderer, { width: "100%", height: "100%", justifyContent: "flex-end" })
+    this.view = column(renderer, { width: "100%", height: "100%" })
     this.jobViewer = new JobViewer(renderer, (message) => this.statusBar.setNotice(message))
     this.live = new LiveTools(renderer, () => this.syncFooter(), shortcuts.help("jobs.background"))
     this.queued = new QueuedInputs(renderer, () => this.syncFooter())
@@ -167,7 +178,7 @@ export class Screen {
       () => this.session.id,
     )
 
-    this.mainPanel = column(renderer, { paddingLeft: 2, paddingRight: 2 })
+    this.mainPanel = column(renderer, { paddingLeft: 2, paddingRight: 2, marginBottom: "auto" })
     this.mainPanel.add(this.live.view)
     this.mainPanel.add(this.queued.view)
     this.mainPanel.add(this.taskList.view)
@@ -362,19 +373,30 @@ export class Screen {
     if (this.paletteBelow || overlaid) this.reserved = 0
     else this.reserved = Math.max(this.reserved, paletteRows)
     const editing = this.composer.rows + this.shortcutHelp.height + Math.max(paletteRows, this.reserved)
-    this.renderer.footerHeight =
+    this.live.setGrouped(this.scrollback.endsWithTool)
+    const contentRows =
       this.live.height +
       this.queued.height +
       this.taskList.height +
       (overlaid ? overlayRows : editing) +
       STATUS_ROWS +
       this.tasks.height
+    this.renderer.footerHeight = mainFooterHeight(
+      this.renderer.terminalHeight,
+      this.scrollback.rows + this.pendingScrollbackRows,
+      contentRows,
+      this.live.height,
+    )
   }
 
   private reclaim(rows: number): void {
-    if (this.reserved === 0) return
     this.reserved = Math.max(0, this.reserved - rows)
-    this.syncFooter()
+    this.pendingScrollbackRows += rows
+    try {
+      this.syncFooter()
+    } finally {
+      this.pendingScrollbackRows -= rows
+    }
   }
 
   private closedFooterRows(): number {

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -95,6 +95,42 @@ test("compaction state is visible in the transcript as soon as it starts", async
   }
 })
 
+test("settled tools leave the scrollback cursor on their row for live tool grouping", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 24,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false },
+      undefined,
+    )
+    scrollback.append({
+      kind: "tool",
+      tool: "wait_agent",
+      title: "Wait for task-agent activity",
+      readOnly: true,
+      denial: undefined,
+      output: "wait ended",
+      execution: undefined,
+      elapsed: "20s",
+      expanded: false,
+    })
+
+    const commits = setup.externalOutput.take()
+    expect(commits.at(-1)?.trailingNewline).toBe(false)
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+
 test("assistant markdown commits only its visible columns", async () => {
   const setup = await createTestRenderer({
     width: 80,
@@ -129,6 +165,7 @@ test("assistant markdown commits only its visible columns", async () => {
     ])
     expect(commits.every((commit) => commit.height === 1)).toBe(true)
     expect(commits.map((commit) => commit.rowColumns)).toEqual(rows.map(displayWidth))
+    expect(commits.map((commit) => commit.trailingNewline)).toEqual([true, true, true, true, false])
   } finally {
     setup.renderer.destroy()
   }

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -90,6 +90,10 @@ export class Scrollback {
     return this.origin + this.committed
   }
 
+  get endsWithTool(): boolean {
+    return this.blocks.findLast((block) => this.visible(block))?.kind === "tool"
+  }
+
   setTerminalBackground(background: RGBA): boolean {
     const next = userMessageBackground(background)
     if (this.userBackground.equals(next)) return false
@@ -297,7 +301,7 @@ export class Scrollback {
     if (target <= stream.committed) return
     const rows = target - stream.committed
     this.onCommit(rows)
-    this.commitStreamRows(stream.surface, rendered, stream.committed, target)
+    this.commitStreamRows(stream.surface, rendered, stream.committed, target, final)
     this.committed += rows
     stream.committed = target
   }
@@ -315,7 +319,7 @@ export class Scrollback {
       )
       surface.render()
       this.onCommit(surface.height)
-      surface.commitRows(0, surface.height)
+      surface.commitRows(0, surface.height, { trailingNewline: false })
       this.committed += surface.height
     } finally {
       surface.destroy()
@@ -329,7 +333,7 @@ export class Scrollback {
       surface.root.add(view)
       surface.render()
       this.onCommit(surface.height)
-      this.commitStreamRows(surface, rendered, 0, surface.height)
+      this.commitStreamRows(surface, rendered, 0, surface.height, true)
       this.committed += surface.height
     } finally {
       surface.destroy()
@@ -341,10 +345,14 @@ export class Scrollback {
     rendered: RenderedMarkdown,
     startRow: number,
     endRowExclusive: number,
+    final: boolean,
   ): void {
     const columns = streamRowColumns(rendered, surface.height)
     for (let row = startRow; row < endRowExclusive; row += 1) {
-      surface.commitRows(row, row + 1, { rowColumns: columns[row] })
+      surface.commitRows(row, row + 1, {
+        rowColumns: columns[row],
+        trailingNewline: !final || row + 1 < endRowExclusive,
+      })
     }
   }
 


### PR DESCRIPTION
Adjust footer sizing and scrollback commits so live tool rows remain attached as completed tools enter the transcript. Remove duplicate spacing when tools are grouped and add regression coverage for layout and trailing-newline behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved terminal UI layout and footer sizing across varying content, scrollback, and live tool activity.
  * Grouped live tools now display more compactly, removing unnecessary spacing.
  * Improved alignment and use of available screen space.

* **Bug Fixes**
  * Fixed scrollback positioning when completed tool output transitions to live tool activity.
  * Corrected trailing newline handling to prevent unwanted blank lines in rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->