### PR TITLE
Fix Copilot image capability discovery

### DIFF
--- a/apps/cli/src/agent/session/compaction.test.ts
+++ b/apps/cli/src/agent/session/compaction.test.ts
@@ -88,7 +88,7 @@ test("summarizes the active history with the dedicated request contract", async 
       type: "user_message",
       messageId: "11111111-1111-4111-8111-111111111111",
       text: "Original prompt",
-      images: [],
+      images: [{ mediaType: "image/png", data: "retained-image" }],
     },
     { type: "assistant_message", text: "Original answer" },
   ]
@@ -102,6 +102,7 @@ test("summarizes the active history with the dedicated request contract", async 
     sessionId: "summary-session",
     history,
     instructions: "the unfinished migration",
+    imageInput: false,
     signal: new AbortController().signal,
   })
 
@@ -117,7 +118,7 @@ test("summarizes the active history with the dedicated request contract", async 
   })
   expect(provider.requests[0]?.cacheKey).toHaveLength(64)
   expect(provider.requests[0]?.input.slice(0, -1)).toEqual([
-    { type: "user_message", text: "Original prompt", images: [] },
+    { type: "user_message", text: "Original prompt\n\n[1 image attachment omitted]", images: [] },
     { type: "assistant_message", text: "Original answer" },
   ])
   const summaryRequest = provider.requests[0]?.input.at(-1)
@@ -140,6 +141,7 @@ test("falls back to streamed summary text and rejects an empty summary", async (
       sessionId: "streamed-summary",
       history: [{ type: "user_message", text: "Prompt", images: [] }],
       instructions: undefined,
+      imageInput: true,
       signal: new AbortController().signal,
     }),
   ).toBe("streamed summary")
@@ -155,6 +157,7 @@ test("falls back to streamed summary text and rejects an empty summary", async (
       sessionId: "empty-summary",
       history: [{ type: "user_message", text: "Prompt", images: [] }],
       instructions: undefined,
+      imageInput: true,
       signal: new AbortController().signal,
     }),
   ).rejects.toThrow("Scripted provider returned an empty summary")

--- a/apps/cli/src/agent/session/compaction.ts
+++ b/apps/cli/src/agent/session/compaction.ts
@@ -1,6 +1,6 @@
 import { resolveThinking } from "../../config/thinking"
 import { describeError } from "../../lib/error"
-import { contextWindow, findModel } from "../../providers/catalog"
+import { contextWindow, findModel, modelSupportsImageInput } from "../../providers/catalog"
 import { prepareConversation } from "../../providers/conversation"
 import { collectStreamedText } from "../../providers/streamed-text"
 import type {
@@ -28,6 +28,7 @@ export type CompactionTrigger = "auto" | "manual"
 export interface CompactionTarget {
   model: string
   thinking: ThinkingEffort | undefined
+  imageInput: boolean
 }
 
 const SUMMARY_INSTRUCTIONS = `Summarize this coding session transcript so the assistant can keep working after the older messages are dropped.
@@ -60,7 +61,12 @@ export async function resolveCompactionTarget(
 ): Promise<CompactionTarget> {
   const fastModel = model.endsWith("-fast") ? model : `${model}-fast`
   const requestModel = fastModel === model || (await findModel(provider, profileId, fastModel)) ? fastModel : model
-  return { model: requestModel, thinking: await resolveThinking(provider, profileId, requestModel, "low") }
+  const info = await findModel(provider, profileId, requestModel)
+  return {
+    model: requestModel,
+    thinking: await resolveThinking(provider, profileId, requestModel, "low"),
+    imageInput: modelSupportsImageInput(provider, info?.inputModalities),
+  }
 }
 
 function textTokens(text: string): number {
@@ -149,6 +155,7 @@ export interface SummaryRequest {
   kind?: SessionKind
   history: HistoryItem[]
   instructions: string | undefined
+  imageInput: boolean
   signal: AbortSignal
 }
 
@@ -159,7 +166,11 @@ function summaryRequest(instructions: string | undefined): UserMessageItem {
 
 export async function summarizeHistory(request: SummaryRequest): Promise<string> {
   const target = { provider: request.provider.id, model: request.historyModel ?? request.model }
-  const input = prepareConversation([...activeHistory(request.history), summaryRequest(request.instructions)], target)
+  const input = prepareConversation(
+    [...activeHistory(request.history), summaryRequest(request.instructions)],
+    target,
+    request.imageInput,
+  )
   const result = await collectStreamedText({
     provider: request.provider,
     profileId: request.profileId,
@@ -224,6 +235,7 @@ export async function runCompaction(
     kind: host.kind,
     history: head,
     instructions,
+    imageInput: target.imageInput,
     signal,
   })
 

--- a/apps/cli/src/agent/session/session.ts
+++ b/apps/cli/src/agent/session/session.ts
@@ -14,7 +14,7 @@ import type { PermissionMode, PermissionScope } from "../../permissions/types"
 import type { SessionPlan } from "../../plans/types"
 import { profileAgentEvent, profileSessionCreated } from "../../profiler/profiler"
 import { promptCacheKey } from "../../providers/cache"
-import { contextWindow } from "../../providers/catalog"
+import { contextWindow, modelSupportsImageInput } from "../../providers/catalog"
 import { pendingToolCalls, prepareConversation } from "../../providers/conversation"
 import { occupiedContext } from "../../providers/types"
 import type {
@@ -388,8 +388,7 @@ export class AgentSession {
   }
 
   get supportsImageInput(): boolean {
-    if (!this.provider.capabilities.imageInput) return false
-    return this.modelInputModalities?.includes("image") ?? true
+    return modelSupportsImageInput(this.provider, this.modelInputModalities)
   }
 
   get currentGoal(): GoalSnapshot | undefined {
@@ -1043,6 +1042,7 @@ export class AgentSession {
           sessionModel: this.model,
           evaluatorModel: target.model,
           thinking: target.thinking,
+          imageInput: target.imageInput,
           conversation: activeHistory(this.items),
           sessionId: this.sessionId,
           kind: this.kind,
@@ -1528,7 +1528,11 @@ export class AgentSession {
     thinking: ThinkingEffort | undefined,
     signal: AbortSignal,
   ): StreamRequest {
-    const input = prepareConversation(activeHistory(this.items), { provider: provider.id, model })
+    const input = prepareConversation(
+      activeHistory(this.items),
+      { provider: provider.id, model },
+      this.supportsImageInput,
+    )
     if (this.transientQuestionInput) {
       input.push({ type: "user_message", text: this.transientQuestionInput, images: [] })
     }

--- a/apps/cli/src/goals/evaluator.test.ts
+++ b/apps/cli/src/goals/evaluator.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { round, ScriptedProvider } from "../agent/session/test-support"
+import { evaluateGoal } from "./evaluator"
+
+test("omits retained images when the evaluator model is text-only", async () => {
+  const provider = new ScriptedProvider([
+    round([
+      {
+        type: "item_done",
+        item: {
+          type: "assistant_message",
+          text: JSON.stringify({ verdict: "not_yet_met", reason: "More evidence is needed." }),
+        },
+      },
+      { type: "done" },
+    ]),
+  ])
+
+  const result = await evaluateGoal({
+    provider,
+    profileId: "test-profile",
+    sessionModel: "vision-model",
+    evaluatorModel: "text-model",
+    thinking: undefined,
+    imageInput: false,
+    conversation: [
+      {
+        type: "user_message",
+        text: "Inspect this",
+        images: [{ mediaType: "image/jpeg", data: "retained-image" }],
+      },
+    ],
+    sessionId: "goal-session",
+    signal: new AbortController().signal,
+    condition: "The issue is fixed",
+  })
+
+  expect(result.verdict).toEqual({ verdict: "not_yet_met", reason: "More evidence is needed." })
+  expect(provider.requests[0]?.input[0]).toEqual({
+    type: "user_message",
+    text: "Inspect this\n\n[1 image attachment omitted]",
+    images: [],
+  })
+})

--- a/apps/cli/src/goals/evaluator.ts
+++ b/apps/cli/src/goals/evaluator.ts
@@ -1,7 +1,7 @@
 import type { SessionKind } from "../agent/types"
 import { settings } from "../config/settings"
 import { promptCacheKey } from "../providers/cache"
-import { findModel } from "../providers/catalog"
+import { findModel, modelSupportsImageInput } from "../providers/catalog"
 import { prepareConversation } from "../providers/conversation"
 import { collectStreamedText } from "../providers/streamed-text"
 import type { ConversationItem, Provider, ThinkingEffort, Usage, UserMessageItem } from "../providers/types"
@@ -23,6 +23,7 @@ const THINKING_ORDER: ThinkingEffort[] = ["none", "low", "medium", "high", "xhig
 export interface GoalEvaluatorTarget {
   model: string
   thinking: ThinkingEffort | undefined
+  imageInput: boolean
 }
 
 export interface GoalEvaluationContext {
@@ -31,6 +32,7 @@ export interface GoalEvaluationContext {
   sessionModel: string
   evaluatorModel: string
   thinking: ThinkingEffort | undefined
+  imageInput: boolean
   conversation: ConversationItem[]
   sessionId: string
   kind?: SessionKind
@@ -56,11 +58,12 @@ export async function resolveGoalEvaluatorTarget(
   const info = await findModel(provider, profileId, model)
   if (configured && !info)
     throw new Error(`${provider.name} does not offer configured goal evaluator model ${configured}`)
-  if (!info?.thinking) return { model, thinking: undefined }
+  const imageInput = modelSupportsImageInput(provider, info?.inputModalities)
+  if (!info?.thinking) return { model, thinking: undefined, imageInput }
   const thinking = THINKING_ORDER.find((effort) => info.thinking?.options.includes(effort))
   if (!thinking)
     throw new Error(`${provider.name} returned no usable thinking effort for goal evaluator model ${model}`)
-  return { model, thinking }
+  return { model, thinking, imageInput }
 }
 
 function evaluationMessage(condition: string): UserMessageItem {
@@ -72,10 +75,14 @@ function evaluationMessage(condition: string): UserMessageItem {
 }
 
 export async function evaluateGoal(request: GoalEvaluationRequest): Promise<GoalEvaluationResult> {
-  const input = prepareConversation(request.conversation, {
-    provider: request.provider.id,
-    model: request.sessionModel,
-  })
+  const input = prepareConversation(
+    request.conversation,
+    {
+      provider: request.provider.id,
+      model: request.sessionModel,
+    },
+    request.imageInput,
+  )
   input.push(evaluationMessage(request.condition))
   const result = await collectStreamedText({
     provider: request.provider,

--- a/apps/cli/src/plugins/alibaba-cloud/transport.ts
+++ b/apps/cli/src/plugins/alibaba-cloud/transport.ts
@@ -13,6 +13,7 @@ function provider(profileId: string): ChatCompletionProvider {
   return {
     id: PROVIDER_ID,
     name: "Alibaba Cloud",
+    imageInput: false,
     async fetch(body, signal) {
       return alibabaCloudFetch("/chat/completions", await apiKey(profileId), {
         method: "POST",

--- a/apps/cli/src/plugins/deepseek/transport.ts
+++ b/apps/cli/src/plugins/deepseek/transport.ts
@@ -24,6 +24,7 @@ function provider(profileId: string): ChatCompletionProvider {
   return {
     id: PROVIDER_ID,
     name: "DeepSeek",
+    imageInput: false,
     async fetch(body, signal) {
       return deepSeekFetch("/chat/completions", await apiKey(profileId), {
         method: "POST",

--- a/apps/cli/src/plugins/github-copilot/models.test.ts
+++ b/apps/cli/src/plugins/github-copilot/models.test.ts
@@ -52,7 +52,7 @@ test("Copilot model caches are bound to the credential that discovered them", as
         id: "account-a-model",
         name: "Account A Model",
         contextWindow: 128_000,
-        inputModalities: ["text"],
+        inputModalities: ["text", "image"],
         endpoint: "/chat/completions",
       },
     ]

--- a/apps/cli/src/plugins/github-copilot/models.ts
+++ b/apps/cli/src/plugins/github-copilot/models.ts
@@ -3,12 +3,17 @@ import { cacheDir } from "../../config/paths"
 import { describeError } from "../../lib/error"
 import { readJsonFile, writeSecureJson } from "../../lib/fs"
 import { asNumber, asString, asStringArray, isRecord } from "../../lib/json"
-import { isThinkingEffort, type ModelCatalog, type ThinkingOptions } from "../../providers/types"
+import {
+  isThinkingEffort,
+  type ModelCatalog,
+  type ModelInputModality,
+  type ThinkingOptions,
+} from "../../providers/types"
 import { copilotFetch, githubDomain, isPersonalCopilotEndpoint } from "./api"
 import { token } from "./credential"
 import { parseCopilotModels, type CopilotEndpoint, type CopilotModel } from "./wire"
 
-const CACHE_VERSION = 2
+const CACHE_VERSION = 3
 const modelEndpoints = new Map<string, Map<string, CopilotEndpoint>>()
 
 type CopilotModelCatalog = Omit<ModelCatalog, "models"> & { models: CopilotModel[] }
@@ -36,19 +41,28 @@ function cachedThinking(raw: unknown): ThinkingOptions | undefined {
   return { options, default: preferred }
 }
 
+function cachedInputModalities(raw: unknown): ModelInputModality[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const modalities = asStringArray(raw)
+  if (modalities.length !== raw.length) return undefined
+  if (modalities.length === 1 && modalities[0] === "text") return ["text"]
+  if (modalities.length === 2 && modalities[0] === "text" && modalities[1] === "image") return ["text", "image"]
+  return undefined
+}
+
 function cachedModel(raw: unknown): CopilotModel | undefined {
   if (!isRecord(raw)) return undefined
   const id = asString(raw.id)?.trim()
   const name = asString(raw.name)?.trim()
   const endpoint = asString(raw.endpoint)
   if (!id || !name || (endpoint !== "/chat/completions" && endpoint !== "/responses")) return undefined
-  const modalities = asStringArray(raw.inputModalities)
-  if (modalities.length !== 1 || modalities[0] !== "text") return undefined
+  const inputModalities = cachedInputModalities(raw.inputModalities)
+  if (!inputModalities) return undefined
   return {
     id,
     name,
     contextWindow: positiveInteger(raw.contextWindow),
-    inputModalities: ["text"],
+    inputModalities,
     thinking: cachedThinking(raw.thinking),
     endpoint,
   }

--- a/apps/cli/src/plugins/github-copilot/provider.ts
+++ b/apps/cli/src/plugins/github-copilot/provider.ts
@@ -8,7 +8,7 @@ export const githubCopilotProvider: Provider = {
   id: PROVIDER_ID,
   name: "GitHub Copilot",
   aliases: ["copilot"],
-  capabilities: { imageInput: false },
+  capabilities: { imageInput: true },
   connect,
   listModels,
   defaultModel,

--- a/apps/cli/src/plugins/github-copilot/transport.test.ts
+++ b/apps/cli/src/plugins/github-copilot/transport.test.ts
@@ -109,6 +109,7 @@ describe("GitHub Copilot transport", () => {
       accept: "text/event-stream",
       "openai-intent": "conversation-edits",
       "x-initiator": "user",
+      "copilot-vision-request": "true",
     })
     expect(JSON.parse(String(requests[0]!.init.body))).toEqual({
       model: "gpt-5.6-luna",
@@ -188,6 +189,7 @@ describe("GitHub Copilot transport", () => {
     )
 
     expect(requests[0]!.path).toBe("/chat/completions")
+    expect(new Headers(requests[0]!.init.headers).get("copilot-vision-request")).toBe("true")
     expect(JSON.parse(String(requests[0]!.init.body))).toMatchObject({
       model: "claude-sonnet-4.6",
       reasoning_effort: "high",
@@ -219,5 +221,13 @@ describe("GitHub Copilot transport", () => {
       },
       { type: "done", usage: { totalInputTokens: 4, cacheReadInputTokens: undefined, outputTokens: 1 } },
     ])
+  })
+
+  test("omits the vision header when a turn carries no image attachments", async () => {
+    responses.push(sse([{ type: "response.completed", response: { usage: {} } }]))
+
+    await collect(streamResponse("profile-1", request()))
+
+    expect(new Headers(requests[0]!.init.headers).get("copilot-vision-request")).toBeNull()
   })
 })

--- a/apps/cli/src/plugins/github-copilot/transport.test.ts
+++ b/apps/cli/src/plugins/github-copilot/transport.test.ts
@@ -86,7 +86,20 @@ describe("GitHub Copilot transport", () => {
       ]),
     )
 
-    const events = await collect(streamResponse("profile-1", request()))
+    const events = await collect(
+      streamResponse(
+        "profile-1",
+        request({
+          input: [
+            {
+              type: "user_message",
+              text: "inspect",
+              images: [{ mediaType: "image/png", data: "YWJjZA==" }],
+            },
+          ],
+        }),
+      ),
+    )
 
     expect(requests).toHaveLength(1)
     expect(requests[0]!.path).toBe("/responses")
@@ -102,7 +115,15 @@ describe("GitHub Copilot transport", () => {
       store: false,
       stream: true,
       instructions: "Answer precisely",
-      input: [{ role: "user", content: [{ type: "input_text", text: "inspect" }] }],
+      input: [
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: "inspect" },
+            { type: "input_image", image_url: "data:image/png;base64,YWJjZA==" },
+          ],
+        },
+      ],
       reasoning: { effort: "max", summary: "auto" },
       include: ["reasoning.encrypted_content"],
       tools: [
@@ -149,13 +170,38 @@ describe("GitHub Copilot transport", () => {
       ),
     )
 
-    const events = await collect(streamResponse("profile-1", request({ model: "claude-sonnet-4.6", thinking: "high" })))
+    const events = await collect(
+      streamResponse(
+        "profile-1",
+        request({
+          model: "claude-sonnet-4.6",
+          thinking: "high",
+          input: [
+            {
+              type: "user_message",
+              text: "inspect",
+              images: [{ mediaType: "image/jpeg", data: "YWJjZA==" }],
+            },
+          ],
+        }),
+      ),
+    )
 
     expect(requests[0]!.path).toBe("/chat/completions")
     expect(JSON.parse(String(requests[0]!.init.body))).toMatchObject({
       model: "claude-sonnet-4.6",
       reasoning_effort: "high",
       stream: true,
+      messages: [
+        { role: "system", content: "Answer precisely" },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "inspect" },
+            { type: "image_url", image_url: { url: "data:image/jpeg;base64,YWJjZA==" } },
+          ],
+        },
+      ],
     })
     expect(events).toEqual([
       { type: "text_delta", text: "done" },

--- a/apps/cli/src/plugins/github-copilot/transport.ts
+++ b/apps/cli/src/plugins/github-copilot/transport.ts
@@ -22,6 +22,7 @@ function chatProvider(accessToken: string, request: StreamRequest): ChatCompleti
   return {
     id: PROVIDER_ID,
     name: PROVIDER_NAME,
+    imageInput: true,
     fetch(body, signal) {
       return copilotFetch("/chat/completions", accessToken, {
         method: "POST",

--- a/apps/cli/src/plugins/github-copilot/transport.ts
+++ b/apps/cli/src/plugins/github-copilot/transport.ts
@@ -18,6 +18,19 @@ function initiator(request: StreamRequest): "user" | "agent" {
   return !last || last.type === "user_message" ? "user" : "agent"
 }
 
+function hasImages(request: StreamRequest): boolean {
+  return request.input.some((item) => item.type === "user_message" && item.images.length > 0)
+}
+
+function streamHeaders(request: StreamRequest): Record<string, string> {
+  return {
+    accept: "text/event-stream",
+    "openai-intent": "conversation-edits",
+    "x-initiator": initiator(request),
+    ...(hasImages(request) ? { "copilot-vision-request": "true" } : {}),
+  }
+}
+
 function chatProvider(accessToken: string, request: StreamRequest): ChatCompletionProvider {
   return {
     id: PROVIDER_ID,
@@ -26,11 +39,7 @@ function chatProvider(accessToken: string, request: StreamRequest): ChatCompleti
     fetch(body, signal) {
       return copilotFetch("/chat/completions", accessToken, {
         method: "POST",
-        headers: {
-          accept: "text/event-stream",
-          "openai-intent": "conversation-edits",
-          "x-initiator": initiator(request),
-        },
+        headers: streamHeaders(request),
         body,
         signal,
       })
@@ -69,11 +78,7 @@ function responsesBody(request: StreamRequest): string {
 async function* streamResponses(accessToken: string, request: StreamRequest): AsyncGenerator<StreamEvent> {
   const response = await copilotFetch("/responses", accessToken, {
     method: "POST",
-    headers: {
-      accept: "text/event-stream",
-      "openai-intent": "conversation-edits",
-      "x-initiator": initiator(request),
-    },
+    headers: streamHeaders(request),
     body: responsesBody(request),
     signal: request.signal,
   })

--- a/apps/cli/src/plugins/github-copilot/wire.test.ts
+++ b/apps/cli/src/plugins/github-copilot/wire.test.ts
@@ -4,7 +4,13 @@ import { parseCopilotModels, parseDeviceAuthorization, parseDeviceToken } from "
 function model(
   id: string,
   endpoint: string | undefined,
-  options: { picker?: boolean; policy?: string; toolCalls?: boolean | "omitted" } = {},
+  options: {
+    picker?: boolean
+    policy?: string
+    toolCalls?: boolean | "omitted"
+    vision?: boolean
+    visionMediaTypes?: string[]
+  } = {},
 ): Record<string, unknown> {
   return {
     id,
@@ -13,9 +19,14 @@ function model(
     ...(endpoint === undefined ? {} : { supported_endpoints: [endpoint] }),
     policy: { state: options.policy ?? "enabled" },
     capabilities: {
-      limits: { max_context_window_tokens: 128_000, max_prompt_tokens: 64_000 },
+      limits: {
+        max_context_window_tokens: 128_000,
+        max_prompt_tokens: 64_000,
+        ...(options.visionMediaTypes ? { vision: { supported_media_types: options.visionMediaTypes } } : {}),
+      },
       supports: {
         ...(options.toolCalls === "omitted" ? {} : { tool_calls: options.toolCalls ?? true }),
+        ...(options.vision === undefined ? {} : { vision: options.vision }),
         reasoning_effort: ["low", "medium", "invalid"],
       },
     },
@@ -88,6 +99,32 @@ describe("GitHub Copilot wire parsing", () => {
         thinking: { options: ["low", "medium"], default: "medium" },
         endpoint: "/responses",
       },
+    ])
+  })
+
+  test("maps Copilot vision metadata to model input modalities", () => {
+    const models = parseCopilotModels(
+      {
+        data: [
+          model("vision-flag", "/responses", { picker: true, vision: true }),
+          model("vision-limits", "/chat/completions", {
+            picker: true,
+            visionMediaTypes: ["image/png", "image/jpeg"],
+          }),
+          model("explicitly-text-only", "/responses", {
+            picker: true,
+            vision: false,
+            visionMediaTypes: ["image/png"],
+          }),
+        ],
+      },
+      true,
+    )
+
+    expect(models.map((entry) => [entry.id, entry.inputModalities])).toEqual([
+      ["vision-flag", ["text", "image"]],
+      ["vision-limits", ["text", "image"]],
+      ["explicitly-text-only", ["text"]],
     ])
   })
 

--- a/apps/cli/src/plugins/github-copilot/wire.ts
+++ b/apps/cli/src/plugins/github-copilot/wire.ts
@@ -83,6 +83,20 @@ function thinking(raw: unknown): ModelInfo["thinking"] {
   return { options, default: preferred }
 }
 
+function inputModalities(
+  supports: Record<string, unknown> | undefined,
+  limits: Record<string, unknown> | undefined,
+): ModelInfo["inputModalities"] {
+  if (supports?.vision === true) return ["text", "image"]
+  if (supports?.vision === false) return ["text"]
+  const vision = limits && isRecord(limits.vision) ? limits.vision : undefined
+  const rawMediaTypes = vision?.supported_media_types
+  if (!Array.isArray(rawMediaTypes)) return ["text"]
+  const mediaTypes = asStringArray(rawMediaTypes)
+  if (mediaTypes.length !== rawMediaTypes.length) return ["text"]
+  return mediaTypes.includes("image/png") || mediaTypes.includes("image/jpeg") ? ["text", "image"] : ["text"]
+}
+
 function candidate(raw: unknown): ModelCandidate | undefined {
   if (!isRecord(raw)) return undefined
   const id = asString(raw.id)?.trim()
@@ -112,7 +126,7 @@ function candidate(raw: unknown): ModelCandidate | undefined {
       id,
       name,
       ...(contextWindow === undefined ? {} : { contextWindow }),
-      inputModalities: ["text"],
+      inputModalities: inputModalities(supports, limits),
       thinking: thinking(supports?.reasoning_effort),
       endpoint,
     },

--- a/apps/cli/src/plugins/opencode-go/transport.ts
+++ b/apps/cli/src/plugins/opencode-go/transport.ts
@@ -11,6 +11,7 @@ function chatProvider(profileId: string): ChatCompletionProvider {
   return {
     id: PROVIDER_ID,
     name: PROVIDER_NAME,
+    imageInput: true,
     async fetch(body, signal) {
       return goFetch("/chat/completions", await apiKey(profileId), {
         method: "POST",

--- a/apps/cli/src/plugins/openrouter/transport.ts
+++ b/apps/cli/src/plugins/openrouter/transport.ts
@@ -24,6 +24,7 @@ function provider(profileId: string): ChatCompletionProvider {
   return {
     id: PROVIDER_ID,
     name: PROVIDER_NAME,
+    imageInput: true,
     async fetch(body, signal) {
       return openRouterFetch("/chat/completions", await apiKey(profileId), {
         method: "POST",

--- a/apps/cli/src/providers/catalog.ts
+++ b/apps/cli/src/providers/catalog.ts
@@ -25,6 +25,14 @@ export interface CatalogNotice {
   message: string
 }
 
+export function modelSupportsImageInput(
+  provider: Provider,
+  inputModalities: ModelInputModality[] | undefined,
+): boolean {
+  if (!provider.capabilities.imageInput) return false
+  return inputModalities?.includes("image") ?? true
+}
+
 export interface ModelChoices {
   choices: ModelChoice[]
   notices: CatalogNotice[]

--- a/apps/cli/src/providers/chat-completions.test.ts
+++ b/apps/cli/src/providers/chat-completions.test.ts
@@ -26,9 +26,15 @@ describe("chat completions wire conversion", () => {
       { type: "assistant_message", text: "done" },
     ]
 
-    expect(buildChatMessages("system prompt", items)).toEqual([
+    expect(buildChatMessages("system prompt", items, true)).toEqual([
       { role: "system", content: "system prompt" },
-      { role: "user", content: "inspect\n\n[1 image attachment omitted]" },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "inspect" },
+          { type: "image_url", image_url: { url: "data:image/jpeg;base64,YWJjZA==" } },
+        ],
+      },
       {
         role: "assistant",
         content: "working",
@@ -40,6 +46,21 @@ describe("chat completions wire conversion", () => {
       },
       { role: "tool", tool_call_id: "first", content: "contents" },
       { role: "assistant", content: "done" },
+    ])
+  })
+
+  test("omits image bytes for text-only transports", () => {
+    expect(
+      buildChatMessages("system prompt", [
+        {
+          type: "user_message",
+          text: "inspect",
+          images: [{ mediaType: "image/png", data: "YWJjZA==" }],
+        },
+      ]),
+    ).toEqual([
+      { role: "system", content: "system prompt" },
+      { role: "user", content: "inspect\n\n[1 image attachment omitted]" },
     ])
   })
 
@@ -135,6 +156,7 @@ describe("chat completions wire conversion", () => {
         for await (const event of streamChatCompletions(request, {
           id: "provider",
           name: "Provider",
+          imageInput: false,
           async fetch() {
             return response
           },

--- a/apps/cli/src/providers/chat-completions.ts
+++ b/apps/cli/src/providers/chat-completions.ts
@@ -1,4 +1,5 @@
 import { asNumber, asString, isRecord, type JsonObject } from "../lib/json"
+import { omitUserMessageImages } from "./conversation"
 import { ProviderError } from "./errors"
 import { parseToolArgs, sseEvents, streamError } from "./transport"
 import type {
@@ -30,6 +31,7 @@ export interface ChatCompletionChunk {
 export interface ChatCompletionProvider {
   id: string
   name: string
+  imageInput: boolean
   fetch(body: string, signal?: AbortSignal): Promise<Response>
   requestOptions(request: StreamRequest): JsonObject
   finishReasonError?(finishReason: string): ProviderError | undefined
@@ -45,7 +47,7 @@ function assistantMessage(): JsonObject {
   return { role: "assistant", content: "" }
 }
 
-export function buildChatMessages(instructions: string, items: ConversationItem[]): JsonObject[] {
+export function buildChatMessages(instructions: string, items: ConversationItem[], imageInput = false): JsonObject[] {
   const messages: JsonObject[] = [{ role: "system", content: instructions }]
   let assistant: JsonObject | undefined
 
@@ -68,9 +70,15 @@ export function buildChatMessages(instructions: string, items: ConversationItem[
           content:
             item.images.length === 0
               ? item.text
-              : [item.text, `[${item.images.length} image attachment${item.images.length === 1 ? "" : "s"} omitted]`]
-                  .filter(Boolean)
-                  .join("\n\n"),
+              : imageInput
+                ? [
+                    ...(item.text ? [{ type: "text", text: item.text }] : []),
+                    ...item.images.map((image) => ({
+                      type: "image_url",
+                      image_url: { url: `data:${image.mediaType};base64,${image.data}` },
+                    })),
+                  ]
+                : omitUserMessageImages(item).text,
         })
         break
       case "assistant_message":
@@ -186,7 +194,7 @@ export function chatToolCallItem(
 function buildBody(request: StreamRequest, provider: ChatCompletionProvider): string {
   return JSON.stringify({
     model: request.model,
-    messages: buildChatMessages(request.instructions, request.input),
+    messages: buildChatMessages(request.instructions, request.input, provider.imageInput),
     stream: true,
     stream_options: { include_usage: true },
     ...provider.requestOptions(request),

--- a/apps/cli/src/providers/conversation.test.ts
+++ b/apps/cli/src/providers/conversation.test.ts
@@ -46,7 +46,7 @@ describe("prepareConversation", () => {
       { type: "tool_result", callId: "call-id", output: "contents" },
     ]
 
-    const prepared = prepareConversation(items, target)
+    const prepared = prepareConversation(items, target, true)
 
     expect(prepared).toEqual([
       { type: "user_message", text: "hook-transformed prompt", images: [] },
@@ -58,6 +58,29 @@ describe("prepareConversation", () => {
     ])
   })
 
+  test("omits retained images when the selected model is text-only", () => {
+    const items: ConversationItem[] = [
+      {
+        type: "user_message",
+        text: "visible prompt",
+        modelText: "hook-transformed prompt",
+        images: [
+          { mediaType: "image/png", data: "first" },
+          { mediaType: "image/jpeg", data: "second" },
+        ],
+      },
+    ]
+
+    expect(prepareConversation(items, target, false)).toEqual([
+      {
+        type: "user_message",
+        text: "hook-transformed prompt\n\n[2 image attachments omitted]",
+        images: [],
+      },
+    ])
+    expect(items[0]).toMatchObject({ text: "visible prompt", images: [{ data: "first" }, { data: "second" }] })
+  })
+
   test("closes interrupted tool calls before a new conversational item", () => {
     const items: ConversationItem[] = [
       { type: "user_message", text: "run tools", images: [] },
@@ -67,7 +90,7 @@ describe("prepareConversation", () => {
       { type: "assistant_message", text: "continuing" },
     ]
 
-    expect(prepareConversation(items, target)).toEqual([
+    expect(prepareConversation(items, target, true)).toEqual([
       { type: "user_message", text: "run tools", images: [] },
       { type: "tool_call", callId: "first", name: "read", args: {} },
       { type: "tool_call", callId: "second", name: "search", args: {} },
@@ -90,7 +113,7 @@ describe("prepareConversation", () => {
       { type: "tool_result", callId: "orphan", output: "still ignored" },
     ]
 
-    expect(prepareConversation(items, target)).toEqual([
+    expect(prepareConversation(items, target, true)).toEqual([
       call,
       {
         type: "tool_result",

--- a/apps/cli/src/providers/conversation.ts
+++ b/apps/cli/src/providers/conversation.ts
@@ -33,6 +33,17 @@ function toolCall(item: ToolCallItem, target: ConversationTarget): ToolCallItem 
   return { type: "tool_call", callId: item.callId, name: item.name, args: item.args }
 }
 
+export function omitUserMessageImages(item: UserMessageItem): UserMessageItem {
+  if (item.images.length === 0) return item
+  return {
+    ...item,
+    text: [item.text, `[${item.images.length} image attachment${item.images.length === 1 ? "" : "s"} omitted]`]
+      .filter(Boolean)
+      .join("\n\n"),
+    images: [],
+  }
+}
+
 function userMessage(item: UserMessageItem): UserMessageItem {
   return { type: "user_message", text: item.modelText ?? item.text, images: item.images }
 }
@@ -101,14 +112,21 @@ export function pendingToolCalls(items: ConversationItem[], target: Conversation
   return normalizedConversation(items, target).pending
 }
 
-export function prepareConversation(items: ConversationItem[], target: ConversationTarget): ConversationItem[] {
+export function prepareConversation(
+  items: ConversationItem[],
+  target: ConversationTarget,
+  imageInput: boolean,
+): ConversationItem[] {
   const normalized = normalizedConversation(items, target)
+  const result = imageInput
+    ? normalized.result
+    : normalized.result.map((item) => (item.type === "user_message" ? omitUserMessageImages(item) : item))
   for (const call of normalized.pending) {
-    normalized.result.push({
+    result.push({
       type: "tool_result",
       callId: call.callId,
       output: "Tool execution was interrupted before returning a result.",
     })
   }
-  return normalized.result
+  return result
 }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -77,7 +77,7 @@ Configure options under `pluginConfig.github-copilot`:
 | `enterpriseDomain` | string | `github.com`             | GitHub Enterprise domain or HTTPS URL used for device login. |
 | `clientName`       | string | Package application name | Client name used in the provider request user agent.         |
 
-Run `xal connect copilot`, open the displayed GitHub device-login URL, and enter its one-time code. Xal uses the resulting GitHub OAuth token directly with the Copilot API and validates that the account returns at least one compatible agent model before storing the token. Personal catalogs that omit endpoint, picker, or policy metadata are accepted unless a model is explicitly incompatible or disabled. Models advertising Responses use that protocol, including newer GPT families, while chat-compatible Claude and other models continue using Chat Completions. For GitHub Enterprise, configure `enterpriseDomain` before connecting.
+Run `xal connect copilot`, open the displayed GitHub device-login URL, and enter its one-time code. Xal uses the resulting GitHub OAuth token directly with the Copilot API and validates that the account returns at least one compatible agent model before storing the token. Personal catalogs that omit endpoint, picker, or policy metadata are accepted unless a model is explicitly incompatible or disabled. Models advertising Responses use that protocol, including newer GPT families, while chat-compatible Claude and other models continue using Chat Completions. Image input is enabled per model from the vision capability advertised by Copilot, so vision-capable models accept PNG and JPEG attachments while text-only models continue to reject them. For GitHub Enterprise, configure `enterpriseDomain` before connecting.
 
 ## xAI
 


### PR DESCRIPTION
## Summary

- derive GitHub Copilot image support from per-model vision metadata and refresh stale model caches
- encode image attachments for both Responses and Chat Completions transports
- prevent retained images from reaching text-only models during turns, compaction, and goal evaluation
- document Copilot image support and add focused regression coverage

## Testing

- `bun checks:fix`
- 501 CLI tests passed
- 17 website tests passed
- native checks, benchmark, typecheck, lint, formatting, build, and release check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image-input support for compatible models and providers, including GitHub Copilot, OpenRouter, and others.
  * Automatically detects model vision capabilities and preserves image attachments when supported.
  * Text-only models omit images while clearly indicating their removal in conversation context.
* **Bug Fixes**
  * Prevented unsupported models from receiving image data during summaries and goal evaluations.
* **Documentation**
  * Clarified GitHub Copilot’s per-model image support and supported attachment formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->