### PR TITLE
Add configurable model context windows

### DIFF
--- a/apps/cli/src/agent/events.ts
+++ b/apps/cli/src/agent/events.ts
@@ -83,6 +83,7 @@ export type AgentEvent =
   | { type: "state_changed"; state: AgentState }
   | { type: "mode_changed"; mode: PermissionMode }
   | { type: "model_changed"; provider: string; profile?: string; model: string }
+  | { type: "context_window_changed" }
   | { type: "thinking_changed"; thinking?: ThinkingEffort }
   | { type: "user_message"; messageId?: string; text: string; imageCount: number; sentAt: number }
   | {

--- a/apps/cli/src/agent/run.ts
+++ b/apps/cli/src/agent/run.ts
@@ -59,6 +59,7 @@ export function runAgentTurn(
         case "state_changed":
         case "mode_changed":
         case "model_changed":
+        case "context_window_changed":
         case "thinking_changed":
         case "user_message":
         case "conversation_rewound":
@@ -162,6 +163,7 @@ export function runAgentGoal(
         case "state_changed":
         case "mode_changed":
         case "model_changed":
+        case "context_window_changed":
         case "thinking_changed":
         case "user_message":
         case "conversation_rewound":

--- a/apps/cli/src/agent/session/compose.ts
+++ b/apps/cli/src/agent/session/compose.ts
@@ -150,6 +150,7 @@ function lastState(loaded: LoadedSession): {
       case "session_replay_finished":
       case "session_title_changed":
       case "state_changed":
+      case "context_window_changed":
       case "user_message":
       case "conversation_rewound":
       case "conversation_redone":

--- a/apps/cli/src/agent/session/session.ts
+++ b/apps/cli/src/agent/session/session.ts
@@ -675,6 +675,10 @@ export class AgentSession {
     return true
   }
 
+  contextWindowChanged(): void {
+    this.notify({ type: "context_window_changed" })
+  }
+
   disconnectProfile(profileId: string): boolean {
     if (this.profileId !== profileId) return true
     if (this.currentState !== "idle") return false

--- a/apps/cli/src/agent/task/activity.ts
+++ b/apps/cli/src/agent/task/activity.ts
@@ -111,6 +111,7 @@ export function activity(
     case "workspace_changed":
     case "mode_changed":
     case "model_changed":
+    case "context_window_changed":
     case "thinking_changed":
     case "user_message":
     case "conversation_rewound":

--- a/apps/cli/src/agent/task/drive.ts
+++ b/apps/cli/src/agent/task/drive.ts
@@ -93,6 +93,7 @@ export async function driveTaskToQuiescence(
       case "workspace_changed":
       case "mode_changed":
       case "model_changed":
+      case "context_window_changed":
       case "thinking_changed":
       case "user_message":
       case "conversation_rewound":

--- a/apps/cli/src/config/context-window.ts
+++ b/apps/cli/src/config/context-window.ts
@@ -1,0 +1,11 @@
+import type { Provider } from "../providers/types"
+import { saveSettings, settings } from "./settings"
+
+export async function saveContextWindow(provider: Provider, model: string, contextWindow: number): Promise<void> {
+  await saveSettings({
+    contextWindows: {
+      ...settings().contextWindows,
+      [provider.id]: { ...settings().contextWindows[provider.id], [model]: contextWindow },
+    },
+  })
+}

--- a/apps/cli/src/config/settings.test.ts
+++ b/apps/cli/src/config/settings.test.ts
@@ -224,6 +224,21 @@ test("rejects permission and redaction settings that are not string arrays", asy
   })
 })
 
+test("rejects malformed context-window settings", async () => {
+  await withSettingsEnvironment(async ({ home }) => {
+    const config = join(home, "config.json")
+
+    await writeJson(config, { contextWindows: "large" })
+    await expect(loadSettings()).rejects.toThrow("contextWindows must be an object")
+
+    await writeJson(config, { contextWindows: { openai: "large" } })
+    await expect(loadSettings()).rejects.toThrow("contextWindows.openai must be an object")
+
+    await writeJson(config, { contextWindows: { openai: { "gpt-5.6-sol": 600_000.5 } } })
+    await expect(loadSettings()).rejects.toThrow("contextWindows.openai.gpt-5.6-sol must be a positive integer")
+  })
+})
+
 test("saves a context window for one provider and model", async () => {
   await withSettingsEnvironment(async () => {
     await loadSettings()

--- a/apps/cli/src/config/settings.test.ts
+++ b/apps/cli/src/config/settings.test.ts
@@ -3,6 +3,9 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { appEnvVar, appInfo } from "../app-info"
+import { clearModelCatalog, findModel } from "../providers/catalog"
+import type { Provider } from "../providers/types"
+import { saveContextWindow } from "./context-window"
 import { projectConfigPath } from "./paths"
 import { loadSettings, saveSettings, settings } from "./settings"
 
@@ -58,6 +61,9 @@ test("trusted project settings override user settings with recursive object merg
       thinking: {
         provider: { shared: "low", userModel: "medium" },
       },
+      contextWindows: {
+        provider: { shared: 400_000, userModel: 600_000 },
+      },
     })
     await writeJson(join(home, "trust.json"), [project])
     await writeJson(projectConfigPath(project), {
@@ -79,6 +85,9 @@ test("trusted project settings override user settings with recursive object merg
       },
       thinking: {
         provider: { shared: "high", projectModel: "xhigh" },
+      },
+      contextWindows: {
+        provider: { shared: 800_000, projectModel: 1_000_000 },
       },
     })
 
@@ -111,6 +120,9 @@ test("trusted project settings override user settings with recursive object merg
       thinking: {
         provider: { shared: "high", userModel: "medium", projectModel: "xhigh" },
       },
+      contextWindows: {
+        provider: { shared: 800_000, userModel: 600_000, projectModel: 1_000_000 },
+      },
     })
   })
 })
@@ -135,6 +147,7 @@ test("does not read malformed project settings until the project is trusted", as
       redaction: { values: [], environment: [] },
       pluginConfig: {},
       thinking: {},
+      contextWindows: {},
     })
 
     await writeJson(join(home, "trust.json"), [project])
@@ -195,6 +208,7 @@ test("saves only user settings securely while retaining project overrides in mem
       redaction: { values: [], environment: [] },
       pluginConfig: { userPlugin: { enabled: true } },
       thinking: {},
+      contextWindows: {},
     })
     expect((await stat(userConfig)).mode & 0o777).toBe(0o600)
   })
@@ -207,5 +221,43 @@ test("rejects permission and redaction settings that are not string arrays", asy
 
     await writeJson(join(home, "config.json"), { permissions: { deny: [42] } })
     await expect(loadSettings()).rejects.toThrow("permissions.deny must be an array of strings")
+  })
+})
+
+test("saves a context window for one provider and model", async () => {
+  await withSettingsEnvironment(async () => {
+    await loadSettings()
+    const provider: Provider = {
+      id: "provider-a",
+      name: "Provider A",
+      aliases: [],
+      capabilities: { imageInput: false },
+      async listModels() {
+        return {
+          models: [
+            {
+              id: "model-a",
+              name: "Model A",
+              aliases: [{ id: "model-a-large", contextWindow: 600_000 }],
+              contextWindow: 260_000,
+              contextWindows: [260_000, 400_000, 600_000],
+              inputModalities: ["text"],
+            },
+          ],
+          source: "bundled",
+        }
+      },
+      async defaultModel() {
+        return "model-a"
+      },
+      async *stream() {},
+    }
+
+    await saveContextWindow(provider, "model-a", 400_000)
+
+    expect(settings().contextWindows).toEqual({ "provider-a": { "model-a": 400_000 } })
+    expect((await findModel(provider, "profile-a", "model-a"))?.contextWindow).toBe(400_000)
+    expect((await findModel(provider, "profile-a", "model-a-large"))?.contextWindow).toBe(400_000)
+    clearModelCatalog("profile-a")
   })
 })

--- a/apps/cli/src/config/settings.ts
+++ b/apps/cli/src/config/settings.ts
@@ -49,6 +49,7 @@ export interface Settings {
   agents: AgentSettings
   pluginConfig: Record<string, Record<string, unknown>>
   thinking: Record<string, Record<string, ThinkingEffort>>
+  contextWindows: Record<string, Record<string, number>>
 }
 
 const AGENT_DEFAULTS: AgentSettings = { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 }
@@ -63,6 +64,7 @@ let current: Settings = {
   agents: { ...AGENT_DEFAULTS },
   pluginConfig: {},
   thinking: {},
+  contextWindows: {},
 }
 
 export function settings(): Settings {
@@ -192,6 +194,17 @@ function parseSettings(raw: Record<string, unknown>): Settings {
       thinking[provider] = efforts
     }
   }
+  const contextWindows: Record<string, Record<string, number>> = {}
+  if (isRecord(raw.contextWindows)) {
+    for (const [provider, models] of Object.entries(raw.contextWindows)) {
+      if (!isRecord(models)) continue
+      const windows: Record<string, number> = {}
+      for (const [model, value] of Object.entries(models)) {
+        if (typeof value === "number" && Number.isInteger(value) && value > 0) windows[model] = value
+      }
+      contextWindows[provider] = windows
+    }
+  }
   return {
     plugins,
     provider: asString(raw.provider),
@@ -229,5 +242,6 @@ function parseSettings(raw: Record<string, unknown>): Settings {
     },
     pluginConfig,
     thinking,
+    contextWindows,
   }
 }

--- a/apps/cli/src/config/settings.ts
+++ b/apps/cli/src/config/settings.ts
@@ -137,6 +137,13 @@ function strictStringArray(value: unknown, path: string): string[] {
   return asStringArray(value)
 }
 
+function strictPositiveInteger(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${path} must be a positive integer`)
+  }
+  return value
+}
+
 export function parseGoalSettings(value: unknown): GoalSettings {
   if (value === undefined) return { evaluatorModels: {} }
   if (!isRecord(value)) throw new Error("goal must be an object")
@@ -195,15 +202,13 @@ function parseSettings(raw: Record<string, unknown>): Settings {
     }
   }
   const contextWindows: Record<string, Record<string, number>> = {}
-  if (isRecord(raw.contextWindows)) {
-    for (const [provider, models] of Object.entries(raw.contextWindows)) {
-      if (!isRecord(models)) continue
-      const windows: Record<string, number> = {}
-      for (const [model, value] of Object.entries(models)) {
-        if (typeof value === "number" && Number.isInteger(value) && value > 0) windows[model] = value
-      }
-      contextWindows[provider] = windows
+  for (const [provider, models] of Object.entries(sectionRecord(raw, "contextWindows"))) {
+    if (!isRecord(models)) throw new Error(`contextWindows.${provider} must be an object`)
+    const windows: Record<string, number> = {}
+    for (const [model, value] of Object.entries(models)) {
+      windows[model] = strictPositiveInteger(value, `contextWindows.${provider}.${model}`)
     }
+    contextWindows[provider] = windows
   }
   return {
     plugins,

--- a/apps/cli/src/config/thinking.ts
+++ b/apps/cli/src/config/thinking.ts
@@ -1,5 +1,5 @@
+import { findModel } from "../providers/catalog"
 import type { Provider, ThinkingEffort, ThinkingOptions } from "../providers/types"
-import { modelCatalog } from "../providers/catalog"
 import { saveSettings, settings } from "./settings"
 
 export async function thinkingOptions(
@@ -7,8 +7,7 @@ export async function thinkingOptions(
   profileId: string,
   model: string,
 ): Promise<ThinkingOptions | undefined> {
-  const catalog = await modelCatalog(provider, profileId)
-  return catalog.models.find((info) => info.id === model)?.thinking
+  return (await findModel(provider, profileId, model))?.thinking
 }
 
 export async function resolveThinking(

--- a/apps/cli/src/permissions/register.test.ts
+++ b/apps/cli/src/permissions/register.test.ts
@@ -34,6 +34,7 @@ test("makes the current writable mode override stale plan-mode context", () => {
     agents: { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 },
     pluginConfig: {},
     thinking: {},
+    contextWindows: {},
   } satisfies Settings)
 
   const yolo = composeSystemPrompt(prompt("yolo"))

--- a/apps/cli/src/plugins/discover.test.ts
+++ b/apps/cli/src/plugins/discover.test.ts
@@ -31,6 +31,7 @@ function settings(plugins: string[] = [], pluginConfig: Settings["pluginConfig"]
     agents: { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 },
     pluginConfig,
     thinking: {},
+    contextWindows: {},
   }
 }
 

--- a/apps/cli/src/plugins/openai/api-models.test.ts
+++ b/apps/cli/src/plugins/openai/api-models.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test"
+import type { Provider } from "../../providers/types"
 
 const cached = new Map<string, unknown>()
 const responses: (Response | Error)[] = []
 const requests: { path: string; key: string }[] = []
 
 mock.module("../../lib/fs", () => ({
+  async pathExists(): Promise<boolean> {
+    return false
+  },
   async readJsonFile(path: string): Promise<unknown> {
     return cached.get(path)
   },
@@ -32,8 +36,19 @@ mock.module("./api-client", () => ({
   },
 }))
 
+const { clearModelCatalog, findModel, modelCatalog } = await import("../../providers/catalog")
 const { setContextWindowCap } = await import("./context-window")
 const { defaultModel, listModels } = await import("./api-models")
+
+const provider: Provider = {
+  id: "openai",
+  name: "OpenAI",
+  aliases: [],
+  capabilities: { imageInput: true },
+  listModels,
+  defaultModel,
+  async *stream() {},
+}
 
 function modelsResponse(ids: string[]): Response {
   return Response.json({ data: ids.map((id) => ({ id, object: "model", owned_by: "openai" })) })
@@ -76,19 +91,29 @@ describe("OpenAI model catalog", () => {
     expect(requests).toEqual([{ path: "/models", key: "sk-test" }])
   })
 
-  test("adds synthetic 1M models for the GPT-5.6 family", async () => {
-    responses.push(modelsResponse(["gpt-5.6-sol", "gpt-5.6-terra"]))
+  test("advertises configurable context windows for Sol, Terra, and Luna", async () => {
+    responses.push(modelsResponse(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6"]))
 
     const models = (await listModels("profile-1", true)).models
 
-    expect(models.map((model) => model.id)).toEqual([
-      "gpt-5.6-sol",
-      "gpt-5.6-sol-1m",
-      "gpt-5.6-terra",
-      "gpt-5.6-terra-1m",
-    ])
-    expect(models[1]).toMatchObject({ contextWindow: 1_000_000, autoCompactTokenLimit: 900_000 })
-    expect(models[3]).toMatchObject({ contextWindow: 1_000_000, autoCompactTokenLimit: 900_000 })
+    expect(models.map((model) => model.id)).toEqual(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6"])
+    expect(models[0]?.aliases).toEqual([{ id: "gpt-5.6-sol-1m", contextWindow: 1_000_000 }])
+    expect(models[0]?.contextWindows).toEqual([260_000, 400_000, 600_000, 800_000, 1_000_000])
+    expect(models[1]?.contextWindows).toEqual([260_000, 400_000, 600_000, 800_000, 1_000_000])
+    expect(models[2]?.contextWindows).toEqual([260_000, 400_000, 600_000, 800_000, 1_000_000])
+    expect(models[3]?.contextWindows).toBeUndefined()
+  })
+
+  test("resolves legacy large-context IDs without listing them", async () => {
+    responses.push(modelsResponse(["gpt-5.6"]))
+
+    const catalog = await modelCatalog(provider, "profile-legacy-context", true)
+    const model = await findModel(provider, "profile-legacy-context", "gpt-5.6-1m")
+
+    expect(catalog.models.map((entry) => entry.id)).toEqual(["gpt-5.6"])
+    expect(model).toMatchObject({ id: "gpt-5.6", contextWindow: 1_000_000 })
+    expect(model?.contextWindows).toBeUndefined()
+    clearModelCatalog("profile-legacy-context")
   })
 
   test("advertises model-specific reasoning ranges", async () => {
@@ -100,15 +125,15 @@ describe("OpenAI model catalog", () => {
       options: ["none", "low", "medium", "high", "xhigh", "max"],
       default: "medium",
     })
-    expect(models[2]?.thinking).toEqual({
+    expect(models[1]?.thinking).toEqual({
       options: ["none", "low", "medium", "high", "xhigh"],
       default: "medium",
     })
-    expect(models[3]?.thinking).toEqual({
+    expect(models[2]?.thinking).toEqual({
       options: ["none", "low", "medium", "high", "xhigh"],
       default: "none",
     })
-    expect(models[4]?.thinking).toEqual({ options: ["medium", "high", "xhigh"], default: "medium" })
+    expect(models[3]?.thinking).toEqual({ options: ["medium", "high", "xhigh"], default: "medium" })
   })
 
   test("reuses the profile cache when live discovery fails", async () => {
@@ -129,7 +154,10 @@ describe("OpenAI model catalog", () => {
     await listModels("profile-2", true)
     requests.length = 0
 
-    expect((await listModels("profile-1", false)).models.map((model) => model.id)).toEqual(["gpt-5.6", "gpt-5.6-1m"])
+    const first = await listModels("profile-1", false)
+    expect(first.models.map((model) => model.id)).toEqual(["gpt-5.6"])
+    expect(first.models[0]?.aliases).toEqual([{ id: "gpt-5.6-1m", contextWindow: 1_000_000 }])
+    expect(first.models[0]?.contextWindows).toBeUndefined()
     expect((await listModels("profile-2", false)).models.map((model) => model.id)).toEqual(["gpt-4.1"])
     expect(requests).toHaveLength(0)
   })

--- a/apps/cli/src/plugins/openai/api-models.ts
+++ b/apps/cli/src/plugins/openai/api-models.ts
@@ -7,7 +7,7 @@ import type { ModelCatalog, ModelInfo, ThinkingOptions } from "../../providers/t
 import { apiKey } from "./api-auth"
 import { openAiFetch, raiseForStatus } from "./api-client"
 import { contextWindowCap } from "./context-window"
-import { type LargeContextModel, withLargeContextVariant } from "./model-variants"
+import { type ConfigurableContextModel, withContextWindowOptions } from "./model-variants"
 
 const CACHE_VERSION = 1
 const DISCOVERY_TIMEOUT_MS = 15_000
@@ -71,20 +71,25 @@ function contextWindow(id: string): number {
   return contextWindowCap()
 }
 
-function modelInfo(id: string): LargeContextModel {
+function configurableContextWindow(id: string): boolean {
+  return /^gpt-5\.6-(?:sol|terra|luna)(?:-|$)/.test(id.toLowerCase())
+}
+
+function modelInfo(id: string): ConfigurableContextModel {
   const thinking = reasoning(id)
   return {
     id,
     name: id,
     contextWindow: contextWindow(id),
-    ...(id.toLowerCase().startsWith("gpt-5.6") ? { maxContextWindow: 1_000_000 } : {}),
+    ...(id.toLowerCase().startsWith("gpt-5.6") ? { legacyLargeContextWindow: 1_000_000 } : {}),
+    ...(configurableContextWindow(id) ? { maxContextWindow: 1_000_000 } : {}),
     inputModalities: ["text", "image"],
     ...(thinking ? { thinking } : {}),
   }
 }
 
 function modelInfos(ids: string[]): ModelInfo[] {
-  return withLargeContextVariant(ids.map(modelInfo))
+  return withContextWindowOptions(ids.map(modelInfo))
 }
 
 function parseModels(raw: unknown): string[] {

--- a/apps/cli/src/plugins/openai/api-transport.test.ts
+++ b/apps/cli/src/plugins/openai/api-transport.test.ts
@@ -150,7 +150,7 @@ describe("OpenAI Responses transport", () => {
     expect(sentBody()).not.toHaveProperty("tool_choice")
   })
 
-  test("sends the synthetic 1M Sol model as its underlying wire model", async () => {
+  test("sends a legacy 1M Sol model ID as its underlying wire model", async () => {
     responses.push(sse([{ type: "response.completed", response: {} }]))
 
     await collect(streamResponse("profile-1", request({ model: "gpt-5.6-sol-1m" })))

--- a/apps/cli/src/plugins/openai/chatgpt-models.test.ts
+++ b/apps/cli/src/plugins/openai/chatgpt-models.test.ts
@@ -40,17 +40,14 @@ beforeEach(() => {
   written = undefined
 })
 
-test("adds regular and fast 1M models to the ChatGPT catalog", async () => {
+test("adds context-window options to regular and fast ChatGPT models", async () => {
   const models = (await listModels("profile-1", false)).models
 
-  expect(models.map((model) => model.id)).toEqual([
-    "gpt-5.6-sol",
-    "gpt-5.6-sol-fast",
-    "gpt-5.6-sol-1m",
-    "gpt-5.6-sol-1m-fast",
-  ])
-  expect(models[2]).toMatchObject({ contextWindow: 872_000, autoCompactTokenLimit: 784_800 })
-  expect(models[3]).toMatchObject({ contextWindow: 872_000, autoCompactTokenLimit: 784_800 })
+  expect(models.map((model) => model.id)).toEqual(["gpt-5.6-sol", "gpt-5.6-sol-fast"])
+  expect(models[0]?.aliases).toEqual([{ id: "gpt-5.6-sol-1m", contextWindow: 872_000 }])
+  expect(models[1]?.aliases).toEqual([{ id: "gpt-5.6-sol-1m-fast", contextWindow: 872_000 }])
+  expect(models[0]?.contextWindows).toEqual([260_000, 400_000, 600_000, 800_000, 872_000])
+  expect(models[1]?.contextWindows).toEqual([260_000, 400_000, 600_000, 800_000, 872_000])
 })
 
 test("round-trips and caps an optional runtime auto-compaction limit", async () => {
@@ -71,9 +68,12 @@ test("round-trips and caps an optional runtime auto-compaction limit", async () 
   ]
 
   const runtime = await listModels("profile-runtime", true)
-  expect(runtime.models[0]).toMatchObject({ contextWindow: 260_000, autoCompactTokenLimit: 234_000 })
+  expect(runtime.models[0]).toMatchObject({
+    contextWindow: 260_000,
+    contextWindows: [260_000, 400_000, 600_000, 800_000, 872_000],
+    autoCompactTokenLimit: 234_000,
+  })
   expect(runtime.models[1]).toMatchObject({ id: "gpt-5.6-sol-fast", autoCompactTokenLimit: 234_000 })
-  expect(runtime.models[2]).toMatchObject({ contextWindow: 872_000, autoCompactTokenLimit: 234_000 })
   if (!isRecord(written) || !Array.isArray(written.models)) throw new Error("runtime catalog was not cached")
 
   cachedModels = written.models

--- a/apps/cli/src/plugins/openai/chatgpt-models.ts
+++ b/apps/cli/src/plugins/openai/chatgpt-models.ts
@@ -17,12 +17,12 @@ import {
 import { chatGptFetch } from "./chatgpt-client"
 import { PROVIDER_NAME } from "./chatgpt-oauth"
 import { contextWindowCap } from "./context-window"
-import { type LargeContextModel, resolveLargeContextModel, withLargeContextVariant } from "./model-variants"
+import { type ConfigurableContextModel, resolveLargeContextModel, withContextWindowOptions } from "./model-variants"
 
 const MODEL_CATALOG_COMPATIBILITY_VERSION = "1.0.0"
 const FAST_MODEL_SUFFIX = "-fast"
 
-interface ChatGptModel extends LargeContextModel {
+interface ChatGptModel extends ConfigurableContextModel {
   supportsFast: boolean
 }
 
@@ -224,13 +224,23 @@ function capped(models: ChatGptModel[]): ChatGptModel[] {
 }
 
 function withVariants(models: ChatGptModel[]): ModelInfo[] {
-  return models.flatMap(({ supportsFast, ...model }) =>
-    withLargeContextVariant([model]).flatMap((variant) =>
-      supportsFast
-        ? [variant, { ...variant, id: `${variant.id}${FAST_MODEL_SUFFIX}`, name: `${variant.name} - fast` }]
-        : [variant],
-    ),
-  )
+  return models.flatMap(({ supportsFast, ...model }) => {
+    const configured = withContextWindowOptions([model])[0]!
+    return supportsFast
+      ? [
+          configured,
+          {
+            ...configured,
+            id: `${configured.id}${FAST_MODEL_SUFFIX}`,
+            name: `${configured.name} - fast`,
+            aliases: configured.aliases?.map((alias) => ({
+              ...alias,
+              id: `${alias.id}${FAST_MODEL_SUFFIX}`,
+            })),
+          },
+        ]
+      : [configured]
+  })
 }
 
 async function refreshModels(profileId: string): Promise<ModelCatalog> {

--- a/apps/cli/src/plugins/openai/chatgpt-transport.test.ts
+++ b/apps/cli/src/plugins/openai/chatgpt-transport.test.ts
@@ -172,7 +172,7 @@ describe("ChatGPT transport", () => {
     })
   })
 
-  test("sends the synthetic 1M Sol model as its underlying wire model", async () => {
+  test("sends a legacy 1M Sol model ID as its underlying wire model", async () => {
     responses.push(sse([{ type: "response.completed", response: {} }]))
 
     await collect(streamResponse("test-profile", { ...request(), model: "gpt-5.6-sol-1m" }))
@@ -184,7 +184,7 @@ describe("ChatGPT transport", () => {
     expect(sent).not.toHaveProperty("service_tier")
   })
 
-  test("sends the synthetic fast 1M Sol model with priority service", async () => {
+  test("sends a legacy fast 1M Sol model ID with priority service", async () => {
     responses.push(sse([{ type: "response.completed", response: {} }]))
 
     await collect(streamResponse("test-profile", { ...request(), model: "gpt-5.6-sol-1m-fast" }))

--- a/apps/cli/src/plugins/openai/model-variants.test.ts
+++ b/apps/cli/src/plugins/openai/model-variants.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
-import { type LargeContextModel, resolveLargeContextModel, withLargeContextVariant } from "./model-variants"
+import { type ConfigurableContextModel, resolveLargeContextModel, withContextWindowOptions } from "./model-variants"
 
-const terra: LargeContextModel = {
+const terra: ConfigurableContextModel & { maxContextWindow: number } = {
   id: "gpt-5.6-terra",
   name: "GPT-5.6-Terra",
   contextWindow: 260_000,
@@ -12,32 +12,37 @@ const terra: LargeContextModel = {
 
 const { maxContextWindow, ...base } = terra
 
-test("adds a 1M picker model when the maximum context window exceeds the default", () => {
-  expect(withLargeContextVariant([terra])).toEqual([
-    base,
+test("adds context-window options from the model default through its maximum", () => {
+  expect(withContextWindowOptions([terra])).toEqual([
     {
       ...base,
-      id: "gpt-5.6-terra-1m",
-      name: "GPT-5.6-Terra - 1M context",
-      contextWindow: maxContextWindow,
-      autoCompactTokenLimit: 784_800,
+      aliases: [{ id: "gpt-5.6-terra-1m", contextWindow: maxContextWindow }],
+      contextWindows: [260_000, 400_000, 600_000, 800_000, maxContextWindow],
     },
   ])
 })
 
 test("keeps models without a larger maximum context window as-is", () => {
-  expect(withLargeContextVariant([base])).toEqual([base])
-  expect(withLargeContextVariant([{ ...terra, maxContextWindow: 260_000 }])).toEqual([base])
+  expect(withContextWindowOptions([base])).toEqual([base])
+  expect(withContextWindowOptions([{ ...terra, maxContextWindow: 260_000 }])).toEqual([base])
 })
 
-test("preserves a valid explicit limit on the large variant", () => {
-  expect(withLargeContextVariant([{ ...terra, autoCompactTokenLimit: 200_000 }])[1]).toMatchObject({
-    contextWindow: 872_000,
-    autoCompactTokenLimit: 200_000,
-  })
+test("preserves a legacy large-context alias without exposing context options", () => {
+  expect(withContextWindowOptions([{ ...base, legacyLargeContextWindow: 1_000_000 }])).toEqual([
+    {
+      ...base,
+      aliases: [{ id: "gpt-5.6-terra-1m", contextWindow: 1_000_000 }],
+    },
+  ])
 })
 
-test("maps only synthetic 1M models back to their wire model", () => {
+test("does not add presets below a model's default context window", () => {
+  expect(withContextWindowOptions([{ ...terra, contextWindow: 700_000 }])[0]?.contextWindows).toEqual([
+    700_000, 800_000, 872_000,
+  ])
+})
+
+test("maps legacy 1M model IDs back to their wire model", () => {
   expect(resolveLargeContextModel("gpt-5.6-terra-1m")).toBe("gpt-5.6-terra")
   expect(resolveLargeContextModel("gpt-5.6-sol")).toBe("gpt-5.6-sol")
 })

--- a/apps/cli/src/plugins/openai/model-variants.ts
+++ b/apps/cli/src/plugins/openai/model-variants.ts
@@ -1,28 +1,42 @@
-import { effectiveAutoCompactTokenLimit } from "../../agent/session/context-budget"
 import type { ModelInfo } from "../../providers/types"
 
-const LARGE_CONTEXT_SUFFIX = "-1m"
+const LEGACY_LARGE_CONTEXT_SUFFIX = "-1m"
 
-export interface LargeContextModel extends ModelInfo {
+export interface ConfigurableContextModel extends ModelInfo {
   maxContextWindow?: number
+  legacyLargeContextWindow?: number
 }
 
-export function withLargeContextVariant(models: LargeContextModel[]): ModelInfo[] {
-  return models.flatMap(({ maxContextWindow, ...model }) => {
-    if (maxContextWindow === undefined || maxContextWindow <= (model.contextWindow ?? 0)) return [model]
-    return [
-      model,
-      {
-        ...model,
-        id: `${model.id}${LARGE_CONTEXT_SUFFIX}`,
-        name: `${model.name} - 1M context`,
-        contextWindow: maxContextWindow,
-        autoCompactTokenLimit: effectiveAutoCompactTokenLimit(maxContextWindow, model.autoCompactTokenLimit),
-      },
-    ]
+function contextWindows(contextWindow: number | undefined, maxContextWindow: number | undefined): number[] | undefined {
+  if (contextWindow === undefined || maxContextWindow === undefined || maxContextWindow <= contextWindow)
+    return undefined
+  const options = [contextWindow, 400_000, 600_000, 800_000, maxContextWindow]
+    .filter((value) => value >= contextWindow && value <= maxContextWindow)
+    .filter((value, index, values) => values.indexOf(value) === index)
+    .sort((left, right) => left - right)
+  return options.length > 1 ? options : undefined
+}
+
+export function withContextWindowOptions(models: ConfigurableContextModel[]): ModelInfo[] {
+  return models.map(({ maxContextWindow, legacyLargeContextWindow, ...model }) => {
+    const options = contextWindows(model.contextWindow, maxContextWindow)
+    const legacyContextWindow = legacyLargeContextWindow ?? (options ? maxContextWindow : undefined)
+    if (options === undefined && legacyContextWindow === undefined) return model
+    return {
+      ...model,
+      ...(legacyContextWindow === undefined
+        ? {}
+        : {
+            aliases: [
+              ...(model.aliases ?? []),
+              { id: `${model.id}${LEGACY_LARGE_CONTEXT_SUFFIX}`, contextWindow: legacyContextWindow },
+            ],
+          }),
+      ...(options === undefined ? {} : { contextWindows: options }),
+    }
   })
 }
 
 export function resolveLargeContextModel(model: string): string {
-  return model.endsWith(LARGE_CONTEXT_SUFFIX) ? model.slice(0, -LARGE_CONTEXT_SUFFIX.length) : model
+  return model.endsWith(LEGACY_LARGE_CONTEXT_SUFFIX) ? model.slice(0, -LEGACY_LARGE_CONTEXT_SUFFIX.length) : model
 }

--- a/apps/cli/src/plugins/tui/controllers/agent-events.ts
+++ b/apps/cli/src/plugins/tui/controllers/agent-events.ts
@@ -244,6 +244,9 @@ export class AgentEventController {
           text: event.profile ? `model: ${event.model} · ${event.provider}` : `disconnected: ${event.provider}`,
         })
         break
+      case "context_window_changed":
+        this.trackContextWindow()
+        break
       case "thinking_changed":
         statusBar.setThinking(event.thinking)
         break

--- a/apps/cli/src/plugins/tui/controllers/attention.ts
+++ b/apps/cli/src/plugins/tui/controllers/attention.ts
@@ -86,6 +86,7 @@ export class AttentionController {
       case "workspace_changed":
       case "mode_changed":
       case "model_changed":
+      case "context_window_changed":
       case "thinking_changed":
       case "user_message":
       case "conversation_rewound":

--- a/apps/cli/src/profiler/profiler.ts
+++ b/apps/cli/src/profiler/profiler.ts
@@ -58,6 +58,7 @@ type AnonymousAgentEvent =
   | { type: "state_changed"; state: Extract<AgentEvent, { type: "state_changed" }>["state"] }
   | { type: "mode_changed"; mode: string }
   | { type: "model_changed"; provider: string; profile?: string; model: string }
+  | { type: "context_window_changed" }
   | { type: "thinking_changed"; thinking?: ThinkingEffort }
   | { type: "user_message"; imageCount: number }
   | { type: "conversation_rewound"; removedMessages: number; fileCount: number }
@@ -314,6 +315,7 @@ function anonymousAgentEvent(event: AgentEvent): AnonymousAgentEvent | undefined
         mode: label("mode", event.mode),
       }
     case "session_replay_finished":
+    case "context_window_changed":
     case "session_title_changed":
     case "workspace_changed":
     case "elicitation_resolved":

--- a/apps/cli/src/providers/catalog.test.ts
+++ b/apps/cli/src/providers/catalog.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { clearModelCatalog, modelCatalog } from "./catalog"
+import { clearModelCatalog, findModel, modelCatalog } from "./catalog"
 import type { ModelCatalog, Provider } from "./types"
 
 function catalog(model: string, source: ModelCatalog["source"]): ModelCatalog {
@@ -55,6 +55,27 @@ test("keeps the previous catalog with a warning after a failed refresh", async (
   expect(result.models[0]?.id).toBe("model-a")
   expect(result.warning).toContain("model refresh failed: offline")
   clearModelCatalog("profile-1")
+})
+
+test("accepts ordered context-window options beginning at the model default", async () => {
+  const provider = fakeProvider("context-options", async () => ({
+    models: [
+      {
+        id: "model-a",
+        name: "model-a",
+        aliases: [{ id: "model-a-large", contextWindow: 600_000 }],
+        contextWindow: 260_000,
+        contextWindows: [260_000, 400_000, 600_000],
+        inputModalities: ["text"],
+      },
+    ],
+    source: "runtime",
+  }))
+
+  const result = await modelCatalog(provider, "profile-context-options")
+  expect(result.models[0]?.contextWindows).toEqual([260_000, 400_000, 600_000])
+  expect((await findModel(provider, "profile-context-options", "model-a-large"))?.contextWindow).toBe(600_000)
+  clearModelCatalog("profile-context-options")
 })
 
 test("rejects invalid internal auto-compaction limits", async () => {

--- a/apps/cli/src/providers/catalog.ts
+++ b/apps/cli/src/providers/catalog.ts
@@ -1,10 +1,12 @@
 import { listProfiles, type ProviderProfile } from "../config/credentials"
+import { settings } from "../config/settings"
 import { describeError } from "../lib/error"
 import { asNumber, asString, isRecord } from "../lib/json"
 import { getProvider, listProviders } from "./registry"
 import {
   isThinkingEffort,
   type ModelCatalog,
+  type ModelAlias,
   type ModelCatalogSource,
   type ModelInfo,
   type ModelInputModality,
@@ -107,6 +109,68 @@ function validateThinking(provider: Provider, model: string, raw: unknown): Thin
   return { options, default: preferred }
 }
 
+function validateContextWindows(
+  provider: Provider,
+  model: string,
+  contextWindow: number | undefined,
+  raw: unknown,
+): number[] | undefined {
+  if (raw === undefined) return undefined
+  if (!Array.isArray(raw) || raw.length < 2 || contextWindow === undefined) {
+    throw new Error(`${provider.name} returned invalid context-window options for ${model}`)
+  }
+  const options: number[] = []
+  for (const entry of raw) {
+    const option = asNumber(entry)
+    if (option === undefined || !Number.isInteger(option) || option <= 0) {
+      throw new Error(`${provider.name} returned invalid context-window options for ${model}`)
+    }
+    options.push(option)
+  }
+  if (
+    new Set(options).size !== options.length ||
+    options[0] !== contextWindow ||
+    options.some((entry, index) => index > 0 && entry <= options[index - 1]!)
+  ) {
+    throw new Error(`${provider.name} returned invalid context-window options for ${model}`)
+  }
+  return options
+}
+
+function validateModelAliases(
+  provider: Provider,
+  model: string,
+  contextWindows: number[] | undefined,
+  raw: unknown,
+): ModelAlias[] | undefined {
+  if (raw === undefined) return undefined
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error(`${provider.name} returned invalid aliases for ${model}`)
+  }
+  const aliases: ModelAlias[] = []
+  for (const entry of raw) {
+    if (!isRecord(entry)) throw new Error(`${provider.name} returned invalid aliases for ${model}`)
+    const id = asString(entry.id)?.trim()
+    const contextWindow = entry.contextWindow === undefined ? undefined : asNumber(entry.contextWindow)
+    if (
+      !id ||
+      id === model ||
+      (entry.contextWindow !== undefined &&
+        (contextWindow === undefined ||
+          !Number.isInteger(contextWindow) ||
+          contextWindow <= 0 ||
+          (contextWindows !== undefined && !contextWindows.includes(contextWindow))))
+    ) {
+      throw new Error(`${provider.name} returned invalid aliases for ${model}`)
+    }
+    aliases.push({ id, ...(contextWindow === undefined ? {} : { contextWindow }) })
+  }
+  if (new Set(aliases.map((alias) => alias.id)).size !== aliases.length) {
+    throw new Error(`${provider.name} returned invalid aliases for ${model}`)
+  }
+  return aliases
+}
+
 function validateModel(provider: Provider, raw: unknown): ModelInfo {
   if (!isRecord(raw)) throw new Error(`${provider.name} returned an invalid model`)
   const id = asString(raw.id)?.trim()
@@ -117,6 +181,7 @@ function validateModel(provider: Provider, raw: unknown): ModelInfo {
   if (raw.contextWindow !== undefined && (!contextWindow || !Number.isInteger(contextWindow) || contextWindow <= 0)) {
     throw new Error(`${provider.name} returned an invalid context window for ${id}`)
   }
+  const contextWindows = validateContextWindows(provider, id, contextWindow, raw.contextWindows)
   const autoCompactTokenLimit =
     raw.autoCompactTokenLimit === undefined ? undefined : asNumber(raw.autoCompactTokenLimit)
   if (
@@ -132,7 +197,9 @@ function validateModel(provider: Provider, raw: unknown): ModelInfo {
   return {
     id,
     name,
+    aliases: validateModelAliases(provider, id, contextWindows, raw.aliases),
     contextWindow,
+    contextWindows,
     autoCompactTokenLimit,
     inputModalities: validateModalities(provider, id, raw.inputModalities),
     thinking: validateThinking(provider, id, raw.thinking),
@@ -150,8 +217,10 @@ function validateCatalog(provider: Provider, raw: unknown): ModelCatalog {
   const models = raw.models.map((model) => validateModel(provider, model))
   const ids = new Set<string>()
   for (const model of models) {
-    if (ids.has(model.id)) throw new Error(`${provider.name} returned duplicate model ${model.id}`)
-    ids.add(model.id)
+    for (const id of [model.id, ...(model.aliases?.map((alias) => alias.id) ?? [])]) {
+      if (ids.has(id)) throw new Error(`${provider.name} returned duplicate model or alias ${id}`)
+      ids.add(id)
+    }
   }
   if (models.length === 0 && !warning) return { models, source, warning: `${provider.name} returned no models` }
   return { models, source, ...(warning ? { warning } : {}) }
@@ -210,6 +279,12 @@ export async function refreshModelCatalogs(): Promise<void> {
   )
 }
 
+function configuredContextWindow(provider: Provider, model: ModelInfo, fallback = model.contextWindow): ModelInfo {
+  const configured = settings().contextWindows[provider.id]?.[model.id]
+  const contextWindow = model.contextWindows?.includes(configured ?? 0) ? configured : fallback
+  return contextWindow === model.contextWindow ? model : { ...model, contextWindow }
+}
+
 export async function contextWindow(provider: Provider, profileId: string, model: string): Promise<number | undefined> {
   return (await findModel(provider, profileId, model))?.contextWindow
 }
@@ -221,7 +296,13 @@ export async function findModel(
   refresh = false,
 ): Promise<ModelInfo | undefined> {
   const catalog = await modelCatalog(provider, profileId, refresh)
-  return catalog.models.find((info) => info.id === model)
+  const found = catalog.models.find((info) => info.id === model)
+  if (found) return configuredContextWindow(provider, found)
+  for (const candidate of catalog.models) {
+    const alias = candidate.aliases?.find((entry) => entry.id === model)
+    if (alias) return configuredContextWindow(provider, candidate, alias.contextWindow)
+  }
+  return undefined
 }
 
 export function modelSummary(model: ModelInfo, listReasoning = false): string {
@@ -240,7 +321,12 @@ export async function listModelChoices(refresh = false): Promise<ModelChoices> {
       try {
         const catalog = await modelCatalog(provider, profile.id, refresh)
         return {
-          choices: catalog.models.map((model) => ({ provider, profile, model, source: catalog.source })),
+          choices: catalog.models.map((model) => ({
+            provider,
+            profile,
+            model: configuredContextWindow(provider, model),
+            source: catalog.source,
+          })),
           notices: catalog.warning ? [{ provider, profile, message: catalog.warning }] : [],
         }
       } catch (error) {

--- a/apps/cli/src/providers/commands.test.ts
+++ b/apps/cli/src/providers/commands.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test"
+import { getCommand } from "../commands/registry"
+import type { CommandContext, SelectRequest } from "../commands/types"
+import { loadSettings, settings } from "../config/settings"
+import { setupAgentSessionTests } from "../agent/session/test-support"
+import type { ModelCatalog, Provider, StreamEvent, StreamRequest } from "./types"
+import { registerProviderCommands } from "./commands"
+
+class BlockingProvider implements Provider {
+  readonly id = "context-window-command"
+  readonly name = "Context window command"
+  readonly aliases: string[] = []
+  readonly capabilities = { imageInput: false }
+
+  async listModels(): Promise<ModelCatalog> {
+    return {
+      models: [
+        {
+          id: "test-model",
+          name: "Test model",
+          contextWindow: 260_000,
+          contextWindows: [260_000, 400_000],
+          inputModalities: ["text"],
+        },
+      ],
+      source: "bundled",
+    }
+  }
+
+  async defaultModel(): Promise<string> {
+    return "test-model"
+  }
+
+  async *stream(_profileId: string, request: StreamRequest): AsyncGenerator<StreamEvent> {
+    await new Promise<void>((resolve) => {
+      if (!request.signal || request.signal.aborted) {
+        resolve()
+        return
+      }
+      request.signal.addEventListener("abort", () => resolve(), { once: true })
+    })
+    yield { type: "done" }
+  }
+}
+
+registerProviderCommands()
+
+test("does not save a context window when a turn starts while selection is pending", async () => {
+  const harness = await setupAgentSessionTests("context-window-command-")
+  try {
+    await loadSettings()
+    const session = harness.createSession(new BlockingProvider())
+    let contextWindowChanges = 0
+    const unsubscribe = session.subscribe((event) => {
+      if (event.type === "context_window_changed") contextWindowChanges += 1
+    })
+    try {
+      const printed: string[] = []
+      const context = {
+        session,
+        print(line: string) {
+          printed.push(line)
+        },
+        busy() {},
+        async select<T>(request: SelectRequest<T>): Promise<T | undefined> {
+          expect(session.send({ text: "start turn", images: [] })).toBeTrue()
+          return request.options.at(-1)?.value
+        },
+        restore() {},
+        async ask(): Promise<string | undefined> {
+          return undefined
+        },
+        async askSecret(): Promise<string | undefined> {
+          return undefined
+        },
+      } satisfies CommandContext
+      const command = getCommand("context-window")
+      if (!command) throw new Error("context-window command was not registered")
+
+      await command.run([], context)
+
+      expect(settings().contextWindows).toEqual({})
+      expect(contextWindowChanges).toBe(0)
+      expect(printed).toEqual(["cannot change context window while a turn is running"])
+    } finally {
+      unsubscribe()
+      session.interrupt()
+    }
+  } finally {
+    await harness.cleanup()
+  }
+})

--- a/apps/cli/src/providers/commands.ts
+++ b/apps/cli/src/providers/commands.ts
@@ -273,6 +273,18 @@ const contextWindowCommand: Command = {
       })),
     })
     if (selected === undefined || selected === modelInfo.contextWindow) return
+    if (ctx.session.currentState !== "idle") {
+      ctx.print("cannot change context window while a turn is running")
+      return
+    }
+    if (
+      ctx.session.currentProvider.id !== provider.id ||
+      ctx.session.currentProfileId !== profileId ||
+      ctx.session.currentModel !== model
+    ) {
+      ctx.print("active model changed; run /context-window again")
+      return
+    }
     await saveContextWindow(provider, modelInfo.id, selected)
     ctx.session.contextWindowChanged()
   },

--- a/apps/cli/src/providers/commands.ts
+++ b/apps/cli/src/providers/commands.ts
@@ -9,10 +9,12 @@ import {
   renameProfile,
   type ProviderProfile,
 } from "../config/credentials"
+import { saveContextWindow } from "../config/context-window"
 import { saveSettings, settings } from "../config/settings"
 import { resolveThinking, saveThinking } from "../config/thinking"
 import {
   clearModelCatalog,
+  findModel,
   listConnectTargets,
   listModelChoices,
   modelCatalog,
@@ -235,6 +237,47 @@ const logoutCommand: Command = {
   },
 }
 
+function contextWindowLabel(tokens: number): string {
+  if (tokens === 1_000_000) return "1M"
+  return `${Math.round(tokens / 1_000)}K`
+}
+
+const contextWindowCommand: Command = {
+  name: "context-window",
+  describe: "choose the context window for the current model",
+  async run(args, ctx) {
+    if (args.length > 0) throw new Error("usage: /context-window")
+    if (ctx.session.currentState !== "idle") {
+      ctx.print("cannot change context window while a turn is running")
+      return
+    }
+
+    const profileId = ctx.session.currentProfileId
+    if (!profileId) throw new Error("no active profile; run /connect first")
+    const provider = ctx.session.currentProvider
+    const model = ctx.session.currentModel
+    const modelInfo = await findModel(provider, profileId, model)
+    if (!modelInfo?.contextWindows) {
+      ctx.print(`${model} does not support configurable context windows`)
+      return
+    }
+
+    const selected = await ctx.select({
+      options: modelInfo.contextWindows.map((contextWindow, index, options) => ({
+        label: contextWindowLabel(contextWindow),
+        detail:
+          index === 0 ? "model default" : index === options.length - 1 ? "model maximum" : "custom context window",
+        note: contextWindow === modelInfo.contextWindow ? "current" : undefined,
+        active: contextWindow === modelInfo.contextWindow,
+        value: contextWindow,
+      })),
+    })
+    if (selected === undefined || selected === modelInfo.contextWindow) return
+    await saveContextWindow(provider, modelInfo.id, selected)
+    ctx.session.contextWindowChanged()
+  },
+}
+
 const thinkingLabels: Record<ThinkingEffort, string> = {
   none: "Off",
   low: "Low",
@@ -257,8 +300,7 @@ const thinkingCommand: Command = {
     if (!profileId) throw new Error("no active profile; run /connect first")
     const provider = ctx.session.currentProvider
     const model = ctx.session.currentModel
-    const catalog = await modelCatalog(provider, profileId)
-    const available = catalog.models.find((info) => info.id === model)?.thinking
+    const available = (await findModel(provider, profileId, model))?.thinking
     if (!available) {
       ctx.print(`${model} does not support configurable thinking`)
       return
@@ -287,5 +329,6 @@ export function registerProviderCommands(): void {
   registerCommand(modelCommand)
   registerCommand(profilesCommand)
   registerCommand(logoutCommand)
+  registerCommand(contextWindowCommand)
   registerCommand(thinkingCommand)
 }

--- a/apps/cli/src/providers/types.ts
+++ b/apps/cli/src/providers/types.ts
@@ -53,10 +53,17 @@ export type ProviderOutputItem = AssistantMessageItem | ReasoningItem | ToolCall
 
 export type ConversationItem = UserMessageItem | ProviderOutputItem | ToolResultItem
 
+export interface ModelAlias {
+  id: string
+  contextWindow?: number
+}
+
 export interface ModelInfo {
   id: string
   name: string
+  aliases?: ModelAlias[]
   contextWindow?: number
+  contextWindows?: number[]
   autoCompactTokenLimit?: number
   inputModalities: ModelInputModality[]
   thinking?: ThinkingOptions

--- a/apps/cli/src/secrets/data.ts
+++ b/apps/cli/src/secrets/data.ts
@@ -231,6 +231,8 @@ export function redactAgentEvent(event: AgentEvent): AgentEvent {
       return { ...event, title: redactText(event.title) }
     case "workspace_changed":
       return { ...event, cwd: redactPath(event.cwd), previous: redactPath(event.previous) }
+    case "context_window_changed":
+      return event
     case "model_changed":
       return {
         ...event,

--- a/apps/cli/src/sessions/export.ts
+++ b/apps/cli/src/sessions/export.ts
@@ -129,6 +129,7 @@ function renderEvent(event: AgentEvent): string | undefined {
       return event.output ? `## Structured output\n\n${indented(JSON.stringify(event.output, null, 2))}` : undefined
     case "session_started":
     case "session_replay_finished":
+    case "context_window_changed":
     case "state_changed":
     case "tool_call_updated":
     case "hook_started":

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -93,7 +93,7 @@ Context-window preferences use the same provider and model keys:
 }
 ```
 
-Use `/context-window` to save this preference for the current model. The command is available when a provider advertises multiple windows. A saved value that is no longer offered is ignored in favor of the model default.
+Use `/context-window` to save this preference for the current model. The command is available when a provider advertises multiple windows. Provider entries must be objects, and each model value must be a positive integer. A saved value that is no longer offered is ignored in favor of the model default.
 
 ## Combined example
 

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -19,27 +19,28 @@ Both files are optional and must contain a JSON object when present. Objects mer
 
 A project-root `.mcp.json` is a discovery source rather than a third configuration layer. On interactive launch, Xal can use its new MCP server names for the current process or copy them into either configuration file. Existing Xal server names are not overwritten. See [Project `.mcp.json` discovery](/docs/integrations#project-mcpjson-discovery) for the accepted schema and launch choices.
 
-Commands that save model, thinking, or TUI display preferences write the user file. Xal then recomputes the effective configuration, and any project override remains active. Importing discovered MCP servers and deleting servers from `/mcp` are source-aware exceptions: project choices update the project file, global choices update the user file, and deletion updates the file that supplied the effective server.
+Commands that save model, thinking, context-window, or TUI display preferences write the user file. Xal then recomputes the effective configuration, and any project override remains active. Importing discovered MCP servers and deleting servers from `/mcp` are source-aware exceptions: project choices update the project file, global choices update the user file, and deletion updates the file that supplied the effective server.
 
 Global memory is stored at `<app-home>/MEMORY.md`. On Unix, Xal creates it with mode `0600` and rejects broader permissions. Windows does not expose an equivalent mode through the filesystem API, so Xal relies on the inherited ACL of `<app-home>`. If the app home is overridden on Windows, its directory must be private to the current user.
 
 ## Top-level options
 
-| Option         | Type       | Default                  | Details                                                                     |
-| -------------- | ---------- | ------------------------ | --------------------------------------------------------------------------- |
-| `plugins`      | `string[]` | `[]`                     | Additional modules described in [Plugins and hooks](/docs/plugins).         |
-| `provider`     | `string`   | Last registered provider | Provider ID or alias used for new sessions.                                 |
-| `profile`      | `string`   | Selected connection      | Internal ID of the named provider profile used for new sessions.            |
-| `model`        | `string`   | Provider default         | Model ID used for new sessions.                                             |
-| `ui`           | `string`   | `"tui"`                  | UI ID started when Xal runs without a command.                              |
-| `mode`         | `string`   | `"normal"`               | Permission mode used for new TUI and headless sessions.                     |
-| `permissions`  | `object`   | `{}`                     | Global rules described in [Permissions and security](/docs/permissions).    |
-| `modes`        | `object`   | `{}`                     | [Custom permission modes](/docs/permissions#custom-modes) keyed by name.    |
-| `goal`         | `object`   | `{}`                     | Evaluator models described in [Goals](/docs/goals).                         |
-| `redaction`    | `object`   | `{}`                     | [Sensitive values](/docs/permissions#redaction) to redact.                  |
-| `agents`       | `object`   | `{}`                     | Limits described in [Background work](/docs/background-work#configuration). |
-| `pluginConfig` | `object`   | `{}`                     | Configuration keyed by plugin name.                                         |
-| `thinking`     | `object`   | `{}`                     | Thinking effort keyed by provider ID and model ID.                          |
+| Option           | Type       | Default                  | Details                                                                     |
+| ---------------- | ---------- | ------------------------ | --------------------------------------------------------------------------- |
+| `plugins`        | `string[]` | `[]`                     | Additional modules described in [Plugins and hooks](/docs/plugins).         |
+| `provider`       | `string`   | Last registered provider | Provider ID or alias used for new sessions.                                 |
+| `profile`        | `string`   | Selected connection      | Internal ID of the named provider profile used for new sessions.            |
+| `model`          | `string`   | Provider default         | Model ID used for new sessions.                                             |
+| `ui`             | `string`   | `"tui"`                  | UI ID started when Xal runs without a command.                              |
+| `mode`           | `string`   | `"normal"`               | Permission mode used for new TUI and headless sessions.                     |
+| `permissions`    | `object`   | `{}`                     | Global rules described in [Permissions and security](/docs/permissions).    |
+| `modes`          | `object`   | `{}`                     | [Custom permission modes](/docs/permissions#custom-modes) keyed by name.    |
+| `goal`           | `object`   | `{}`                     | Evaluator models described in [Goals](/docs/goals).                         |
+| `redaction`      | `object`   | `{}`                     | [Sensitive values](/docs/permissions#redaction) to redact.                  |
+| `agents`         | `object`   | `{}`                     | Limits described in [Background work](/docs/background-work#configuration). |
+| `pluginConfig`   | `object`   | `{}`                     | Configuration keyed by plugin name.                                         |
+| `thinking`       | `object`   | `{}`                     | Thinking effort keyed by provider ID and model ID.                          |
+| `contextWindows` | `object`   | `{}`                     | Context-window choices keyed by provider ID and model ID.                   |
 
 The `profile` value is managed by `/connect` and `/model`. Profile names remain user-facing and may be renamed without changing this ID.
 
@@ -74,6 +75,25 @@ Thinking preferences use this shape:
 ```
 
 Supported effort values are `none`, `low`, `medium`, `high`, `xhigh`, and `max`. Each provider and model may support only a subset. An unavailable saved effort is ignored in favor of that model's default.
+
+## Context windows
+
+Context-window preferences use the same provider and model keys:
+
+```json
+{
+  "contextWindows": {
+    "openai-chatgpt": {
+      "gpt-5.6-terra": 600000
+    },
+    "openai": {
+      "gpt-5.6-sol": 1000000
+    }
+  }
+}
+```
+
+Use `/context-window` to save this preference for the current model. The command is available when a provider advertises multiple windows. A saved value that is no longer offered is ignored in favor of the model default.
 
 ## Combined example
 
@@ -110,6 +130,11 @@ Every option is optional. This example shows how the top-level sections fit toge
   "thinking": {
     "openai-chatgpt": {
       "gpt-5.6-terra": "high"
+    }
+  },
+  "contextWindows": {
+    "openai-chatgpt": {
+      "gpt-5.6-terra": 600000
     }
   },
   "pluginConfig": {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -106,7 +106,7 @@ The `openai` plugin registers both OpenAI providers: `openai` for OpenAI Platfor
 | `contextWindow` | Positive integer | `260000`       | Context-window cap for ChatGPT and assumed context window for OpenAI models. |
 | `clientName`    | string           | `codex_cli_rs` | Client name used in both providers' request user agent.                      |
 
-When a model advertises a maximum context window larger than its default — the whole GPT-5.6 family (Sol, Terra, and Luna) does — `/model` also lists a synthetic `-1m` variant, such as `gpt-5.6-sol-1m`. ChatGPT profiles that advertise fast service also list a `-1m-fast` variant. Both synthetic models use the same underlying wire model with the advertised maximum context budget (872,000 tokens on ChatGPT profiles, one million on the OpenAI API) and start automatic compaction at ninety percent of it unless the provider advertises a lower limit; the fast variant additionally requests priority service. Choose them only when your OpenAI access supports the documented larger context window. The ordinary entries keep Xal's tuned default cap.
+GPT-5.6 Sol, Terra, and Luna support configurable context windows. Select one of those models, then run `/context-window` to choose its default 2xxK window, 400K, 600K, 800K, or the provider-advertised maximum. The maximum is 872K for ChatGPT profiles and 1M for OpenAI API profiles. Xal remembers the choice separately for each provider and model, uses it for context tracking and hard request admission, and starts automatic compaction at ninety percent unless the provider advertises a lower limit. Other providers can expose the same command by advertising multiple context-window options for a model.
 
 ### OpenAI API
 


### PR DESCRIPTION
Add persistent per-model context-window selection through `/context-window`, expose validated provider options, and refresh TUI context tracking when settings change. Replace synthetic 1M model variants with backward-compatible aliases and document the new configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/context-window` for selecting supported context sizes per model.
  * Context-window preferences persist across sessions, with fallback when unavailable.
  * OpenAI GPT-5.6 Sol, Terra, and Luna models support configurable context windows and aliases.
  * The interface refreshes context-window information when settings change.

* **Bug Fixes**
  * Context-window updates no longer disrupt agent activity, session history, or output.
  * Improved validation for context-window settings.

* **Documentation**
  * Added configuration and provider guidance for context-window settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->