### PR TITLE
fix(agent): disable default task timeout

### DIFF
--- a/apps/cli/src/agent/task/spawn.ts
+++ b/apps/cli/src/agent/task/spawn.ts
@@ -188,7 +188,7 @@ async function runTask(
     acquired = true
     if (controller.signal.aborted) throw new Error("task cancelled before it started")
     startAgentJob(job)
-    scheduleDeadline()
+    if (job.timeoutMs > 0) scheduleDeadline()
 
     worktree =
       item.isolation === "worktree"

--- a/apps/cli/src/background/jobs.test.ts
+++ b/apps/cli/src/background/jobs.test.ts
@@ -11,6 +11,7 @@ import {
   createAgentJob,
   createProcessJob,
   drainOwnerDeliveries,
+  extendAgentBudget,
   finishAgentJob,
   finishProcessJob,
   getJob,
@@ -37,11 +38,11 @@ function processJob(prefix: string, ownerId = "background-jobs-test"): Backgroun
   return job
 }
 
-function agentJob(prefix: string): BackgroundAgentJob {
+function agentJob(prefix: string, timeoutMs = 60_000): BackgroundAgentJob {
   const job = createAgentJob(prefix, {
     ownerId: "background-jobs-test",
     task: prefix,
-    timeoutMs: 60_000,
+    timeoutMs,
     maxTurns: 24,
     stop: () => {},
     send: () => ({ status: "guided" }),
@@ -155,6 +156,15 @@ test("distinguishes pending-question answers from ordinary guidance", () => {
   expect(job.transcript.text()).toContain("Parent guidance")
 })
 
+test("does not create a deadline or shorten waits when the runtime limit is disabled", () => {
+  const job = agentJob("test-agent-without-runtime-limit", 0)
+
+  startAgentJob(job)
+
+  expect(job.deadlineAt).toBeUndefined()
+  expect(agentSupervisionWaitMs(job, 60_000, 1_000_000)).toBe(60_000)
+})
+
 test("reserves a supervision window before a queued agent starts", () => {
   const job = agentJob("test-queued-agent-supervision-window")
 
@@ -180,6 +190,20 @@ test("uses at most a one-minute supervision window for longer agent budgets", ()
   job.deadlineAt = now + 9 * 60_000
 
   expect(agentSupervisionWaitMs(job, 10 * 60_000, now)).toBe(8 * 60_000)
+})
+
+test("extends only the soft turn budget", () => {
+  const job = agentJob("test-agent-turn-extension")
+  startAgentJob(job)
+  const deadlineAt = job.deadlineAt
+
+  extendAgentBudget(job, 10, "parent")
+
+  expect(job.turnBudget).toBe(34)
+  expect(job.turnLimit).toBe(51)
+  expect(job.timeoutMs).toBe(60_000)
+  expect(job.deadlineAt).toBe(deadlineAt)
+  expect(job.transcript.text()).toContain("Parent extended budget by 10 turns")
 })
 
 test("redacts secrets split across process and agent output chunks", async () => {

--- a/apps/cli/src/background/jobs.ts
+++ b/apps/cli/src/background/jobs.ts
@@ -305,7 +305,7 @@ export function startAgentJob(job: BackgroundAgentJob): void {
   if (job.done) return
   job.phase = "running"
   job.runningAt = Date.now()
-  job.deadlineAt = Date.now() + job.timeoutMs
+  if (job.timeoutMs > 0) job.deadlineAt = Date.now() + job.timeoutMs
   job.lastActivityAt = Date.now()
   job.activity = "Initializing…"
   backgroundTasksChanged("lifecycle")
@@ -323,43 +323,14 @@ export function beginAgentStop(job: BackgroundAgentJob): void {
   backgroundTasksChanged("lifecycle")
 }
 
-export interface AgentBudgetExtension {
-  minutes: number
-  turns: number
-}
-
-export function extendAgentBudget(
-  job: BackgroundAgentJob,
-  extension: AgentBudgetExtension,
-  source: JobSendSource,
-): void {
+export function extendAgentBudget(job: BackgroundAgentJob, turns: number, source: JobSendSource): void {
   if (job.done) throw new Error(`${job.id} has already finished`)
   if (job.phase === "stopping") throw new Error(`${job.id} is already stopping`)
-  if (job.phase === "running" && job.deadlineAt !== undefined && job.deadlineAt <= Date.now()) {
-    throw new Error(`${job.id} has reached its deadline`)
-  }
   if (job.completedTurns >= job.turnLimit) throw new Error(`${job.id} has reached its turn limit`)
-  if (!Number.isSafeInteger(extension.minutes) || extension.minutes < 0) {
-    throw new Error("extension minutes must be a non-negative integer")
-  }
-  if (!Number.isSafeInteger(extension.turns) || extension.turns < 0) {
-    throw new Error("extension turns must be a non-negative integer")
-  }
-  if (extension.minutes === 0 && extension.turns === 0) throw new Error("the extension must add minutes or turns")
-  if (extension.minutes > 0) {
-    const additionalMs = extension.minutes * 60_000
-    job.timeoutMs += additionalMs
-    if (job.deadlineAt !== undefined) job.deadlineAt += additionalMs
-  }
-  if (extension.turns > 0) {
-    job.turnBudget += extension.turns
-    job.turnLimit = Math.ceil(job.turnBudget * 1.5)
-  }
-  const parts = [
-    extension.minutes > 0 ? `${extension.minutes}m runtime` : "",
-    extension.turns > 0 ? `${extension.turns} turns` : "",
-  ].filter(Boolean)
-  appendTranscript(job, `\n> ${source === "user" ? "User" : "Parent"} extended budget by ${parts.join(" and ")}\n`)
+  if (!Number.isSafeInteger(turns) || turns <= 0) throw new Error("extension turns must be a positive integer")
+  job.turnBudget += turns
+  job.turnLimit = Math.ceil(job.turnBudget * 1.5)
+  appendTranscript(job, `\n> ${source === "user" ? "User" : "Parent"} extended budget by ${turns} turns\n`)
   backgroundTasksChanged("lifecycle")
 }
 
@@ -712,6 +683,7 @@ export async function waitForProcessOutput(
 
 export function agentSupervisionWaitMs(job: BackgroundAgentJob, requestedMs: number, now = Date.now()): number {
   if (requestedMs <= 0) return Math.max(0, requestedMs)
+  if (job.timeoutMs <= 0) return requestedMs
   const supervisionMargin = Math.min(MAX_AGENT_SUPERVISION_MARGIN_MS, Math.floor(job.timeoutMs / 5))
   const untilCheckpoint =
     job.deadlineAt === undefined

--- a/apps/cli/src/background/tools.test.ts
+++ b/apps/cli/src/background/tools.test.ts
@@ -41,8 +41,8 @@ test("returns before the deadline with an actionable supervision checkpoint", as
   const output = await collectAgentOutput(job, 60, new AbortController().signal)
 
   expect(output).toContain("turn cycles 0/24")
-  expect(output).toContain("Supervision checkpoint reached before the task deadline")
-  expect(output).toContain("job_extend")
+  expect(output).toContain("Supervision checkpoint reached before the configured task deadline")
+  expect(output).not.toContain("job_extend")
   expect(job.delivery).toBe("none")
 })
 

--- a/apps/cli/src/background/tools.ts
+++ b/apps/cli/src/background/tools.ts
@@ -28,7 +28,6 @@ import { nativeToolRecord, nativeToolString } from "../native/tool-runtime"
 import type { SessionTool } from "../tools/types"
 
 const MAX_WAIT_S = 600
-const MAX_EXTENSION_MINUTES = 60
 const MAX_EXTENSION_TURNS = 100
 
 function jobOf(args: Record<string, unknown>, ownerId: string): BackgroundJob {
@@ -183,7 +182,7 @@ function nativeStatusOutput(id: string | undefined, ownerId: string): string {
 export const jobOutputTool: SessionTool = {
   name: "job_output",
   description:
-    "Collect a background job explicitly. For a process, returns new output and optionally waits for output or exit. Task-agent results normally deliver automatically. An explicit task-agent wait returns before its deadline with a supervision checkpoint, and collecting a finished report suppresses duplicate automatic delivery.",
+    "Collect a background job explicitly. For a process, returns new output and optionally waits for output or exit. Task-agent results normally deliver automatically. With a configured agent deadline, an explicit wait returns at a supervision checkpoint before it; collecting a finished report suppresses duplicate automatic delivery.",
   parameters: {
     type: "object",
     properties: {
@@ -271,7 +270,7 @@ export const jobKillTool: SessionTool = {
 export const jobStatusTool: SessionTool = {
   name: "job_status",
   description:
-    "Inspect one background job or list every job without consuming output. Includes processes, task agents, and schedules. Task-agent status includes queue state, current activity, idle and elapsed time, turn usage and limits, and its remaining deadline after it starts.",
+    "Inspect one background job or list every job without consuming output. Includes processes, task agents, and schedules. Task-agent status includes queue state, current activity, idle and elapsed time, turn usage and limits, and any configured remaining deadline.",
   parameters: {
     type: "object",
     properties: { id: idProperty },
@@ -293,17 +292,11 @@ export const jobStatusTool: SessionTool = {
 export const jobExtendTool: SessionTool = {
   name: "job_extend",
   description:
-    "Extend a running or queued task agent's execution budget by wall-clock minutes, turns, or both without restarting it. job_status reports the current remaining budget.",
+    "Extend a running or queued task agent's soft turn budget without restarting it. job_status reports the current turn usage and limits.",
   parameters: {
     type: "object",
     properties: {
       id: idProperty,
-      minutes: {
-        type: "integer",
-        minimum: 1,
-        maximum: MAX_EXTENSION_MINUTES,
-        description: `Wall-clock minutes to add; maximum ${MAX_EXTENSION_MINUTES} per call`,
-      },
       turns: {
         type: "integer",
         minimum: 1,
@@ -311,7 +304,7 @@ export const jobExtendTool: SessionTool = {
         description: `Soft-budget turns to add; maximum ${MAX_EXTENSION_TURNS} per call`,
       },
     },
-    required: ["id"],
+    required: ["id", "turns"],
     additionalProperties: false,
   },
   sessionAware: true,
@@ -327,26 +320,19 @@ export const jobExtendTool: SessionTool = {
   async execute(args, ctx) {
     const prepared = nativeToolRecord("job_extend_prepare", args)
     const id = asString(prepared.id)
-    const minutes = asNumber(prepared.minutes)
     const turns = asNumber(prepared.turns)
-    if (id === undefined || minutes === undefined || turns === undefined) {
-      throw new Error("native job_extend returned an invalid value")
-    }
+    if (id === undefined || turns === undefined) throw new Error("native job_extend returned an invalid value")
     const job = jobOf({ id }, ctx.session.id)
     if (job.kind !== "agent") throw new Error(`${job.id} is not a task agent`)
     if (job.done) throw new Error(`${job.id} has already finished (${jobStatus(job)})`)
-    extendAgentBudget(job, { minutes, turns }, "parent")
+    extendAgentBudget(job, turns, "parent")
     try {
       const finalized = nativeToolRecord("job_extend_finalize", {
         id: job.id,
-        minutes,
         turns,
         completedTurns: job.completedTurns,
         turnBudget: job.turnBudget,
         turnLimit: job.turnLimit,
-        timeoutMs: job.timeoutMs,
-        now: Date.now(),
-        ...(job.deadlineAt === undefined ? {} : { deadlineAt: job.deadlineAt }),
       })
       return { output: nativeToolString(finalized, "output", "job_extend") }
     } catch (error) {
@@ -360,7 +346,7 @@ export const jobExtendTool: SessionTool = {
 export const jobSendTool: SessionTool = {
   name: "job_send",
   description:
-    "Answer a running task agent's pending parent question, or send additional context or a correction when no question is pending. The message does not restart or extend the task deadline.",
+    "Answer a running task agent's pending parent question, or send additional context or a correction when no question is pending. The message does not restart the task or extend its limits.",
   parameters: {
     type: "object",
     properties: {

--- a/apps/cli/src/config/settings.test.ts
+++ b/apps/cli/src/config/settings.test.ts
@@ -104,7 +104,7 @@ test("trusted project settings override user settings with recursive object merg
       },
       modes: {},
       goal: { evaluatorModels: {} },
-      agents: { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 },
+      agents: { maxConcurrent: 4, timeoutMinutes: 0, maxTurns: 24 },
       redaction: {
         values: [],
         environment: ["MY_PROJECT_TOKEN"],
@@ -143,7 +143,7 @@ test("does not read malformed project settings until the project is trusted", as
       permissions: { allow: [], ask: [], deny: [] },
       modes: {},
       goal: { evaluatorModels: {} },
-      agents: { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 },
+      agents: { maxConcurrent: 4, timeoutMinutes: 0, maxTurns: 24 },
       redaction: { values: [], environment: [] },
       pluginConfig: {},
       thinking: {},
@@ -204,7 +204,7 @@ test("saves only user settings securely while retaining project overrides in mem
       permissions: { allow: [], ask: [], deny: [] },
       modes: {},
       goal: { evaluatorModels: {} },
-      agents: { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 },
+      agents: { maxConcurrent: 4, timeoutMinutes: 0, maxTurns: 24 },
       redaction: { values: [], environment: [] },
       pluginConfig: { userPlugin: { enabled: true } },
       thinking: {},
@@ -221,6 +221,18 @@ test("rejects permission and redaction settings that are not string arrays", asy
 
     await writeJson(join(home, "config.json"), { permissions: { deny: [42] } })
     await expect(loadSettings()).rejects.toThrow("permissions.deny must be an array of strings")
+  })
+})
+
+test("accepts a disabled task-agent runtime limit and rejects negative values", async () => {
+  await withSettingsEnvironment(async ({ home }) => {
+    const config = join(home, "config.json")
+    await writeJson(config, { agents: { timeoutMinutes: 0 } })
+
+    expect((await loadSettings()).agents.timeoutMinutes).toBe(0)
+
+    await writeJson(config, { agents: { timeoutMinutes: -1 } })
+    await expect(loadSettings()).rejects.toThrow("agents.timeoutMinutes must be an integer between 0 and 60")
   })
 })
 

--- a/apps/cli/src/config/settings.ts
+++ b/apps/cli/src/config/settings.ts
@@ -52,7 +52,7 @@ export interface Settings {
   contextWindows: Record<string, Record<string, number>>
 }
 
-const AGENT_DEFAULTS: AgentSettings = { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 }
+const AGENT_DEFAULTS: AgentSettings = { maxConcurrent: 4, timeoutMinutes: 0, maxTurns: 24 }
 
 let current: Settings = {
   plugins: [],
@@ -240,7 +240,7 @@ function parseSettings(raw: Record<string, unknown>): Settings {
         agents.timeoutMinutes,
         "agents.timeoutMinutes",
         AGENT_DEFAULTS.timeoutMinutes,
-        1,
+        0,
         60,
       ),
       maxTurns: strictBoundedInteger(agents.maxTurns, "agents.maxTurns", AGENT_DEFAULTS.maxTurns, 1, 100),

--- a/apps/cli/src/permissions/register.test.ts
+++ b/apps/cli/src/permissions/register.test.ts
@@ -31,7 +31,7 @@ test("makes the current writable mode override stale plan-mode context", () => {
     },
     goal: { evaluatorModels: {} },
     redaction: { values: [], environment: [] },
-    agents: { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 },
+    agents: { maxConcurrent: 4, timeoutMinutes: 0, maxTurns: 24 },
     pluginConfig: {},
     thinking: {},
     contextWindows: {},

--- a/apps/cli/src/plugins/discover.test.ts
+++ b/apps/cli/src/plugins/discover.test.ts
@@ -28,7 +28,7 @@ function settings(plugins: string[] = [], pluginConfig: Settings["pluginConfig"]
     modes: {},
     goal: { evaluatorModels: {} },
     redaction: { values: [], environment: [] },
-    agents: { maxConcurrent: 4, timeoutMinutes: 10, maxTurns: 24 },
+    agents: { maxConcurrent: 4, timeoutMinutes: 0, maxTurns: 24 },
     pluginConfig,
     thinking: {},
     contextWindows: {},

--- a/crates/xal-native/src/tool_runtime/job.rs
+++ b/crates/xal-native/src/tool_runtime/job.rs
@@ -181,16 +181,14 @@ fn agent_status(request: &Map<String, Value>) -> napi::Result<String> {
         String::new()
     } else if let Some(deadline) = request.get("deadlineAt").and_then(Value::as_i64) {
         format!(" · deadline in {}", duration(deadline - now))
+    } else if let Some(timeout) = request
+        .get("timeoutMs")
+        .and_then(Value::as_i64)
+        .filter(|timeout| *timeout > 0)
+    {
+        format!(" · runtime budget {}", duration(timeout))
     } else {
-        format!(
-            " · runtime budget {}",
-            duration(
-                request
-                    .get("timeoutMs")
-                    .and_then(Value::as_i64)
-                    .unwrap_or(0)
-            )
-        )
+        String::new()
     };
     let task = required_string(request, "task")?;
     Ok(format!(
@@ -204,7 +202,7 @@ pub(super) fn agent_output(value: &Value) -> napi::Result<Value> {
     if request.get("done").and_then(Value::as_bool) != Some(true) {
         let mut output = agent_status(request)?;
         if request.get("checkpoint").and_then(Value::as_bool) == Some(true) {
-            output.push_str("\nSupervision checkpoint reached before the task deadline. Use job_status, then job_extend to add time or job_kill to stop it before waiting again.");
+            output.push_str("\nSupervision checkpoint reached before the configured task deadline. Use job_status, then job_kill to stop it or wait again.");
         }
         return Ok(json!({ "output": output }));
     }
@@ -373,51 +371,17 @@ fn extension(value: Option<&Value>, field: &str, maximum: i64) -> napi::Result<i
 pub(super) fn job_extend_prepare(value: &Value) -> napi::Result<Value> {
     let request = object(value)?;
     let id = required_string(request, "id")?;
-    let minutes = extension(request.get("minutes"), "minutes", MAX_EXTENSION_MINUTES)?;
     let turns = extension(request.get("turns"), "turns", MAX_EXTENSION_TURNS)?;
-    if minutes == 0 && turns == 0 {
-        return Err(invalid("minutes or turns is required"));
+    if turns == 0 {
+        return Err(invalid("turns is required"));
     }
-    Ok(json!({ "id": id, "minutes": minutes, "turns": turns }))
+    Ok(json!({ "id": id, "turns": turns }))
 }
 
 pub(super) fn job_extend_finalize(value: &Value) -> napi::Result<Value> {
     let request = object(value)?;
     let id = required_string(request, "id")?;
-    let minutes = request.get("minutes").and_then(Value::as_i64).unwrap_or(0);
     let turns = request.get("turns").and_then(Value::as_i64).unwrap_or(0);
-    let added = [
-        if minutes > 0 {
-            format!("{minutes}m")
-        } else {
-            String::new()
-        },
-        if turns > 0 {
-            format!("{turns} turns")
-        } else {
-            String::new()
-        },
-    ]
-    .into_iter()
-    .filter(|part| !part.is_empty())
-    .collect::<Vec<_>>()
-    .join(" and ");
-    let now = request
-        .get("now")
-        .and_then(Value::as_i64)
-        .ok_or_else(|| invalid("now is required"))?;
-    let time = match request.get("deadlineAt").and_then(Value::as_i64) {
-        Some(deadline) => format!("{} until deadline", duration(deadline - now)),
-        None => format!(
-            "{} runtime when it starts",
-            duration(
-                request
-                    .get("timeoutMs")
-                    .and_then(Value::as_i64)
-                    .unwrap_or(0)
-            )
-        ),
-    };
     let completed = request
         .get("completedTurns")
         .and_then(Value::as_u64)
@@ -431,7 +395,7 @@ pub(super) fn job_extend_finalize(value: &Value) -> napi::Result<Value> {
         .and_then(Value::as_u64)
         .unwrap_or(0);
     Ok(
-        json!({ "output": format!("Extended {id} by {added}. New budget: {completed}/{budget} turns (limit {limit}); {time}.") }),
+        json!({ "output": format!("Extended {id} by {turns} turns. New budget: {completed}/{budget} turns (limit {limit}).") }),
     )
 }
 
@@ -464,7 +428,9 @@ pub(super) fn job_send_finalize(value: &Value) -> napi::Result<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{job_kill, job_send_finalize, job_status, run};
+    use super::{
+        job_extend_finalize, job_extend_prepare, job_kill, job_send_finalize, job_status, run,
+    };
 
     #[test]
     fn formats_scheduled_job_status() {
@@ -480,6 +446,32 @@ mod tests {
         )
         .unwrap();
         assert!(stopped.contains("finished after stop was requested"));
+    }
+
+    #[test]
+    fn extends_only_turn_budgets() {
+        let prepared = run(
+            r#"{"id":"child-1","turns":10}"#.to_owned(),
+            job_extend_prepare,
+        )
+        .unwrap();
+        assert_eq!(prepared, r#"{"id":"child-1","turns":10}"#);
+        assert!(
+            run(
+                r#"{"id":"child-1","minutes":10}"#.to_owned(),
+                job_extend_prepare,
+            )
+            .is_err()
+        );
+
+        let finalized = run(
+            r#"{"id":"child-1","turns":10,"completedTurns":2,"turnBudget":34,"turnLimit":51}"#
+                .to_owned(),
+            job_extend_finalize,
+        )
+        .unwrap();
+        assert!(finalized.contains("Extended child-1 by 10 turns"));
+        assert!(!finalized.contains("deadline"));
     }
 
     #[test]

--- a/crates/xal-native/src/tool_runtime/mod.rs
+++ b/crates/xal-native/src/tool_runtime/mod.rs
@@ -6,7 +6,6 @@ use serde_json::{Map, Value, json};
 
 const MAX_WAIT_SECONDS: f64 = 600.0;
 const MAX_SCHEDULER_DURATION_MS: i64 = 12 * 60 * 60 * 1_000;
-const MAX_EXTENSION_MINUTES: i64 = 60;
 const MAX_EXTENSION_TURNS: i64 = 100;
 const MAX_MESSAGE_LENGTH: usize = 20_000;
 const MAX_CONTEXT_LENGTH: usize = 20_000;

--- a/docs/background-work.md
+++ b/docs/background-work.md
@@ -45,9 +45,9 @@ Each task declares its `access`:
 - `read`: the agent runs in a read-only mode and cannot modify files.
 - `write`: the agent inherits the parent's permission mode. With `isolation: "worktree"` it works in its own Git worktree and branch; otherwise it edits the shared checkout.
 
-Dispatching any `write` task asks for approval. Sub-agents cannot ask for approval themselves; any action that would need it is denied automatically. Each agent runs until it produces a final report, reaches the `agents.timeoutMinutes` deadline, or exceeds its turn budget: after `agents.maxTurns` completed turns the agent is told to wrap up, and at 1.5× the budget its last report is returned as-is instead of running forever. The primary agent can inspect both budgets while the task runs and extend its deadline, soft turn budget, or both before either limit is reached.
+Dispatching any `write` task asks for approval. Sub-agents cannot ask for approval themselves; any action that would need it is denied automatically. Each agent runs until it produces a final report, is explicitly stopped, or exceeds its turn budget: after `agents.maxTurns` completed turns the agent is told to wrap up, and at 1.5× the budget its last report is returned as-is instead of running forever. The primary agent can inspect and extend the soft turn budget while the task runs. `agents.timeoutMinutes` can add an operator-configured wall-clock safety limit, but its default value of `0` leaves agent lifetime unlimited and the primary agent cannot change it.
 
-A task agent should work independently, but it can call `ask_parent` when a parent-only decision or missing context truly blocks useful progress. The tool suspends that child tool call and shows `Waiting for parent…` without starting another provider turn or polling. Each child can have one pending question. The existing task deadline bounds the wait, and cancellation or parent failure releases it with an unavailable result. Questions are process-local live state and are not resumed after teardown.
+A task agent should work independently, but it can call `ask_parent` when a parent-only decision or missing context truly blocks useful progress. The tool suspends that child tool call and shows `Waiting for parent…` without starting another provider turn or polling. Each child can have one pending question. A configured task deadline bounds the wait; cancellation or parent failure also releases it with an unavailable result. Questions are process-local live state and are not resumed after teardown.
 
 The parent receives a persisted, expandable question notice in the transcript and TUI plus a transient model instruction. It answers with `job_send`; while a question is pending, the next accepted `job_send` or TUI agent message is the answer rather than ordinary guidance. If the parent finishes without answering, it gets one transient correction. Finishing again releases the child as parent-unavailable. A question wakes `wait_agent` and an explicit `job_output(wait)` so the parent cannot deadlock while waiting for the blocked child. Historical question events remain visible after restart, but no actionable instruction is restored into provider history. Assignments should still be self-contained, and agents should not use this path for status questions.
 
@@ -66,16 +66,16 @@ A running foreground `bash` command can be promoted to a background job at any m
 
 The model coordinates jobs with six tools:
 
-| Tool         | Purpose                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `wait_agent` | Wait for task-agent activity without collecting or consuming the automatically delivered report.                     |
-| `job_output` | Read process output, collect an agent report, or inspect a schedule; agent waits return at a supervision checkpoint. |
-| `job_status` | Inspect processes, task agents, and schedules without consuming output.                                              |
-| `job_send`   | Answer a pending task-agent question, or queue guidance when no question is pending.                                 |
-| `job_extend` | Add up to 60 runtime minutes, 100 soft-budget turns, or both to a queued or running task agent per call.             |
-| `job_kill`   | Stop a process, task agent, or schedule. A process that ignores the graceful stop is hard-killed after 2 seconds.    |
+| Tool         | Purpose                                                                                                                |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `wait_agent` | Wait for task-agent activity without collecting or consuming the automatically delivered report.                       |
+| `job_output` | Read process output, collect an agent report, or inspect a schedule; configured deadlines add supervision checkpoints. |
+| `job_status` | Inspect processes, task agents, and schedules without consuming output.                                                |
+| `job_send`   | Answer a pending task-agent question, or queue guidance when no question is pending.                                   |
+| `job_extend` | Add up to 100 soft-budget turns to a queued or running task agent per call.                                            |
+| `job_kill`   | Stop a process, task agent, or schedule. A process that ignores the graceful stop is hard-killed after 2 seconds.      |
 
-`wait_agent` defaults to 30 seconds, clamps shorter requests to 10 seconds, and accepts waits up to one hour. It ends early for queued task-agent results, task-agent questions, or new user input. An explicit `job_output` wait cannot consume a task agent's whole runtime budget. It reserves a supervision window of up to one minute and returns with live status so the parent can inspect, extend, steer, or stop the task; a wait started while queued may return earlier because its runtime deadline has not started. If an agent still times out, collection includes a bounded transcript tail labeled as incomplete alongside the durable task-record path.
+`wait_agent` defaults to 30 seconds, clamps shorter requests to 10 seconds, and accepts waits up to one hour. It ends early for queued task-agent results, task-agent questions, or new user input, and its timeout never stops an agent. An explicit `job_output` wait also returns without affecting agent execution. When an operator configures a nonzero runtime limit, `job_output` reserves a supervision window of up to one minute before the deadline and returns with live status so the parent can inspect, steer, or stop the task. If the configured runtime limit is reached, collection includes a bounded transcript tail labeled as incomplete alongside the durable task-record path.
 
 Stopping a job from the TUI is never silent: the result is marked `stopped by the user` and still delivered so the model knows what happened. A task agent remains unsettled until its runner has finished cleanup and saved its task record.
 
@@ -106,10 +106,10 @@ The viewer takes over the screen and follows the job's output live. While it is 
 
 Every field in the top-level `agents` object must be an integer and is validated strictly.
 
-| Option                  | Default | Range   | Description                                                 |
-| ----------------------- | ------- | ------- | ----------------------------------------------------------- |
-| `agents.maxConcurrent`  | `4`     | `1–8`   | Task agents running at once; further tasks queue.           |
-| `agents.timeoutMinutes` | `10`    | `1–60`  | Hard deadline per task agent.                               |
-| `agents.maxTurns`       | `24`    | `1–100` | Soft completed turn-cycle budget; agents wrap up beyond it. |
+| Option                  | Default | Range   | Description                                                       |
+| ----------------------- | ------- | ------- | ----------------------------------------------------------------- |
+| `agents.maxConcurrent`  | `4`     | `1–8`   | Task agents running at once; further tasks queue.                 |
+| `agents.timeoutMinutes` | `0`     | `0–60`  | Optional hard deadline per task agent; `0` disables the deadline. |
+| `agents.maxTurns`       | `24`    | `1–100` | Soft completed turn-cycle budget; agents wrap up beyond it.       |
 
 Set these values in the top-level `agents` object. See [Configuration](/docs/configs) for file locations and merge behavior.

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -124,7 +124,7 @@ Every option is optional. This example shows how the top-level sections fit toge
   },
   "agents": {
     "maxConcurrent": 4,
-    "timeoutMinutes": 10,
+    "timeoutMinutes": 0,
     "maxTurns": 24
   },
   "thinking": {


### PR DESCRIPTION
## Summary

- disable the whole-agent wall-clock deadline by default while retaining an optional operator-configured cap
- keep agent waits non-terminating and limit `job_extend` to soft turn-budget extensions
- update native contracts, focused tests, and background-work documentation

## Testing

- `bun checks`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background tasks can now run without a wall-clock timeout by default.
  * Task extensions now add only soft-budget turns, preserving configured deadlines and turn limits.
* **Bug Fixes**
  * Tasks configured without a timeout no longer create or enforce unnecessary deadline timers.
  * Supervision waits are no longer shortened when no timeout is configured.
* **Documentation**
  * Updated configuration and background-task guidance to describe optional timeouts and turn-only extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->