### PR TITLE
Batch TUI session replay to recent scrollback

### DIFF
--- a/apps/cli/src/agent/session/session.ts
+++ b/apps/cli/src/agent/session/session.ts
@@ -638,8 +638,8 @@ export class AgentSession {
     this.mode = target.mode
     this.asyncState.register()
     this.recorder?.attach(target.path)
-    this.emit(this.startEvent(true))
     try {
+      this.emit(this.startEvent(true))
       for (const event of target.session.events) this.notify(event)
     } finally {
       this.notify({ type: "session_replay_finished" })

--- a/apps/cli/src/plugins/tui/app.ts
+++ b/apps/cli/src/plugins/tui/app.ts
@@ -164,7 +164,7 @@ export async function startTui(events: EventService, config: TuiConfig, options:
   const replayLayout = (): void => {
     screen.composer.reflow()
     screen.syncFooter()
-    screen.scrollback.replay()
+    screen.scrollback.replayViewport()
   }
   renderer.on(CliRenderEvents.RESIZE, () => {
     if (renderer.terminalWidth === lastWidth && renderer.terminalHeight === lastHeight) return

--- a/apps/cli/src/plugins/tui/app.ts
+++ b/apps/cli/src/plugins/tui/app.ts
@@ -35,7 +35,7 @@ import { describeTerminal, sessionTerminalTitle, terminalBackground } from "./te
 import { TerminalOutput } from "./terminal-output"
 import { applyTerminalPalette, COLORS } from "./theme/colors"
 
-const RESIZE_DEBOUNCE_MS = 60
+const RESIZE_DEBOUNCE_MS = 200
 const TERMINAL_RESET = "\u001b[r\u001b[<u\u001b[?25h"
 const KITTY_KEYBOARD: KittyKeyboardOptions = { allKeysAsEscapes: true, reportText: true }
 
@@ -158,13 +158,22 @@ export async function startTui(events: EventService, config: TuiConfig, options:
   renderer.root.add(screen.view)
   let lastWidth = renderer.terminalWidth
   let lastHeight = renderer.terminalHeight
+  let replayWidth = renderer.terminalWidth
   let replayTimer: ReturnType<typeof setTimeout> | undefined
   let replayPending = false
   let editing = false
-  const replayLayout = (): void => {
+  const syncLayout = (): void => {
     screen.composer.reflow()
     screen.syncFooter()
+  }
+  const replayScrollback = (): void => {
+    if (renderer.terminalWidth === replayWidth) return
+    replayWidth = renderer.terminalWidth
     screen.scrollback.replayViewport()
+  }
+  const replayLayout = (): void => {
+    syncLayout()
+    replayScrollback()
   }
   renderer.on(CliRenderEvents.RESIZE, () => {
     if (renderer.terminalWidth === lastWidth && renderer.terminalHeight === lastHeight) return
@@ -174,10 +183,12 @@ export async function startTui(events: EventService, config: TuiConfig, options:
       replayPending = true
       return
     }
+    syncLayout()
+    if (renderer.terminalWidth === replayWidth) return
     clearTimeout(replayTimer)
     replayTimer = setTimeout(() => {
       replayTimer = undefined
-      replayLayout()
+      replayScrollback()
     }, RESIZE_DEBOUNCE_MS)
   })
   const resetCommands = setTuiCommandActions({

--- a/apps/cli/src/plugins/tui/controllers/agent-events.ts
+++ b/apps/cli/src/plugins/tui/controllers/agent-events.ts
@@ -126,12 +126,14 @@ export class AgentEventController {
         this.goalId = undefined
         this.reasoningStreamed = false
         this.replaying = event.resumed
+        if (event.resumed) scrollback.beginReplay()
         this.screen.startSession(event.title, event.cwd, event.model, event.thinking, event.mode)
         statusBar.resetGoal()
         this.trackContextWindow()
         break
       case "session_replay_finished":
         this.replaying = false
+        scrollback.endReplay()
         break
       case "session_title_changed":
         this.screen.setSessionTitle(event.title)

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -196,8 +196,10 @@ test("session replay defers emission and lands as one viewport batch", async () 
     scrollback.endReplay()
 
     const commits = setup.externalOutput.take()
-    const entries = commits.flatMap((commit) => commit.rows).filter((row) => row.includes("entry"))
+    const rows = commits.flatMap((commit) => commit.rows)
+    const entries = rows.filter((row) => row.includes("entry"))
     expect(commits.length).toBe(1)
+    expect(rows.find((row) => row.trim().length > 0)).toContain("resumed · earlier transcript omitted")
     expect(entries[0]).toContain("entry 20")
     expect(entries.at(-1)).toContain("entry 29")
   } finally {

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -207,6 +207,51 @@ test("session replay defers emission and lands as one viewport batch", async () 
   }
 })
 
+test("a tool block leading the resumed batch separates from the omission notice", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 10,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false },
+      undefined,
+    )
+    scrollback.beginReplay()
+    for (let index = 0; index < 30; index += 1) {
+      scrollback.append({
+        kind: "tool",
+        tool: "bash",
+        title: `cmd ${index}`,
+        readOnly: true,
+        denial: undefined,
+        output: "",
+        execution: undefined,
+        elapsed: undefined,
+        expanded: false,
+      })
+    }
+
+    scrollback.endReplay()
+
+    const rows = setup.externalOutput.take().flatMap((commit) => commit.rows)
+    expect(rows[1]).toContain("resumed · earlier transcript omitted")
+    expect(rows[2]).toBe("")
+    expect(rows[3]).toContain("cmd 10")
+    expect(rows[4]).toContain("cmd 11")
+    expect(rows.at(-1)).toContain("cmd 29")
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+
 test("assistant markdown commits only its visible columns", async () => {
   const setup = await createTestRenderer({
     width: 80,

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -131,6 +131,80 @@ test("settled tools leave the scrollback cursor on their row for live tool group
   }
 })
 
+test("viewport replay re-prints only the last two viewports of blocks", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 10,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    await setup.renderer.setupTerminal()
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false },
+      undefined,
+    )
+    for (let index = 0; index < 30; index += 1) {
+      scrollback.append({ kind: "info", text: `entry ${index}` })
+    }
+    setup.externalOutput.clear()
+
+    scrollback.replayViewport()
+
+    const commits = setup.externalOutput.take()
+    const rows = commits.flatMap((commit) => commit.rows)
+    const entries = rows.filter((row) => row.includes("entry"))
+    expect(commits.length).toBe(1)
+    expect(rows.length).toBeGreaterThanOrEqual(20)
+    expect(rows.length).toBeLessThan(30)
+    expect(entries[0]).toContain("entry 20")
+    expect(entries.at(-1)).toContain("entry 29")
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+
+test("session replay defers emission and lands as one viewport batch", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 10,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false },
+      undefined,
+    )
+    scrollback.beginReplay()
+    scrollback.clear()
+    for (let index = 0; index < 30; index += 1) {
+      scrollback.append({ kind: "info", text: `entry ${index}` })
+    }
+    expect(setup.externalOutput.take()).toEqual([])
+
+    scrollback.endReplay()
+
+    const commits = setup.externalOutput.take()
+    const entries = commits.flatMap((commit) => commit.rows).filter((row) => row.includes("entry"))
+    expect(commits.length).toBe(1)
+    expect(entries[0]).toContain("entry 20")
+    expect(entries.at(-1)).toContain("entry 29")
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+
 test("assistant markdown commits only its visible columns", async () => {
   const setup = await createTestRenderer({
     width: 80,

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -191,7 +191,7 @@ export class Scrollback {
     if (!this.deferred) return
     this.deferred = false
     if (!this.active) return
-    this.emitTranscript(false)
+    this.emitTranscript(false, true)
   }
 
   clear(): void {
@@ -252,7 +252,7 @@ export class Scrollback {
     this.emitTranscript(fromStart)
   }
 
-  private emitTranscript(fromStart: boolean): void {
+  private emitTranscript(fromStart: boolean, resumed = false): void {
     const streaming = this.stream
     if (streaming) {
       streaming.surface?.destroy()
@@ -262,7 +262,14 @@ export class Scrollback {
     if (fromStart) {
       for (const [index, block] of blocks.entries()) this.emit(block, blocks[index - 1])
     } else {
-      this.emitBatch(blocks, this.viewportStart(blocks))
+      const start = this.viewportStart(blocks)
+      if (resumed && start > 0) {
+        const hint = this.detailsShortcut ? ` · ${this.detailsShortcut} reprints it` : ""
+        const notice: Block = { kind: "info", text: `resumed · earlier transcript omitted${hint}` }
+        this.emitBatch([notice, ...blocks.slice(start)], 0)
+      } else {
+        this.emitBatch(blocks, start)
+      }
     }
     if (!streaming) return
     this.stream = this.openRedactedStream(streaming.block, streaming.redactor)

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -72,6 +72,7 @@ export class Scrollback {
   private committed = 0
   private origin: number
   private active = true
+  private deferred = false
   private userBackground = userMessageBackground(COLORS.background)
 
   constructor(
@@ -182,12 +183,28 @@ export class Scrollback {
     return flushed
   }
 
+  beginReplay(): void {
+    this.deferred = true
+  }
+
+  endReplay(): void {
+    if (!this.deferred) return
+    this.deferred = false
+    if (!this.active) return
+    this.emitTranscript(false)
+  }
+
   clear(): void {
     this.endStream()
     this.blocks.length = 0
     this.checkpoints.length = 0
     this.header.length = 0
     this.redos.length = 0
+    if (this.deferred) {
+      this.origin = this.rows
+      this.committed = 0
+      return
+    }
     this.reset()
     if (this.active) this.renderer.resetSplitFooterForReplay({ clearSavedLines: true })
   }
@@ -221,23 +238,82 @@ export class Scrollback {
   }
 
   replay(): void {
-    if (!this.active) return
+    this.replayBlocks(true)
+  }
+
+  replayViewport(): void {
+    this.replayBlocks(false)
+  }
+
+  private replayBlocks(fromStart: boolean): void {
+    if (!this.emitting) return
+    this.renderer.resetSplitFooterForReplay({ clearSavedLines: fromStart })
+    this.reset()
+    this.emitTranscript(fromStart)
+  }
+
+  private emitTranscript(fromStart: boolean): void {
     const streaming = this.stream
     if (streaming) {
       streaming.surface?.destroy()
       this.stream = undefined
     }
-    this.renderer.resetSplitFooterForReplay({ clearSavedLines: true })
-    this.reset()
-    let previous: Block | undefined
-    for (const block of this.blocks) {
-      if (block === streaming?.block || !this.visible(block)) continue
-      this.emit(block, previous)
-      previous = block
+    const blocks = this.blocks.filter((block) => block !== streaming?.block && this.visible(block))
+    if (fromStart) {
+      for (const [index, block] of blocks.entries()) this.emit(block, blocks[index - 1])
+    } else {
+      this.emitBatch(blocks, this.viewportStart(blocks))
     }
     if (!streaming) return
     this.stream = this.openRedactedStream(streaming.block, streaming.redactor)
-    this.flush(this.stream, false)
+    this.flush(this.stream, false, !fromStart)
+  }
+
+  private emitBatch(blocks: Block[], start: number): void {
+    if (start >= blocks.length) return
+    const surface = this.renderer.createScrollbackSurface()
+    try {
+      for (let index = start; index < blocks.length; index += 1) {
+        surface.root.add(
+          renderBlock(
+            surface.renderContext,
+            blocks[index]!,
+            this.expanded,
+            this.userBackground,
+            this.detailsShortcut,
+            blocks[index - 1],
+          ),
+        )
+      }
+      surface.render()
+      this.onCommit(surface.height)
+      surface.commitRows(0, surface.height, { trailingNewline: false })
+      this.committed += surface.height
+    } finally {
+      surface.destroy()
+    }
+  }
+
+  private viewportStart(blocks: Block[]): number {
+    let rows = 0
+    for (let index = blocks.length - 1; index > 0; index -= 1) {
+      rows += this.measure(blocks[index]!, blocks[index - 1])
+      if (rows >= this.renderer.terminalHeight * 2) return index
+    }
+    return 0
+  }
+
+  private measure(block: Block, previous: Block | undefined): number {
+    const surface = this.renderer.createScrollbackSurface()
+    try {
+      surface.root.add(
+        renderBlock(surface.renderContext, block, this.expanded, this.userBackground, this.detailsShortcut, previous),
+      )
+      surface.render()
+      return surface.height
+    } finally {
+      surface.destroy()
+    }
   }
 
   private restore(blocks: Block[], checkpoints: TranscriptCheckpoint[]): void {
@@ -257,11 +333,15 @@ export class Scrollback {
     return Math.max(1, this.renderer.terminalHeight - this.renderer.footerHeight - 1)
   }
 
+  private get emitting(): boolean {
+    return this.active && !this.deferred
+  }
+
   private appendBlock(block: Block): void {
     this.endStream()
     const previous = this.blocks.findLast((candidate) => this.visible(candidate))
     this.blocks.push(block)
-    if (this.active) this.emit(block, previous)
+    if (this.emitting) this.emit(block, previous)
   }
 
   private drop(block: Block): void {
@@ -282,15 +362,15 @@ export class Scrollback {
   }
 
   private openRedactedStream(block: StreamBlock, redactor: RedactedStream): Stream {
-    if (!this.active) return { block, committed: 0, flushedAt: 0, redactor }
+    if (!this.emitting) return { block, committed: 0, flushedAt: 0, redactor }
     const surface = this.renderer.createScrollbackSurface()
     const { view, text } = streamView(surface.renderContext, block)
     surface.root.add(view)
     return { block, surface, text, committed: 0, flushedAt: 0, redactor }
   }
 
-  private flush(stream: Stream, final: boolean): void {
-    if (!this.active || !stream.surface || !stream.text || !this.visible(stream.block)) return
+  private flush(stream: Stream, final: boolean, batch = false): void {
+    if (!this.emitting || !stream.surface || !stream.text || !this.visible(stream.block)) return
     const rendered = streamContent(stream.block, contentWidth(stream.surface.renderContext))
     stream.text.content = rendered.content
     stream.text.height = rendered.rows
@@ -301,7 +381,8 @@ export class Scrollback {
     if (target <= stream.committed) return
     const rows = target - stream.committed
     this.onCommit(rows)
-    this.commitStreamRows(stream.surface, rendered, stream.committed, target, final)
+    if (batch) stream.surface.commitRows(stream.committed, target, { trailingNewline: true })
+    else this.commitStreamRows(stream.surface, rendered, stream.committed, target, final)
     this.committed += rows
     stream.committed = target
   }


### PR DESCRIPTION
Defer transcript rendering while resumed sessions replay, then emit the last two viewports in a single batch. Reuse viewport-limited replay during terminal resizing and add coverage for batching and truncation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resumed-session replay to show only the final visible scrollback content.
  * Prevented intermediate replay output from appearing before replay completes.
  * Added clearer resume indicators when earlier transcript content is omitted.
  * Batched replay rendering for smoother, more consistent terminal updates.
  * Improved terminal resizing by applying layout updates immediately while deferring viewport replay when needed.

* **Tests**
  * Added coverage for viewport-limited replay, deferred session replay, tool-block handling, final-output batching, and resume indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->