### PR TITLE
Rebuild TUI scrollback on resize instead of re-emitting the tail

### DIFF
--- a/apps/cli/src/plugins/tui/app.ts
+++ b/apps/cli/src/plugins/tui/app.ts
@@ -158,7 +158,6 @@ export async function startTui(events: EventService, config: TuiConfig, options:
   renderer.root.add(screen.view)
   let lastWidth = renderer.terminalWidth
   let lastHeight = renderer.terminalHeight
-  let replayWidth = renderer.terminalWidth
   let replayTimer: ReturnType<typeof setTimeout> | undefined
   let replayPending = false
   let editing = false
@@ -166,17 +165,13 @@ export async function startTui(events: EventService, config: TuiConfig, options:
     screen.composer.reflow()
     screen.syncFooter()
   }
-  const replayScrollback = (): void => {
-    if (renderer.terminalWidth === replayWidth) return
-    replayWidth = renderer.terminalWidth
-    screen.scrollback.replayViewport()
-  }
   const replayLayout = (): void => {
     syncLayout()
-    replayScrollback()
+    screen.scrollback.reflow()
   }
   renderer.on(CliRenderEvents.RESIZE, () => {
-    if (renderer.terminalWidth === lastWidth && renderer.terminalHeight === lastHeight) return
+    const widthChanged = renderer.terminalWidth !== lastWidth
+    if (!widthChanged && renderer.terminalHeight === lastHeight) return
     lastWidth = renderer.terminalWidth
     lastHeight = renderer.terminalHeight
     if (editing) {
@@ -184,11 +179,11 @@ export async function startTui(events: EventService, config: TuiConfig, options:
       return
     }
     syncLayout()
-    if (renderer.terminalWidth === replayWidth) return
+    if (!widthChanged) return
     clearTimeout(replayTimer)
     replayTimer = setTimeout(() => {
       replayTimer = undefined
-      replayScrollback()
+      screen.scrollback.reflow()
     }, RESIZE_DEBOUNCE_MS)
   })
   const resetCommands = setTuiCommandActions({

--- a/apps/cli/src/plugins/tui/components/config-popover.ts
+++ b/apps/cli/src/plugins/tui/components/config-popover.ts
@@ -1,6 +1,6 @@
 import { StyledText, TextAttributes, type BoxRenderable, type RenderContext, type TextRenderable } from "@opentui/core"
 import { describeError } from "../../../lib/error"
-import type { TuiConfigKey, TuiPreferences } from "../config"
+import type { TuiPreferences } from "../config"
 import { column, label, row } from "../lib/renderables"
 import { terminalGlyph } from "../lib/text"
 import { COLORS } from "../theme/colors"
@@ -19,6 +19,8 @@ const SETTINGS = [
   },
 ] as const
 
+export type TuiToggleKey = (typeof SETTINGS)[number]["key"]
+
 interface SettingRow {
   cursor: TextRenderable
   name: TextRenderable
@@ -27,7 +29,7 @@ interface SettingRow {
 }
 
 interface ConfigPopoverActions {
-  change(config: TuiPreferences, key: TuiConfigKey): Promise<void>
+  change(config: TuiPreferences, key: TuiToggleKey): Promise<void>
   changed(): void
   error(message: string): void
 }

--- a/apps/cli/src/plugins/tui/config.ts
+++ b/apps/cli/src/plugins/tui/config.ts
@@ -1,10 +1,11 @@
 import { saveSettings } from "../../config/settings"
-import { asBoolean } from "../../lib/json"
+import { asBoolean, asNumber } from "../../lib/json"
 import { parseShortcutOverrides, type ShortcutOverrides } from "./shortcuts"
 
 export interface TuiPreferences {
   showOutputs: boolean
   showThinking: boolean
+  scrollbackRows: number
 }
 
 export interface TuiConfig extends TuiPreferences {
@@ -13,6 +14,8 @@ export interface TuiConfig extends TuiPreferences {
 
 export type TuiConfigKey = keyof TuiPreferences
 
+export const DEFAULT_SCROLLBACK_ROWS = 1000
+
 function booleanOption(raw: Record<string, unknown>, key: TuiConfigKey): boolean {
   if (!Object.hasOwn(raw, key)) return false
   const value = asBoolean(raw[key])
@@ -20,10 +23,20 @@ function booleanOption(raw: Record<string, unknown>, key: TuiConfigKey): boolean
   return value
 }
 
+function scrollbackRows(raw: Record<string, unknown>): number {
+  if (!Object.hasOwn(raw, "scrollbackRows")) return DEFAULT_SCROLLBACK_ROWS
+  const value = asNumber(raw.scrollbackRows)
+  if (value === undefined || !Number.isInteger(value) || value < 0) {
+    throw new Error("tui scrollbackRows must be a non-negative integer")
+  }
+  return value
+}
+
 export function parseTuiConfig(raw: Record<string, unknown>): TuiConfig {
   return {
     showOutputs: booleanOption(raw, "showOutputs"),
     showThinking: booleanOption(raw, "showThinking"),
+    scrollbackRows: scrollbackRows(raw),
     keybindings: parseShortcutOverrides(raw.keybindings),
   }
 }

--- a/apps/cli/src/plugins/tui/screen.ts
+++ b/apps/cli/src/plugins/tui/screen.ts
@@ -107,15 +107,22 @@ export class Screen {
     this.picker = new Picker(renderer, () => this.syncFooter())
     this.config = new ConfigPopover(
       renderer,
-      { showOutputs: preferences.showOutputs, showThinking: preferences.showThinking },
+      {
+        showOutputs: preferences.showOutputs,
+        showThinking: preferences.showThinking,
+        scrollbackRows: preferences.scrollbackRows,
+      },
       {
         change: async (config, key) => {
           await saveTuiConfig(config)
-          if (key === "showOutputs") {
-            this.scrollback.setExpanded(config.showOutputs)
-            return
+          switch (key) {
+            case "showOutputs":
+              this.scrollback.setExpanded(config.showOutputs)
+              return
+            case "showThinking":
+              this.scrollback.setReasoningVisible(config.showThinking)
+              return
           }
-          this.scrollback.setReasoningVisible(config.showThinking)
         },
         changed: () => this.syncFooter(),
         error: (message) => this.scrollback.append({ kind: "error", text: message }),

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -325,3 +325,37 @@ test("a rebuild during a live stream re-prints the stream once", async () => {
     setup.renderer.destroy()
   }
 })
+
+test("a live stream is charged to the scrollback row budget", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 24,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    await setup.renderer.setupTerminal()
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false, scrollbackRows: 20 },
+      undefined,
+    )
+    for (let index = 0; index < 30; index += 1) {
+      scrollback.append({ kind: "info", text: `entry ${index}` })
+    }
+    scrollback.appendStream("text", `${Array.from({ length: 30 }, (_, row) => `stream row ${row}`).join("\n\n")}\n\n`)
+    setup.externalOutput.clear()
+
+    scrollback.replay()
+
+    const rows = setup.externalOutput.take().flatMap((commit) => commit.rows)
+    expect(rows.some((row) => row.includes("earlier transcript omitted"))).toBe(true)
+    expect(rows.filter((row) => row.includes("entry")).length).toBe(0)
+  } finally {
+    setup.renderer.destroy()
+  }
+})

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -359,3 +359,37 @@ test("a live stream is charged to the scrollback row budget", async () => {
     setup.renderer.destroy()
   }
 })
+
+test("a block that would overflow the row budget is dropped, including the oldest", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 24,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    await setup.renderer.setupTerminal()
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false, scrollbackRows: 5 },
+      undefined,
+    )
+    for (let index = 0; index < 3; index += 1) {
+      scrollback.append({ kind: "info", text: `entry ${index}` })
+    }
+    setup.externalOutput.clear()
+
+    scrollback.replay()
+
+    const rows = setup.externalOutput.take().flatMap((commit) => commit.rows)
+    expect(rows.filter((row) => row.includes("entry")).length).toBe(2)
+    expect(rows.some((row) => row.includes("entry 0"))).toBe(false)
+    expect(rows.some((row) => row.includes("entry 2"))).toBe(true)
+  } finally {
+    setup.renderer.destroy()
+  }
+})

--- a/apps/cli/src/plugins/tui/scrollback/render.test.ts
+++ b/apps/cli/src/plugins/tui/scrollback/render.test.ts
@@ -55,7 +55,7 @@ test("user bubbles preserve composer line breaks", async () => {
       setup.renderer,
       0,
       () => {},
-      { showOutputs: false, showThinking: false },
+      { showOutputs: false, showThinking: false, scrollbackRows: 20 },
       undefined,
     )
     scrollback.append({ kind: "user", text: "first line\n\n$implement second line", imageCount: 0, sentAt: 0 })
@@ -83,7 +83,7 @@ test("compaction state is visible in the transcript as soon as it starts", async
       setup.renderer,
       0,
       () => {},
-      { showOutputs: false, showThinking: false },
+      { showOutputs: false, showThinking: false, scrollbackRows: 20 },
       undefined,
     )
     scrollback.append({ kind: "compaction", state: "compacting" })
@@ -109,7 +109,7 @@ test("settled tools leave the scrollback cursor on their row for live tool group
       setup.renderer,
       0,
       () => {},
-      { showOutputs: false, showThinking: false },
+      { showOutputs: false, showThinking: false, scrollbackRows: 20 },
       undefined,
     )
     scrollback.append({
@@ -131,7 +131,7 @@ test("settled tools leave the scrollback cursor on their row for live tool group
   }
 })
 
-test("viewport replay re-prints only the last two viewports of blocks", async () => {
+test("a rebuild clears saved scrollback and re-prints one capped batch", async () => {
   const setup = await createTestRenderer({
     width: 80,
     height: 10,
@@ -146,7 +146,7 @@ test("viewport replay re-prints only the last two viewports of blocks", async ()
       setup.renderer,
       0,
       () => {},
-      { showOutputs: false, showThinking: false },
+      { showOutputs: false, showThinking: false, scrollbackRows: 20 },
       undefined,
     )
     for (let index = 0; index < 30; index += 1) {
@@ -154,14 +154,14 @@ test("viewport replay re-prints only the last two viewports of blocks", async ()
     }
     setup.externalOutput.clear()
 
-    scrollback.replayViewport()
+    scrollback.replay()
 
     const commits = setup.externalOutput.take()
     const rows = commits.flatMap((commit) => commit.rows)
     const entries = rows.filter((row) => row.includes("entry"))
     expect(commits.length).toBe(1)
-    expect(rows.length).toBeGreaterThanOrEqual(20)
     expect(rows.length).toBeLessThan(30)
+    expect(rows.find((row) => row.trim().length > 0)).toContain("earlier transcript omitted")
     expect(entries[0]).toContain("entry 20")
     expect(entries.at(-1)).toContain("entry 29")
   } finally {
@@ -183,7 +183,7 @@ test("session replay defers emission and lands as one viewport batch", async () 
       setup.renderer,
       0,
       () => {},
-      { showOutputs: false, showThinking: false },
+      { showOutputs: false, showThinking: false, scrollbackRows: 20 },
       undefined,
     )
     scrollback.beginReplay()
@@ -199,7 +199,7 @@ test("session replay defers emission and lands as one viewport batch", async () 
     const rows = commits.flatMap((commit) => commit.rows)
     const entries = rows.filter((row) => row.includes("entry"))
     expect(commits.length).toBe(1)
-    expect(rows.find((row) => row.trim().length > 0)).toContain("resumed · earlier transcript omitted")
+    expect(rows.find((row) => row.trim().length > 0)).toContain("earlier transcript omitted")
     expect(entries[0]).toContain("entry 20")
     expect(entries.at(-1)).toContain("entry 29")
   } finally {
@@ -221,7 +221,7 @@ test("a tool block leading the resumed batch separates from the omission notice"
       setup.renderer,
       0,
       () => {},
-      { showOutputs: false, showThinking: false },
+      { showOutputs: false, showThinking: false, scrollbackRows: 20 },
       undefined,
     )
     scrollback.beginReplay()
@@ -242,7 +242,7 @@ test("a tool block leading the resumed batch separates from the omission notice"
     scrollback.endReplay()
 
     const rows = setup.externalOutput.take().flatMap((commit) => commit.rows)
-    expect(rows[1]).toContain("resumed · earlier transcript omitted")
+    expect(rows[1]).toContain("earlier transcript omitted")
     expect(rows[2]).toBe("")
     expect(rows[3]).toContain("cmd 10")
     expect(rows[4]).toContain("cmd 11")
@@ -266,7 +266,7 @@ test("assistant markdown commits only its visible columns", async () => {
       setup.renderer,
       0,
       () => {},
-      { showOutputs: false, showThinking: false },
+      { showOutputs: false, showThinking: false, scrollbackRows: 20 },
       undefined,
     )
     scrollback.appendStream(
@@ -287,6 +287,40 @@ test("assistant markdown commits only its visible columns", async () => {
     expect(commits.every((commit) => commit.height === 1)).toBe(true)
     expect(commits.map((commit) => commit.rowColumns)).toEqual(rows.map(displayWidth))
     expect(commits.map((commit) => commit.trailingNewline)).toEqual([true, true, true, true, false])
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+
+test("a rebuild during a live stream re-prints the stream once", async () => {
+  const setup = await createTestRenderer({
+    width: 80,
+    height: 24,
+    footerHeight: 1,
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  try {
+    await setup.renderer.setupTerminal()
+    const scrollback = new Scrollback(
+      setup.renderer,
+      0,
+      () => {},
+      { showOutputs: false, showThinking: false, scrollbackRows: 0 },
+      undefined,
+    )
+    scrollback.append({ kind: "info", text: "before the stream" })
+    scrollback.appendStream("text", "streamed paragraph one\n\nstreamed paragraph two\n\n")
+    setup.externalOutput.clear()
+
+    scrollback.replay()
+    scrollback.endStream()
+
+    const rows = setup.externalOutput.take().flatMap((commit) => commit.rows)
+    expect(rows.filter((row) => row.includes("before the stream")).length).toBe(1)
+    expect(rows.filter((row) => row.includes("streamed paragraph one")).length).toBe(1)
+    expect(rows.filter((row) => row.includes("streamed paragraph two")).length).toBe(1)
   } finally {
     setup.renderer.destroy()
   }

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -302,9 +302,10 @@ export class Scrollback {
     const surface = this.renderer.createScrollbackSurface()
     try {
       let rows = streaming && this.visible(streaming) ? this.measure(surface, streaming, blocks.at(-1)) : 0
-      for (let index = blocks.length - 1; index > 0; index -= 1) {
-        if (rows >= this.maxRows) return index + 1
-        rows += this.measure(surface, blocks[index]!, blocks[index - 1])
+      for (let index = blocks.length - 1; index >= 0; index -= 1) {
+        const height = this.measure(surface, blocks[index]!, blocks[index - 1])
+        if (rows > 0 && rows + height > this.maxRows) return index + 1
+        rows += height
       }
       return 0
     } finally {

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -261,7 +261,7 @@ export class Scrollback {
     }
     this.reflowedWidth = this.renderer.terminalWidth
     const blocks = this.blocks.filter((block) => block !== streaming?.block && this.visible(block))
-    const start = this.transcriptStart(blocks)
+    const start = this.transcriptStart(blocks, streaming?.block)
     const retained = blocks.slice(start)
     if (start > 0) {
       retained.unshift({ kind: "info", text: "earlier transcript omitted · raise tui scrollbackRows to keep more" })
@@ -297,14 +297,14 @@ export class Scrollback {
     }
   }
 
-  private transcriptStart(blocks: Block[]): number {
+  private transcriptStart(blocks: Block[], streaming: StreamBlock | undefined): number {
     if (this.maxRows === 0) return 0
     const surface = this.renderer.createScrollbackSurface()
     try {
-      let rows = 0
+      let rows = streaming && this.visible(streaming) ? this.measure(surface, streaming, blocks.at(-1)) : 0
       for (let index = blocks.length - 1; index > 0; index -= 1) {
+        if (rows >= this.maxRows) return index + 1
         rows += this.measure(surface, blocks[index]!, blocks[index - 1])
-        if (rows >= this.maxRows) return index
       }
       return 0
     } finally {

--- a/apps/cli/src/plugins/tui/scrollback/scrollback.ts
+++ b/apps/cli/src/plugins/tui/scrollback/scrollback.ts
@@ -73,6 +73,8 @@ export class Scrollback {
   private origin: number
   private active = true
   private deferred = false
+  private reflowedWidth: number
+  private readonly maxRows: number
   private userBackground = userMessageBackground(COLORS.background)
 
   constructor(
@@ -85,6 +87,8 @@ export class Scrollback {
     this.origin = startRow
     this.expanded = config.showOutputs
     this.reasoningVisible = config.showThinking
+    this.maxRows = config.scrollbackRows
+    this.reflowedWidth = renderer.terminalWidth
   }
 
   get rows(): number {
@@ -191,7 +195,7 @@ export class Scrollback {
     if (!this.deferred) return
     this.deferred = false
     if (!this.active) return
-    this.emitTranscript(false, true)
+    this.emitTranscript(false)
   }
 
   clear(): void {
@@ -237,54 +241,46 @@ export class Scrollback {
     this.replay()
   }
 
+  reflow(): void {
+    if (this.renderer.terminalWidth === this.reflowedWidth) return
+    this.replay()
+  }
+
   replay(): void {
-    this.replayBlocks(true)
-  }
-
-  replayViewport(): void {
-    this.replayBlocks(false)
-  }
-
-  private replayBlocks(fromStart: boolean): void {
     if (!this.emitting) return
-    this.renderer.resetSplitFooterForReplay({ clearSavedLines: fromStart })
+    this.renderer.resetSplitFooterForReplay({ clearSavedLines: true })
     this.reset()
-    this.emitTranscript(fromStart)
+    this.emitTranscript(true)
   }
 
-  private emitTranscript(fromStart: boolean, resumed = false): void {
+  private emitTranscript(cleared: boolean): void {
     const streaming = this.stream
     if (streaming) {
       streaming.surface?.destroy()
       this.stream = undefined
     }
+    this.reflowedWidth = this.renderer.terminalWidth
     const blocks = this.blocks.filter((block) => block !== streaming?.block && this.visible(block))
-    if (fromStart) {
-      for (const [index, block] of blocks.entries()) this.emit(block, blocks[index - 1])
-    } else {
-      const start = this.viewportStart(blocks)
-      if (resumed && start > 0) {
-        const hint = this.detailsShortcut ? ` · ${this.detailsShortcut} reprints it` : ""
-        const notice: Block = { kind: "info", text: `resumed · earlier transcript omitted${hint}` }
-        this.emitBatch([notice, ...blocks.slice(start)], 0)
-      } else {
-        this.emitBatch(blocks, start)
-      }
+    const start = this.transcriptStart(blocks)
+    const retained = blocks.slice(start)
+    if (start > 0) {
+      retained.unshift({ kind: "info", text: "earlier transcript omitted · raise tui scrollbackRows to keep more" })
     }
+    this.emitBatch(retained)
     if (!streaming) return
     this.stream = this.openRedactedStream(streaming.block, streaming.redactor)
-    this.flush(this.stream, false, !fromStart)
+    this.flush(this.stream, false, !cleared)
   }
 
-  private emitBatch(blocks: Block[], start: number): void {
-    if (start >= blocks.length) return
+  private emitBatch(blocks: Block[]): void {
+    if (blocks.length === 0) return
     const surface = this.renderer.createScrollbackSurface()
     try {
-      for (let index = start; index < blocks.length; index += 1) {
+      for (const [index, block] of blocks.entries()) {
         surface.root.add(
           renderBlock(
             surface.renderContext,
-            blocks[index]!,
+            block,
             this.expanded,
             this.userBackground,
             this.detailsShortcut,
@@ -301,25 +297,36 @@ export class Scrollback {
     }
   }
 
-  private viewportStart(blocks: Block[]): number {
-    let rows = 0
-    for (let index = blocks.length - 1; index > 0; index -= 1) {
-      rows += this.measure(blocks[index]!, blocks[index - 1])
-      if (rows >= this.renderer.terminalHeight * 2) return index
-    }
-    return 0
-  }
-
-  private measure(block: Block, previous: Block | undefined): number {
+  private transcriptStart(blocks: Block[]): number {
+    if (this.maxRows === 0) return 0
     const surface = this.renderer.createScrollbackSurface()
     try {
-      surface.root.add(
-        renderBlock(surface.renderContext, block, this.expanded, this.userBackground, this.detailsShortcut, previous),
-      )
+      let rows = 0
+      for (let index = blocks.length - 1; index > 0; index -= 1) {
+        rows += this.measure(surface, blocks[index]!, blocks[index - 1])
+        if (rows >= this.maxRows) return index
+      }
+      return 0
+    } finally {
+      surface.destroy()
+    }
+  }
+
+  private measure(surface: ScrollbackSurface, block: Block, previous: Block | undefined): number {
+    const view = renderBlock(
+      surface.renderContext,
+      block,
+      this.expanded,
+      this.userBackground,
+      this.detailsShortcut,
+      previous,
+    )
+    surface.root.add(view)
+    try {
       surface.render()
       return surface.height
     } finally {
-      surface.destroy()
+      view.destroyRecursively()
     }
   }
 

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -115,7 +115,8 @@ Every option is optional. This example shows how the top-level sections fit toge
   "pluginConfig": {
     "tui": {
       "showOutputs": false,
-      "showThinking": false
+      "showThinking": false,
+      "scrollbackRows": 1000
     },
     "project-instructions": {
       "maxBytes": 65536

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -4,12 +4,13 @@ Customize Xal's terminal interface, keyboard shortcuts, transcript details, and 
 
 ## Display preferences
 
-Run `/config` in the TUI to change display preferences. Changes save immediately to the user configuration and apply to the current transcript. Both preferences default to `false`.
+Run `/config` in the TUI to change display preferences. Changes save immediately to the user configuration and apply to the current transcript. `scrollbackRows` is edited in the configuration file rather than through `/config`.
 
-| Option         | Type      | Default | Description                                       |
-| -------------- | --------- | ------- | ------------------------------------------------- |
-| `showOutputs`  | `boolean` | `false` | Expand tool outputs and other transcript details. |
-| `showThinking` | `boolean` | `false` | Include model reasoning in the transcript.        |
+| Option           | Type      | Default | Description                                                                  |
+| ---------------- | --------- | ------- | ---------------------------------------------------------------------------- |
+| `showOutputs`    | `boolean` | `false` | Expand tool outputs and other transcript details.                            |
+| `showThinking`   | `boolean` | `false` | Include model reasoning in the transcript.                                   |
+| `scrollbackRows` | `number`  | `1000`  | Rows of transcript rebuilt into terminal scrollback. `0` disables the limit. |
 
 These values live under `pluginConfig.tui`:
 
@@ -18,11 +19,18 @@ These values live under `pluginConfig.tui`:
   "pluginConfig": {
     "tui": {
       "showOutputs": false,
-      "showThinking": false
+      "showThinking": false,
+      "scrollbackRows": 1000
     }
   }
 }
 ```
+
+## Transcript rebuilds
+
+The terminal owns wrapping for rows Xal has already written, so a terminal that changes width leaves the transcript above wrapped for the old one. Xal rebuilds instead: on a width change it clears its scrollback and re-prints the transcript from the session's own blocks at the new width, after the resize has been quiet for a moment. Resuming a session prints the same rebuilt transcript.
+
+`scrollbackRows` bounds that rebuild. Xal prints the most recent rows up to the limit and marks the top of the transcript when anything was left out, so rebuild cost stays flat as a session grows. Set it near what your terminal actually retains — rows beyond that are dropped by the terminal anyway. Set it to `0` to rebuild the whole transcript every time, which is exact but grows more expensive the longer a session runs.
 
 The `display.toggle-details` shortcut, Ctrl+O by default, temporarily toggles transcript details for the current session without changing `showOutputs`. Normal mode keeps task dispatches compact and shows completed background work as its ID plus the first report line. Expanded mode adds assignment metadata, status and line counts, spawned-agent details, and report output. Context compaction appears in the transcript as soon as it starts, followed by the completed compaction summary. Task plans are optional and created at the model's discretion for non-trivial, multi-phase work. Xal does not inject reminders to create or update a plan. A fully completed plan is dismissed when the session returns to idle, while plans with pending or in-progress work remain visible.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -6,11 +6,11 @@ Customize Xal's terminal interface, keyboard shortcuts, transcript details, and 
 
 Run `/config` in the TUI to change display preferences. Changes save immediately to the user configuration and apply to the current transcript. `scrollbackRows` is edited in the configuration file rather than through `/config`.
 
-| Option           | Type      | Default | Description                                                                  |
-| ---------------- | --------- | ------- | ---------------------------------------------------------------------------- |
-| `showOutputs`    | `boolean` | `false` | Expand tool outputs and other transcript details.                            |
-| `showThinking`   | `boolean` | `false` | Include model reasoning in the transcript.                                   |
-| `scrollbackRows` | `number`  | `1000`  | Rows of transcript rebuilt into terminal scrollback. `0` disables the limit. |
+| Option           | Type      | Default | Description                                                                                             |
+| ---------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `showOutputs`    | `boolean` | `false` | Expand tool outputs and other transcript details.                                                       |
+| `showThinking`   | `boolean` | `false` | Include model reasoning in the transcript.                                                              |
+| `scrollbackRows` | `number`  | `1000`  | Rows of transcript rebuilt into terminal scrollback, as a non-negative integer. `0` disables the limit. |
 
 These values live under `pluginConfig.tui`:
 
@@ -30,7 +30,7 @@ These values live under `pluginConfig.tui`:
 
 The terminal owns wrapping for rows Xal has already written, so a terminal that changes width leaves the transcript above wrapped for the old one. Xal rebuilds instead: on a width change it clears its scrollback and re-prints the transcript from the session's own blocks at the new width, after the resize has been quiet for a moment. Resuming a session prints the same rebuilt transcript.
 
-`scrollbackRows` bounds that rebuild. Xal prints the most recent rows up to the limit and marks the top of the transcript when anything was left out, so rebuild cost stays flat as a session grows. Set it near what your terminal actually retains — rows beyond that are dropped by the terminal anyway. Set it to `0` to rebuild the whole transcript every time, which is exact but grows more expensive the longer a session runs.
+`scrollbackRows` bounds that rebuild. Xal prints the most recent rows up to the limit and marks the top of the transcript when anything was left out, so rebuild cost stays flat as a session grows. A response still being written counts against the limit but is never itself trimmed, so a single very long response can carry the rebuild past it until that response finishes. Set the limit near what your terminal actually retains — rows beyond that are dropped by the terminal anyway. Set it to `0` to rebuild the whole transcript every time, which is exact but grows more expensive the longer a session runs.
 
 The `display.toggle-details` shortcut, Ctrl+O by default, temporarily toggles transcript details for the current session without changing `showOutputs`. Normal mode keeps task dispatches compact and shows completed background work as its ID plus the first report line. Expanded mode adds assignment metadata, status and line counts, spawned-agent details, and report output. Context compaction appears in the transcript as soon as it starts, followed by the completed compaction summary. Task plans are optional and created at the model's discretion for non-trivial, multi-phase work. Xal does not inject reminders to create or update a plan. A fully completed plan is dismissed when the session returns to idle, while plans with pending or in-progress work remain visible.
 


### PR DESCRIPTION
Fixes the scrollback damage introduced by #40.

## The regression

#40 changed the resize path from a full rebuild to a viewport rebuild, trading correctness for speed. `replayViewport()` resolves to `resetSplitFooterForReplay({ clearSavedLines: false })`, which emits `ESC[2J` — the *visible* screen — but not `ESC[3J`, the saved scrollback lines. It then re-emitted the last `terminalHeight * 2` rows underneath.

So every width change left the earlier transcript in scrollback still wrapped for the old width, and appended a duplicate tail below it. The damage compounded per resize, and the ~100-row re-emission was far too small to cover what had been cleared.

## The fix

Resize goes back to the full rebuild — clear saved lines, re-print the transcript from `Block[]` at the new width. No path re-emits without clearing any more. `replayViewport()` and `replayBlocks()` lose their last consumer and are deleted.

The "last replayed width" bookkeeping moves out of `startTui` into `Scrollback`. It previously advanced even when the scrollback declined to emit (inactive, or mid-resume-replay), recording a width that was never rebuilt.

To make the correct rebuild affordable, and following how codex solves the same problem in the same architecture:

- **`scrollbackRows`** (default 1000, `0` disables) bounds the rebuild. `transcriptStart()` walks backward from the tail and stops at the cap. It replaces the `terminalHeight * 2` limit that governed resume alone, so rebuild and resume now share one cap instead of disagreeing.
- **Measuring shares one surface.** `measure()` allocated a `ScrollbackSurface` — and with it a native `OptimizedBuffer` — per block, then threw it away. It now adds and `destroyRecursively()`-es a single view against one shared surface.

## Notes for review

- **The omission notice no longer promises a reprint.** Once `replay()` is capped, `display.toggle-details` no longer reprints full history, so the old hint would have been false. It now names the lever instead: `earlier transcript omitted · raise tui scrollbackRows to keep more`. The `resumed · ` prefix is gone, since the notice is no longer resume-specific.
- **One default (1000) rather than a per-terminal table.** codex tunes per terminal (VS Code 1000, WezTerm 3500, Alacritty 10000); this takes the conservative single value. Low for a large-scrollback terminal — worth revisiting with real use.
- **Reflow stays width-only.** codex and pi also rebuild on height change, but their reasons don't transfer: both anchor a rendered region to the viewport, whereas xal commits rows into real scrollback and keeps only the footer live. Wrapping depends on width alone.
- **No multiplexer special-casing.** tmux implements `ESC[3J` against its own pane history and never rewraps on resize, so the rebuild is worth more there, not less. Verified working in tmux.

## Verification

- `bun test apps/cli/src/plugins/tui` — 35 pass.
- Full `bun test apps/cli` — 480 pass, 9 fail, 1 error, identical to clean `main` (pre-existing `PROVIDER_NAME` export error in `plugins/openai/api-client.ts`, unrelated).
- `bun run typecheck` and `bun checks:fix` clean.
- Manually resized long sessions in a plain terminal and under tmux.
- New test covers a rebuild landing mid-stream — each streamed paragraph commits exactly once.

Docs updated: `docs/tui.md` gains the option and a "Transcript rebuilds" section; `docs/configs.md` gains the key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable terminal scrollback limits, defaulting to 1,000 rows.
  * Displays a notice when older transcript content is omitted.
  * Supports unlimited scrollback when the limit is set to 0.

* **Bug Fixes**
  * Improved transcript reflow when terminal width changes.
  * Preserved active streamed content during transcript rebuilds.
  * Improved layout updates for terminal resizing.

* **Documentation**
  * Documented scrollback configuration, limits, defaults, and rebuild behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->