### PR TITLE
Skip invalid skills and report startup warnings

### DIFF
--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -152,6 +152,9 @@ export async function runApp(
     if (failure.phase !== "bootstrap") continue
     ctx.error(`plugin bootstrap failed: ${failure.plugin}: ${failure.reason}`)
   }
+  for (const notice of bootstrapped.notices) {
+    ctx.error(`plugin bootstrap warning: ${notice.plugin}: ${notice.reason}`)
+  }
 
   await runCli(args, ctx)
 }

--- a/apps/cli/src/events/index.ts
+++ b/apps/cli/src/events/index.ts
@@ -14,6 +14,10 @@ function redactEvent(event: AppEvent): AppEvent {
             plugin: redactText(failure.plugin),
             reason: redactText(failure.reason),
           })),
+          notices: event.status.notices.map((notice) => ({
+            plugin: redactText(notice.plugin),
+            reason: redactText(notice.reason),
+          })),
         },
       }
     case "plugin_bootstrap_started":
@@ -50,4 +54,4 @@ class AppEventService implements EventService {
 }
 
 export const events: EventService = new AppEventService()
-export type { AppEvent, EventService, PluginFailure, PluginStatus } from "./types"
+export type { AppEvent, EventService, PluginFailure, PluginNotice, PluginStatus } from "./types"

--- a/apps/cli/src/events/types.ts
+++ b/apps/cli/src/events/types.ts
@@ -4,9 +4,15 @@ export interface PluginFailure {
   reason: string
 }
 
+export interface PluginNotice {
+  plugin: string
+  reason: string
+}
+
 export interface PluginStatus {
   total: number
   failures: PluginFailure[]
+  notices: PluginNotice[]
 }
 
 export type AppEvent =

--- a/apps/cli/src/plugins/discover.test.ts
+++ b/apps/cli/src/plugins/discover.test.ts
@@ -19,7 +19,7 @@ mock.module("./load", () => ({
   },
 }))
 
-const { bootstrapPlugins, registerPlugins, shutdownPlugins } = await import("./discover")
+const { bootstrapPlugins, registerBootstrapStep, registerPlugins, shutdownPlugins } = await import("./discover")
 
 function settings(plugins: string[] = [], pluginConfig: Settings["pluginConfig"] = {}): Settings {
   return {
@@ -83,6 +83,7 @@ describe("plugin orchestration", () => {
       expect(status).toEqual({
         total: 2,
         failures: [{ plugin: "broken", phase: "register", reason: "registration exploded" }],
+        notices: [],
       })
       expect(registered).toEqual(["broken", "working:true"])
       expect(listHooks()).toEqual([{ id: "working-plugin/active", events: ["prompt"] }])
@@ -111,6 +112,7 @@ describe("plugin orchestration", () => {
     expect(status).toEqual({
       total: 1,
       failures: [{ plugin: "invalid-secrets", phase: "register", reason: "secret redaction marker resolution failed" }],
+      notices: [],
     })
     expect(resolveCli(["invalid-secrets-cli"])).toBeUndefined()
   })
@@ -156,6 +158,7 @@ describe("plugin orchestration", () => {
           { plugin: "register-failure", phase: "register", reason: "could not import" },
           { plugin: "bootstrap-failure", phase: "bootstrap", reason: "bootstrap exploded" },
         ],
+        notices: [],
       })
       expect(observed).toEqual([
         { type: "plugin_registration_finished", status: registered },
@@ -211,7 +214,19 @@ describe("plugin orchestration", () => {
     expect(await first).toEqual({
       total: 3,
       failures: [{ plugin: "second", phase: "shutdown", reason: "second shutdown exploded" }],
+      notices: [],
     })
     expect(stopped).toEqual(["third", "second", "first"])
+  })
+
+  test("reports bootstrap step warnings without treating them as failures", async () => {
+    registerBootstrapStep("skills", async () => ["invalid skill was skipped"])
+    await registerPlugins(settings())
+
+    expect(await bootstrapPlugins()).toEqual({
+      total: 0,
+      failures: [],
+      notices: [{ plugin: "skills", reason: "invalid skill was skipped" }],
+    })
   })
 })

--- a/apps/cli/src/plugins/discover.ts
+++ b/apps/cli/src/plugins/discover.ts
@@ -5,7 +5,7 @@ import { registerCommand } from "../commands/registry"
 import { loadCredential, replaceCredential, saveCredential } from "../config/credentials"
 import { agentHome, cacheDir } from "../config/paths"
 import type { Settings } from "../config/settings"
-import { events, type PluginFailure, type PluginStatus } from "../events"
+import { events, type PluginFailure, type PluginNotice, type PluginStatus } from "../events"
 import { describeError } from "../lib/error"
 import { clearHooks, registerHook, removeHooks } from "../hooks/registry"
 import { contributeRules } from "../permissions/rules"
@@ -29,15 +29,20 @@ interface RegisteredPlugin {
 
 interface BootstrapStep {
   name: string
-  run(): Promise<void>
+  run(): Promise<string[]>
 }
 
-let status: PluginStatus = { total: 0, failures: [] }
+let status: PluginStatus = { total: 0, failures: [], notices: [] }
 let registered: RegisteredPlugin[] = []
 const bootstrapSteps: BootstrapStep[] = []
 
-export function registerBootstrapStep(name: string, run: () => Promise<void>): void {
-  bootstrapSteps.push({ name, run })
+export function registerBootstrapStep(name: string, run: () => Promise<void | string[]>): void {
+  bootstrapSteps.push({
+    name,
+    async run() {
+      return (await run()) ?? []
+    },
+  })
 }
 let bootstrapRun: Promise<PluginStatus> | undefined
 let shutdownRun: Promise<PluginStatus> | undefined
@@ -123,30 +128,42 @@ export async function registerPlugins(settings: Settings): Promise<PluginStatus>
     }
   }
 
-  status = { total: builtinPlugins.length + settings.plugins.length, failures }
+  status = { total: builtinPlugins.length + settings.plugins.length, failures, notices: [] }
   events.emitRetained({ type: "plugin_registration_finished", status })
   return status
 }
 
 async function runBootstrap(): Promise<PluginStatus> {
   const entries = registered.filter((entry) => entry.plugin.bootstrap)
-  const jobs: { name: string; pluginOrder?: number; run(): void | Promise<void> }[] = [
-    ...bootstrapSteps.map((step) => ({ name: step.name, run: step.run })),
+  const jobs: { name: string; pluginOrder?: number; run(): Promise<string[]> }[] = [
+    ...bootstrapSteps,
     ...entries.map((entry) => ({
       name: entry.plugin.name,
       pluginOrder: entry.pluginOrder,
-      run: () => entry.plugin.bootstrap?.(entry.ctx),
+      async run() {
+        await entry.plugin.bootstrap?.(entry.ctx)
+        return []
+      },
     })),
   ]
   events.emitRetained({ type: "plugin_bootstrap_started", total: jobs.length })
-  const outcomes = await Promise.allSettled(jobs.map((job) => Promise.resolve().then(() => job.run())))
-  const failures = outcomes.flatMap((outcome, index): PluginFailure[] => {
-    if (outcome.status === "fulfilled") return []
+  const outcomes = await Promise.allSettled(jobs.map((job) => job.run()))
+  const failures: PluginFailure[] = []
+  const notices: PluginNotice[] = []
+  for (const [index, outcome] of outcomes.entries()) {
     const job = jobs[index]!
+    if (outcome.status === "fulfilled") {
+      notices.push(...outcome.value.map((reason) => ({ plugin: job.name, reason })))
+      continue
+    }
     if (job.pluginOrder !== undefined) removeHooks(job.pluginOrder)
-    return [{ plugin: job.name, phase: "bootstrap", reason: describeError(outcome.reason) }]
-  })
-  status = { total: status.total, failures: [...status.failures, ...failures] }
+    failures.push({ plugin: job.name, phase: "bootstrap", reason: describeError(outcome.reason) })
+  }
+  status = {
+    total: status.total,
+    failures: [...status.failures, ...failures],
+    notices: [...status.notices, ...notices],
+  }
   events.emitRetained({ type: "plugin_bootstrap_finished", status })
   return status
 }
@@ -168,7 +185,7 @@ async function runShutdown(): Promise<PluginStatus> {
       failures.push({ plugin: entry.plugin.name, phase: "shutdown", reason: describeError(error) })
     }
   }
-  status = { total: status.total, failures: [...status.failures, ...failures] }
+  status = { total: status.total, failures: [...status.failures, ...failures], notices: status.notices }
   return status
 }
 

--- a/apps/cli/src/plugins/tui/controllers/app-events.ts
+++ b/apps/cli/src/plugins/tui/controllers/app-events.ts
@@ -1,4 +1,4 @@
-import type { AppEvent, PluginFailure } from "../../../events"
+import type { AppEvent, PluginFailure, PluginNotice } from "../../../events"
 import type { UserInput } from "../../../providers/types"
 import type { Screen } from "../screen"
 
@@ -22,6 +22,10 @@ export class InputQueue {
 
 function failureDetails(failures: PluginFailure[]): string[] {
   return failures.map((failure) => `${failure.plugin}: ${failure.reason}`)
+}
+
+function noticeDetails(notices: PluginNotice[]): string[] {
+  return notices.map((notice) => `${notice.plugin}: ${notice.reason}`)
 }
 
 export class AppEventController {
@@ -62,6 +66,14 @@ export class AppEventController {
             kind: "notice",
             summary: `plugins: ${failures.length} failed to initialize${hint}`,
             details: failureDetails(failures),
+          })
+        }
+        if (event.status.notices.length > 0) {
+          const hint = this.detailsShortcut ? ` · ${this.detailsShortcut} to see warnings` : ""
+          scrollback.appendHeader({
+            kind: "notice",
+            summary: `plugins: initialized with ${event.status.notices.length} warning${event.status.notices.length === 1 ? "" : "s"}${hint}`,
+            details: noticeDetails(event.status.notices),
           })
         }
         this.input.release()

--- a/apps/cli/src/profiler/profiler.ts
+++ b/apps/cli/src/profiler/profiler.ts
@@ -93,9 +93,9 @@ type AnonymousAgentEvent =
   | { type: "error" }
 
 type AnonymousAppEvent =
-  | { type: "plugin_registration_finished"; total: number; failedPhases: string[] }
+  | { type: "plugin_registration_finished"; total: number; failedPhases: string[]; notices: number }
   | { type: "plugin_bootstrap_started"; total: number }
-  | { type: "plugin_bootstrap_finished"; total: number; failedPhases: string[] }
+  | { type: "plugin_bootstrap_finished"; total: number; failedPhases: string[]; notices: number }
 
 type ProfileRecord =
   | { type: "run_started"; version: string }
@@ -407,6 +407,7 @@ function anonymousAppEvent(event: AppEvent): AnonymousAppEvent {
         type: event.type,
         total: event.status.total,
         failedPhases: event.status.failures.map((failure) => failure.phase),
+        notices: event.status.notices.length,
       }
     case "plugin_bootstrap_started":
       return event

--- a/apps/cli/src/skills/catalog.test.ts
+++ b/apps/cli/src/skills/catalog.test.ts
@@ -56,32 +56,54 @@ test("ignores a missing root and finds skills nested below it", async () => {
   })
 })
 
-test("skips invalid skill documents without dropping valid skills", async () => {
+test("repairs common plain scalar YAML and accepts relaxed skill metadata", async () => {
   await withSkillsRoot(async (root) => {
-    const cases: [string, string, string][] = [
-      ["no-frontmatter", "", "body without frontmatter"],
-      ["bad-name", "name: Bad_Name\ndescription: fine", "body"],
-      ["mismatched", "name: other\ndescription: fine", "body"],
-      ["empty-body", "name: empty-body\ndescription: fine", ""],
-      ["no-description", "name: no-description", "body"],
-      ["broken-yaml", "name: [unclosed\ndescription: fine", "body"],
-    ]
+    await writeSkill(
+      root,
+      "release-swift",
+      "description: Cut a release (Swift app): pick a version\nargument-hint: <duration: e.g. 7d>\ntags: [next,@release]\nmetadata:\n  notes: |-\n    Keep this: unchanged",
+      "",
+    )
+    await writeSkill(root, "directory-name", "name:  Display   Name\ndescription:  Multiple\n  words", "body")
 
-    for (const [name, frontmatter, body] of cases) {
+    const { skills, failures } = await loadSkills(roots([root, "user"]))
+
+    expect(failures).toEqual([])
+    expect(skills).toHaveLength(2)
+    expect(skills.find((skill) => skill.path.endsWith("directory-name/SKILL.md"))).toMatchObject({
+      name: "Display Name",
+      description: "Multiple words",
+      body: "body",
+    })
+    expect(skills.find((skill) => skill.path.endsWith("release-swift/SKILL.md"))).toMatchObject({
+      name: "release-swift",
+      description: "Cut a release (Swift app): pick a version",
+      body: "",
+    })
+  })
+})
+
+test("skips structurally invalid skill documents without dropping valid skills", async () => {
+  await withSkillsRoot(async (root) => {
+    const invalidDocuments: [string, string][] = [
+      ["no-frontmatter", "body without frontmatter"],
+      ["no-description", "---\nname: no-description\n---\nbody"],
+      ["invalid-yaml", '---\nname: invalid-yaml\ndescription: "unterminated\n---\nbody'],
+      ["long-name", `---\nname: ${"x".repeat(65)}\ndescription: fine\n---\nbody`],
+    ]
+    for (const [name, document] of invalidDocuments) {
       const directory = join(root, name)
       await mkdir(directory, { recursive: true })
-      await writeFile(join(directory, "SKILL.md"), frontmatter ? `---\n${frontmatter}\n---\n\n${body}\n` : `${body}\n`)
+      await writeFile(join(directory, "SKILL.md"), document)
     }
-    await writeSkill(root, "valid", "name: valid\ndescription: fine", "body")
+    await writeSkill(root, "valid", `name: valid\ndescription: ${"x".repeat(1_025)}`, "body")
 
     const { skills, failures } = await loadSkills(roots([root, "user"]))
 
     expect(skills.map((skill) => skill.name)).toEqual(["valid"])
-    expect(failures).toHaveLength(cases.length)
-    expect(failures.map((failure) => failure.path)).toEqual(
-      cases.map(([name]) => join(root, name, "SKILL.md")).sort((left, right) => left.localeCompare(right)),
-    )
-    expect(failures.find((failure) => failure.path.endsWith("broken-yaml/SKILL.md"))?.reason).toContain(
+    expect(skills[0]?.description).toHaveLength(1_025)
+    expect(failures).toHaveLength(invalidDocuments.length)
+    expect(failures.find((failure) => failure.path.endsWith("invalid-yaml/SKILL.md"))?.reason).toContain(
       "invalid YAML frontmatter",
     )
   })

--- a/apps/cli/src/skills/catalog.test.ts
+++ b/apps/cli/src/skills/catalog.test.ts
@@ -34,8 +34,9 @@ test("loads skills from every root and lets a later root shadow an earlier name"
     await writeSkill(user, "review", "name: review\ndescription: user review", "review body")
     await writeSkill(project, "deploy", "name: deploy\ndescription: project deploy", "project body")
 
-    const skills = await loadSkills(roots([user, "user"], [project, "project"]))
+    const { skills, failures } = await loadSkills(roots([user, "user"], [project, "project"]))
 
+    expect(failures).toEqual([])
     expect(skills.map((skill) => skill.name)).toEqual(["deploy", "review"])
     expect(skills[0]).toMatchObject({ source: "project", description: "project deploy", body: "project body" })
     expect(skills[1]).toMatchObject({ source: "user", description: "user review" })
@@ -46,13 +47,16 @@ test("ignores a missing root and finds skills nested below it", async () => {
   await withSkillsRoot(async (root) => {
     await writeSkill(join(root, "present", "vendor", "pack"), "audit", "name: audit\ndescription: audits", "body")
 
-    const skills = await loadSkills(roots([join(root, "absent"), "user"], [join(root, "present"), "project"]))
+    const { skills, failures } = await loadSkills(
+      roots([join(root, "absent"), "user"], [join(root, "present"), "project"]),
+    )
 
+    expect(failures).toEqual([])
     expect(skills.map((skill) => skill.name)).toEqual(["audit"])
   })
 })
 
-test("rejects skill documents that break the frontmatter contract", async () => {
+test("skips invalid skill documents without dropping valid skills", async () => {
   await withSkillsRoot(async (root) => {
     const cases: [string, string, string][] = [
       ["no-frontmatter", "", "body without frontmatter"],
@@ -65,11 +69,21 @@ test("rejects skill documents that break the frontmatter contract", async () => 
 
     for (const [name, frontmatter, body] of cases) {
       const directory = join(root, name)
-      await mkdir(join(directory, name), { recursive: true })
-      const path = join(directory, name, "SKILL.md")
-      await writeFile(path, frontmatter ? `---\n${frontmatter}\n---\n\n${body}\n` : `${body}\n`)
-      await expect(loadSkills(roots([directory, "user"]))).rejects.toThrow(path)
+      await mkdir(directory, { recursive: true })
+      await writeFile(join(directory, "SKILL.md"), frontmatter ? `---\n${frontmatter}\n---\n\n${body}\n` : `${body}\n`)
     }
+    await writeSkill(root, "valid", "name: valid\ndescription: fine", "body")
+
+    const { skills, failures } = await loadSkills(roots([root, "user"]))
+
+    expect(skills.map((skill) => skill.name)).toEqual(["valid"])
+    expect(failures).toHaveLength(cases.length)
+    expect(failures.map((failure) => failure.path)).toEqual(
+      cases.map(([name]) => join(root, name, "SKILL.md")).sort((left, right) => left.localeCompare(right)),
+    )
+    expect(failures.find((failure) => failure.path.endsWith("broken-yaml/SKILL.md"))?.reason).toContain(
+      "invalid YAML frontmatter",
+    )
   })
 })
 
@@ -88,7 +102,8 @@ test("reads supporting files inside the skill directory", async () => {
     await mkdir(join(directory, "references"), { recursive: true })
     await writeFile(join(directory, "references", "steps.md"), "step one")
 
-    const [skill] = await loadSkills(roots([root, "user"]))
+    const { skills } = await loadSkills(roots([root, "user"]))
+    const [skill] = skills
 
     expect(await listSkillFiles(skill!)).toEqual(["references/steps.md"])
     expect(await readSkillResource(skill!, "references/steps.md")).toBe("step one")
@@ -103,7 +118,8 @@ test("refuses to read a resource that escapes the skill directory", async () => 
     await symlink(outside, join(directory, "escape.txt"))
     await symlink(root, join(directory, "escape-dir"))
 
-    const [skill] = await loadSkills(roots([join(root, "skills"), "user"]))
+    const { skills } = await loadSkills(roots([join(root, "skills"), "user"]))
+    const [skill] = skills
 
     await expect(readSkillResource(skill!, "../outside.txt")).rejects.toThrow("must stay inside the skill directory")
     await expect(readSkillResource(skill!, outside)).rejects.toThrow("must be relative to the skill directory")
@@ -122,7 +138,8 @@ test("refuses to read a binary supporting file", async () => {
     const directory = await writeSkill(root, "deploy", "name: deploy\ndescription: deploys", "body")
     await writeFile(join(directory, "blob.bin"), Buffer.from([0x68, 0x00, 0x69]))
 
-    const [skill] = await loadSkills(roots([root, "user"]))
+    const { skills } = await loadSkills(roots([root, "user"]))
+    const [skill] = skills
 
     await expect(readSkillResource(skill!, "blob.bin")).rejects.toThrow("skill file is binary: blob.bin")
   })

--- a/apps/cli/src/skills/catalog.ts
+++ b/apps/cli/src/skills/catalog.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile, realpath, stat } from "node:fs/promises"
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path"
-import { isMissingPathError } from "../lib/error"
+import { describeError, isMissingPathError } from "../lib/error"
 import { asString, isRecord } from "../lib/json"
 import type { Skill, SkillSource } from "./types"
 
@@ -10,6 +10,16 @@ const MAX_RESOURCE_BYTES = 50_000
 export interface SkillRoot {
   directory: string
   source: SkillSource
+}
+
+export interface SkillLoadFailure {
+  path: string
+  reason: string
+}
+
+export interface SkillLoadResult {
+  skills: Skill[]
+  failures: SkillLoadFailure[]
 }
 
 interface SkillDocument {
@@ -107,22 +117,39 @@ async function loadSkill(path: string, source: SkillSource): Promise<Skill> {
   return { ...document, directory: resolve(path, ".."), path, source }
 }
 
-async function loadRoot(root: SkillRoot): Promise<Skill[]> {
-  const skills = await Promise.all((await findSkillFiles(root.directory)).map((path) => loadSkill(path, root.source)))
+async function loadRoot(root: SkillRoot): Promise<SkillLoadResult> {
+  const paths = await findSkillFiles(root.directory)
+  const outcomes = await Promise.allSettled(paths.map((path) => loadSkill(path, root.source)))
+  const skills: Skill[] = []
+  const failures: SkillLoadFailure[] = []
   const names = new Set<string>()
-  for (const skill of skills) {
-    if (names.has(skill.name)) throw new Error(`${root.directory}: duplicate skill name: ${skill.name}`)
-    names.add(skill.name)
+
+  for (const [index, outcome] of outcomes.entries()) {
+    if (outcome.status === "rejected") {
+      const path = paths[index]!
+      const reason = describeError(outcome.reason)
+      failures.push({ path, reason: reason.startsWith(`${path}: `) ? reason.slice(path.length + 2) : reason })
+      continue
+    }
+    if (names.has(outcome.value.name)) {
+      throw new Error(`${root.directory}: duplicate skill name: ${outcome.value.name}`)
+    }
+    names.add(outcome.value.name)
+    skills.push(outcome.value)
   }
-  return skills
+  return { skills, failures }
 }
 
-export async function loadSkills(roots: SkillRoot[]): Promise<Skill[]> {
+export async function loadSkills(roots: SkillRoot[]): Promise<SkillLoadResult> {
   const catalog = new Map<string, Skill>()
+  const failures: SkillLoadFailure[] = []
   for (const root of roots) {
-    for (const skill of await loadRoot(root)) catalog.set(skill.name, skill)
+    const loaded = await loadRoot(root)
+    failures.push(...loaded.failures)
+    for (const skill of loaded.skills) catalog.set(skill.name, skill)
   }
-  return [...catalog.values()].sort((left, right) => left.name.localeCompare(right.name))
+  const skills = [...catalog.values()].sort((left, right) => left.name.localeCompare(right.name))
+  return { skills, failures }
 }
 
 export async function listSkillFiles(skill: Skill): Promise<string[]> {

--- a/apps/cli/src/skills/catalog.ts
+++ b/apps/cli/src/skills/catalog.ts
@@ -75,39 +75,125 @@ async function findSkillFiles(directory: string): Promise<string[]> {
   return (await walkFiles(directory)).filter((path) => basename(path) === "SKILL.md")
 }
 
+function sanitizeSingleLine(value: string): string {
+  return value.split(/\s+/).filter(Boolean).join(" ")
+}
+
+function repairFrontmatterScalarFields(frontmatter: string): string | undefined {
+  let changed = false
+  let blockScalarIndent: number | undefined
+  const repaired: string[] = []
+
+  for (const line of frontmatter.split("\n")) {
+    const indent = /^ */.exec(line)?.[0].length ?? 0
+    if (blockScalarIndent !== undefined) {
+      if (!line.trim() || indent > blockScalarIndent) {
+        repaired.push(line)
+        continue
+      }
+      blockScalarIndent = undefined
+    }
+
+    const separator = line.indexOf(":")
+    if (separator < 0) {
+      repaired.push(line)
+      continue
+    }
+    const key = line.slice(0, separator)
+    const value = line.slice(separator + 1)
+    if (!key.trim() || (value[0] !== undefined && !/\s/.test(value[0]))) {
+      repaired.push(line)
+      continue
+    }
+
+    const trimmedStart = value.trimStart()
+    const leadingWhitespace = value.slice(0, value.length - trimmedStart.length)
+    let scalar = trimmedStart
+    let comment = ""
+    for (let index = 0; index < trimmedStart.length; index++) {
+      if (trimmedStart[index] !== "#" || (index > 0 && !/\s/.test(trimmedStart[index - 1]!))) continue
+      const commentStart = trimmedStart.slice(0, index).trimEnd().length
+      scalar = trimmedStart.slice(0, commentStart)
+      comment = trimmedStart.slice(commentStart)
+      break
+    }
+
+    scalar = scalar.trimEnd()
+    const first = scalar[0]
+    if (first === undefined) {
+      repaired.push(line)
+      continue
+    }
+    if (first === "|" || first === ">") {
+      blockScalarIndent = indent
+      repaired.push(line)
+      continue
+    }
+    if (first === "'" || first === '"') {
+      repaired.push(line)
+      continue
+    }
+
+    let invalidFlowLikeScalar = false
+    if (first === "[" || first === "{" || first === "@" || first === "`") {
+      try {
+        Bun.YAML.parse(scalar)
+      } catch {
+        invalidFlowLikeScalar = true
+      }
+    }
+    if (!/:\s/.test(scalar) && !invalidFlowLikeScalar) {
+      repaired.push(line)
+      continue
+    }
+
+    repaired.push(`${key}:${leadingWhitespace}'${scalar.replaceAll("'", "''")}'${comment}`)
+    changed = true
+  }
+
+  return changed ? repaired.join("\n") : undefined
+}
+
+function parseFrontmatter(path: string, frontmatter: string): unknown {
+  try {
+    return Bun.YAML.parse(frontmatter)
+  } catch (error) {
+    const repaired = repairFrontmatterScalarFields(frontmatter)
+    if (repaired !== undefined) {
+      try {
+        return Bun.YAML.parse(repaired)
+      } catch (repairError) {
+        const reason = error instanceof Error ? error.message : String(error)
+        throw new Error(`${path}: invalid YAML frontmatter: ${reason}`, { cause: repairError })
+      }
+    }
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(`${path}: invalid YAML frontmatter: ${reason}`, { cause: error })
+  }
+}
+
 function parseSkill(path: string, content: string): SkillDocument {
   const normalized = content
     .replace(/^\uFEFF/, "")
     .replaceAll("\r\n", "\n")
     .replaceAll("\r", "\n")
-  const frontmatter = /^---\n([\s\S]*?)\n---(?:\n|$)/.exec(normalized)
+  const frontmatter = /^[ \t]*---[ \t]*\n([\s\S]*?)\n[ \t]*---[ \t]*(?:\n|$)/.exec(normalized)
   if (!frontmatter) throw new Error(`${path}: SKILL.md must begin with closed YAML frontmatter`)
 
-  let fields: unknown
-  try {
-    fields = Bun.YAML.parse(frontmatter[1] ?? "")
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error)
-    throw new Error(`${path}: invalid YAML frontmatter: ${reason}`, { cause: error })
-  }
+  const fields = parseFrontmatter(path, frontmatter[1] ?? "")
   if (!isRecord(fields)) throw new Error(`${path}: frontmatter must be an object`)
 
-  const name = asString(fields.name)?.trim()
-  if (!name || name.length > 64 || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) {
-    throw new Error(`${path}: name must use 1-64 lower-case letters, numbers, and single hyphens`)
-  }
-  if (basename(dirname(path)) !== name) {
-    throw new Error(`${path}: parent directory must be named ${name}`)
-  }
+  const rawName = fields.name === undefined ? basename(dirname(path)) : asString(fields.name)
+  if (rawName === undefined) throw new Error(`${path}: name must be a string`)
+  const name = sanitizeSingleLine(rawName) || basename(dirname(path))
+  if ([...name].length > 64) throw new Error(`${path}: name must not exceed 64 characters`)
 
-  const description = asString(fields.description)?.trim()
-  if (!description || description.length > 1024) {
-    throw new Error(`${path}: description must contain 1-1024 characters`)
-  }
+  const rawDescription = asString(fields.description)
+  if (rawDescription === undefined) throw new Error(`${path}: description is required`)
+  const description = sanitizeSingleLine(rawDescription)
+  if (!description) throw new Error(`${path}: description is required`)
 
-  const body = normalized.slice(frontmatter[0].length).trim()
-  if (!body) throw new Error(`${path}: skill instructions must not be empty`)
-  return { name, description, body }
+  return { name, description, body: normalized.slice(frontmatter[0].length).trim() }
 }
 
 async function loadSkill(path: string, source: SkillSource): Promise<Skill> {

--- a/apps/cli/src/skills/register.ts
+++ b/apps/cli/src/skills/register.ts
@@ -31,14 +31,14 @@ export function registerSkills(): void {
   registerPrompt({ id: "skills", text: catalogPrompt })
 }
 
-export async function discoverSkills(): Promise<void> {
+export async function discoverSkills(): Promise<string[]> {
   const root = await findProjectRoot(process.cwd())
-  replaceSkills(
-    await loadSkills([
-      { directory: join(homedir(), ".agents", "skills"), source: "user" },
-      { directory: join(agentHome(), "skills"), source: "user" },
-      { directory: join(root, ".agents", "skills"), source: "project" },
-      { directory: join(dirname(projectConfigPath(root)), "skills"), source: "project" },
-    ]),
-  )
+  const loaded = await loadSkills([
+    { directory: join(homedir(), ".agents", "skills"), source: "user" },
+    { directory: join(agentHome(), "skills"), source: "user" },
+    { directory: join(root, ".agents", "skills"), source: "project" },
+    { directory: join(dirname(projectConfigPath(root)), "skills"), source: "project" },
+  ])
+  replaceSkills(loaded.skills)
+  return loaded.failures.map((failure) => `${failure.path}: ${failure.reason}`)
 }

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -68,7 +68,7 @@ description: Review the current workspace changes for correctness
 Inspect the current diff, validate every finding, and report only actionable issues.
 ```
 
-Only skill names and up to the first 160 characters of each normalized description enter the system prompt. Lead with concise matching criteria; put procedures and edge cases in the skill body. The model loads full instructions on demand with the read-only `skill` tool, which can also read referenced text files inside that package without allowing paths to escape the package directory. `SKILL.md` files are limited to 64 KiB and supporting files read through the tool are limited to 50,000 bytes.
+Only skill names and up to the first 160 characters of each normalized description enter the system prompt. Lead with concise matching criteria; put procedures and edge cases in the skill body. The model loads full instructions on demand with the read-only `skill` tool, which can also read referenced text files inside that package without allowing paths to escape the package directory. `SKILL.md` files are limited to 64 KiB and supporting files read through the tool are limited to 50,000 bytes. An invalid `SKILL.md` is skipped and reported as a startup warning without blocking other skills from loading.
 
 Type `$` anywhere in the TUI composer to open skill completion. Continue typing to filter, then press Tab, Right, or Enter to replace only the skill reference at the cursor. Known `$skill-name` references are highlighted both while editing and in the submitted user message.
 

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -57,7 +57,7 @@ Xal discovers reusable skill packages from four directories, in increasing prior
 
 A later package replaces an earlier package with the same skill name. Project skill directories are read only after workspace trust is established.
 
-Every package is a directory named after its skill and containing a `SKILL.md` entry file. The entry file requires YAML frontmatter with a lower-case, hyphen-separated `name` and a `description`, followed by non-empty instructions:
+Every package is a directory containing a `SKILL.md` entry file. The entry file requires YAML frontmatter with a `description`. Its `name` is optional and defaults to the package directory name:
 
 ```md
 ---
@@ -68,7 +68,9 @@ description: Review the current workspace changes for correctness
 Inspect the current diff, validate every finding, and report only actionable issues.
 ```
 
-Only skill names and up to the first 160 characters of each normalized description enter the system prompt. Lead with concise matching criteria; put procedures and edge cases in the skill body. The model loads full instructions on demand with the read-only `skill` tool, which can also read referenced text files inside that package without allowing paths to escape the package directory. `SKILL.md` files are limited to 64 KiB and supporting files read through the tool are limited to 50,000 bytes. An invalid `SKILL.md` is skipped and reported as a startup warning without blocking other skills from loading.
+Skill names may contain up to 64 characters. Lower-case, hyphen-separated names remain recommended because they work naturally with `$skill-name` references. Xal normalizes metadata whitespace, accepts descriptions of any length, and repairs common third-party YAML mistakes such as unquoted prose containing colons. Unknown frontmatter fields are ignored, and the Markdown body may be empty.
+
+Only skill names and up to the first 160 characters of each normalized description enter the system prompt. Lead with concise matching criteria; put procedures and edge cases in the skill body. The model loads full instructions on demand with the read-only `skill` tool, which can also read referenced text files inside that package without allowing paths to escape the package directory. `SKILL.md` files are limited to 64 KiB and supporting files read through the tool are limited to 50,000 bytes. A structurally invalid `SKILL.md` is skipped and reported as a startup warning without blocking other skills from loading.
 
 Type `$` anywhere in the TUI composer to open skill completion. Continue typing to filter, then press Tab, Right, or Enter to replace only the skill reference at the cursor. Known `$skill-name` references are highlighted both while editing and in the submitted user message.
 


### PR DESCRIPTION
Load valid skills even when individual SKILL.md files are invalid, surface skipped files as redacted plugin bootstrap warnings in the CLI and TUI, include warning counts in profiler events, and document the behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plugin startup can report non-blocking warnings with plugin names and details.
  - The terminal interface displays plugin notices and provides access to additional details.
  - Skill discovery continues when individual skill files are invalid, while collecting clear failure information.
  - Skill metadata now supports more flexible names, descriptions, YAML formatting, and empty bodies.

- **Bug Fixes**
  - Plugin bootstrap warnings are no longer treated as startup failures.
  - Invalid skill files no longer prevent valid skills from loading.

- **Documentation**
  - Updated skill discovery guidance to explain warning behavior for invalid files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->