### PR TITLE
feat(tui): add interactive task agent views

### DIFF
--- a/apps/cli/src/agent/task/spawn.test.ts
+++ b/apps/cli/src/agent/task/spawn.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import type { AgentEvent } from "../events"
+import { createAgentEventMulticast } from "./spawn"
+
+const event: AgentEvent = { type: "text_delta", text: "hi" }
+
+describe("task agent event multicast", () => {
+  test("delivers each event to every subscribed listener until it unsubscribes", () => {
+    const multicast = createAgentEventMulticast()
+    const first: AgentEvent[] = []
+    const second: AgentEvent[] = []
+    const offFirst = multicast.onEvent((event) => first.push(event))
+    multicast.onEvent((event) => second.push(event))
+
+    multicast.emit(event)
+    expect(first).toEqual([event])
+    expect(second).toEqual([event])
+
+    offFirst()
+    multicast.emit(event)
+    expect(first).toEqual([event])
+    expect(second).toEqual([event, event])
+  })
+
+  test("a throwing listener does not block the others", () => {
+    const multicast = createAgentEventMulticast()
+    const delivered: AgentEvent[] = []
+    multicast.onEvent(() => {
+      throw new Error("boom")
+    })
+    multicast.onEvent((event) => delivered.push(event))
+
+    multicast.emit(event)
+    expect(delivered).toEqual([event])
+  })
+})

--- a/apps/cli/src/agent/task/spawn.ts
+++ b/apps/cli/src/agent/task/spawn.ts
@@ -18,7 +18,9 @@ import { createManagedWorktree, type ManagedWorktree } from "../../git/worktrees
 import { describeError } from "../../lib/error"
 import { compactPath } from "../../lib/path"
 import type { PermissionMode } from "../../permissions/types"
+import { redactText } from "../../secrets/redactor"
 import type { SessionToolContext } from "../../tools/types"
+import type { AgentEvent } from "../events"
 import { AgentSession } from "../session/session"
 import { activity, type ActivityState } from "./activity"
 import { driveTaskToQuiescence, type TaskDriveOutcome } from "./drive"
@@ -82,6 +84,30 @@ function childMode(access: TaskAccess, parentMode: PermissionMode): PermissionMo
   return access === "read" ? "plan" : parentMode
 }
 
+export interface AgentEventMulticast {
+  onEvent(listener: (event: AgentEvent) => void): () => void
+  emit(event: AgentEvent): void
+}
+
+export function createAgentEventMulticast(): AgentEventMulticast {
+  const listeners = new Set<(event: AgentEvent) => void>()
+  return {
+    onEvent: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    emit: (event) => {
+      for (const listener of listeners) {
+        try {
+          listener(event)
+        } catch (error) {
+          console.error(redactText(`task agent event listener failed: ${describeError(error)}`))
+        }
+      }
+    },
+  }
+}
+
 function childPrompt(context: string, task: string): string {
   return `# Context\n${context}\n\n# Assignment\n${task}`
 }
@@ -93,6 +119,7 @@ function registerTask(
   state: ActivityState,
   cwd: () => string,
   child: () => AgentSession | undefined,
+  onEvent: (listener: (event: AgentEvent) => void) => () => void,
 ): void {
   registerBackgroundTask({
     kind: "agent",
@@ -102,11 +129,15 @@ function registerTask(
     startedAt: job.startedAt,
     role: item.isolation === "worktree" ? "task agent · worktree" : "task agent",
     model: ctx.session.model,
+    get mode() {
+      return child()?.currentMode ?? childMode(item.access, ctx.session.mode)
+    },
     get cwd() {
       return cwd()
     },
     childSessionId: () => child()?.id,
     send: (message) => sendAgentGuidance(job, message, "user") !== false,
+    onEvent,
     state: () =>
       job.done
         ? {
@@ -150,6 +181,7 @@ async function runTask(
   questions: ParentQuestionChannel,
   setChild: (child: AgentSession) => void,
   setCwd: (cwd: string) => void,
+  emitEvent: (event: AgentEvent) => void,
 ): Promise<void> {
   let acquired = false
   let timedOut = false
@@ -157,6 +189,7 @@ async function runTask(
   let worktree: ManagedWorktree | undefined
   let child: AgentSession | undefined
   let terminal: TaskTerminal | undefined
+  let unsubscribeEvents: (() => void) | undefined
   const record = (text: string): void => appendAgentTranscript(job, text)
   const cleanupFailure = (error: unknown): void => {
     const message = describeError(error)
@@ -224,6 +257,7 @@ async function runTask(
     })
     child = taskSession
     setChild(taskSession)
+    unsubscribeEvents = taskSession.subscribe(emitEvent)
     taskSession.setMode(childMode(item.access, ctx.session.mode))
     const abortChild = (): void => {
       taskSession.suppressAsyncDeliveries()
@@ -276,6 +310,7 @@ async function runTask(
       terminal = { outcome: { status: "failed" }, detail: `failed: ${message}` }
     }
   } finally {
+    unsubscribeEvents?.()
     beginAgentStop(job)
     questions.close("the task ended before the parent answered")
     if (deadline) clearTimeout(deadline)
@@ -306,6 +341,7 @@ async function runTask(
 export function spawnTask(item: TaskItem, context: string, ctx: SessionToolContext): BackgroundAgentJob {
   const controller = new AbortController()
   const agentSettings = settings().agents
+  const events = createAgentEventMulticast()
   let child: AgentSession | undefined
   let cwd = ctx.session.cwd
   const job = createAgentJob("agent", {
@@ -351,6 +387,7 @@ export function spawnTask(item: TaskItem, context: string, ctx: SessionToolConte
     state,
     () => cwd,
     () => child,
+    events.onEvent,
   )
   void runTask(
     job,
@@ -366,6 +403,7 @@ export function spawnTask(item: TaskItem, context: string, ctx: SessionToolConte
     (value) => {
       cwd = value
     },
+    events.emit,
   )
   return job
 }

--- a/apps/cli/src/background/registry.test.ts
+++ b/apps/cli/src/background/registry.test.ts
@@ -39,6 +39,7 @@ function agentTask(id: string, state: BackgroundTaskState): BackgroundAgentTask 
     cwd: "/tmp",
     role: "task agent",
     model: "test",
+    mode: "plan",
     state: () => state,
     output: () => "",
     stop: async () => {},

--- a/apps/cli/src/background/registry.ts
+++ b/apps/cli/src/background/registry.ts
@@ -1,3 +1,5 @@
+import type { AgentEvent } from "../agent/events"
+import type { PermissionMode } from "../permissions/types"
 import { redactText } from "../secrets/redactor"
 
 export type BackgroundTaskState = { running: true } | { running: false; ok: boolean; detail: string }
@@ -42,9 +44,11 @@ export interface BackgroundAgentTask extends BackgroundTaskBase {
   kind: "agent"
   role: string
   model: string
+  mode: PermissionMode
   snapshot(): BackgroundAgentSnapshot
   childSessionId(): string | undefined
   send(message: string): boolean
+  onEvent?(listener: (event: AgentEvent) => void): () => void
 }
 
 export type BackgroundTask = BackgroundProcessTask | BackgroundAgentTask | BackgroundScheduleTask

--- a/apps/cli/src/plugins/tui/app.ts
+++ b/apps/cli/src/plugins/tui/app.ts
@@ -120,7 +120,8 @@ export async function startTui(events: EventService, config: TuiConfig, options:
   })
   const unsubscribeTerminalBackground = renderer.subscribeOsc((sequence) => {
     const background = terminalBackground(sequence)
-    if (background && screen.scrollback.setTerminalBackground(background)) screen.scrollback.replay()
+    if (!background) return
+    if (screen.setTerminalBackground(background)) screen.replayActiveTranscript()
   })
   let paletteSignature = initialPalette ? buildTerminalPaletteSignature(initialPalette) : undefined
   const applyPalette = (palette: TerminalColors): void => {
@@ -129,8 +130,8 @@ export async function startTui(events: EventService, config: TuiConfig, options:
     paletteSignature = signature
     applyTerminalPalette(palette)
     renderer.setBackgroundColor(COLORS.background)
-    screen.scrollback.setTerminalBackground(COLORS.background)
-    screen.scrollback.replay()
+    screen.setTerminalBackground(COLORS.background)
+    screen.replayActiveTranscript()
   }
   renderer.on(CliRenderEvents.PALETTE, applyPalette)
   if (paletteError) {
@@ -163,11 +164,12 @@ export async function startTui(events: EventService, config: TuiConfig, options:
   let editing = false
   const syncLayout = (): void => {
     screen.composer.reflow()
+    screen.agentComposer.reflow()
     screen.syncFooter()
   }
   const replayLayout = (): void => {
     syncLayout()
-    screen.scrollback.reflow()
+    screen.replayActiveTranscript()
   }
   renderer.on(CliRenderEvents.RESIZE, () => {
     if (renderer.terminalWidth === lastWidth && renderer.terminalHeight === lastHeight) return
@@ -181,7 +183,7 @@ export async function startTui(events: EventService, config: TuiConfig, options:
     clearTimeout(replayTimer)
     replayTimer = setTimeout(() => {
       replayTimer = undefined
-      screen.scrollback.reflow()
+      screen.replayActiveTranscript()
     }, RESIZE_DEBOUNCE_MS)
   })
   const resetCommands = setTuiCommandActions({
@@ -250,7 +252,7 @@ export async function startTui(events: EventService, config: TuiConfig, options:
     }
     try {
       const command = externalEditorCommand()
-      const draft = screen.composer.draft()
+      const draft = screen.activeComposer.draft()
       const ignoreInterrupt = (): void => {}
       let suspended = false
       let text: string
@@ -275,7 +277,7 @@ export async function startTui(events: EventService, config: TuiConfig, options:
         }
       }
       if (comparableEditorText(text) !== comparableEditorText(draft.text)) {
-        screen.composer.replaceDraft({ ...draft, text }, draft)
+        screen.activeComposer.replaceDraft({ ...draft, text }, draft)
       }
       screen.syncFooter()
     } finally {

--- a/apps/cli/src/plugins/tui/components/background-tasks.ts
+++ b/apps/cli/src/plugins/tui/components/background-tasks.ts
@@ -410,20 +410,14 @@ export class BackgroundTasks {
     const entry = this.rows[this.selected]
     if (this.viewedJobId !== undefined) {
       const viewed = this.rows.find((row) => row.kind === "task" && row.task.id === this.viewedJobId)
-      const steer =
-        viewed?.kind === "task" &&
-        viewed.task.kind === "agent" &&
-        viewed.task.state().running &&
-        viewed.task.childSessionId() !== undefined
-          ? ["i steer"]
-          : []
+      const scroll = viewed?.kind === "task" && viewed.task.kind !== "agent" ? ["pgup/pgdn scroll", "end follow"] : []
       const open =
         !entry || entry.kind === "main"
           ? "enter main"
           : entry.task.id === this.viewedJobId
             ? "enter close"
             : "enter view"
-      return ["↑↓ move", open, "pgup/pgdn scroll", "end follow", ...steer, "esc close"].join(" · ")
+      return ["↑↓ move", open, ...scroll, "esc close"].join(" · ")
     }
     const stopAll = this.stopAllShortcut ? [`${this.stopAllShortcut} stop all`] : []
     if (!entry || entry.kind === "main") return ["↑↓ move", "enter main", ...stopAll, "esc back"].join(" · ")

--- a/apps/cli/src/plugins/tui/components/composer.ts
+++ b/apps/cli/src/plugins/tui/components/composer.ts
@@ -8,6 +8,7 @@ import {
   TextAttributes,
   type PasteEvent,
   type RenderContext,
+  type RGBA,
   type TextRenderable,
 } from "@opentui/core"
 import { describeError } from "../../../lib/error"
@@ -97,6 +98,7 @@ export class Composer {
   readonly view: BoxRenderable
   private readonly input: TextareaRenderable
   private readonly prompt: TextRenderable
+  private readonly badge: TextRenderable
   private readonly pastedContentType: number
   private readonly pastedImageType: number
   private readonly skillHighlightType: number
@@ -113,6 +115,7 @@ export class Composer {
     private readonly ctx: RenderContext,
     private readonly history: MessageHistory,
     private readonly actions: ComposerActions,
+    private readonly indicator: RGBA | undefined = undefined,
   ) {
     this.view = row(ctx, {
       height: 3,
@@ -125,12 +128,17 @@ export class Composer {
       marginTop: 1,
       ...border(COLORS.border),
     })
+    if (indicator !== undefined) {
+      const borderColor = resolveColor(indicator)
+      this.view.borderColor = borderColor
+      this.view.focusedBorderColor = borderColor
+    }
 
     this.prompt = label(ctx, {
       content: "❯",
       width: FOOTER_ICON_WIDTH,
       attributes: TextAttributes.BOLD,
-      color: COLORS.accent,
+      color: indicator ?? COLORS.accent,
     })
     this.view.add(this.prompt)
     this.syntaxStyle = SyntaxStyle.create()
@@ -177,10 +185,20 @@ export class Composer {
     this.skillHighlightType = this.input.extmarks.registerType("composer-skill-highlight")
     this.fileHighlightType = this.input.extmarks.registerType("composer-file-highlight")
     this.view.add(this.input)
+    this.badge = label(ctx, {
+      content: "",
+      color: indicator ?? COLORS.accent,
+      flexShrink: 0,
+    })
+    this.view.add(this.badge)
     this.view.on(RenderableEvents.DESTROYED, () => {
       this.imeCommit.clear()
       this.syntaxStyle.destroy()
     })
+  }
+
+  setBadge(text: string | undefined): void {
+    this.badge.content = text ?? ""
   }
 
   get rows(): number {
@@ -348,6 +366,16 @@ export class Composer {
   }
 
   private change(): void {
+    if (this.indicator !== undefined) {
+      const borderColor = resolveColor(this.indicator)
+      this.prompt.fg = borderColor
+      this.view.borderColor = borderColor
+      this.view.focusedBorderColor = borderColor
+      this.syncSkillHighlights()
+      this.reflow()
+      this.notifyCompletion()
+      return
+    }
     const shell =
       this.input.extmarks.getAllForTypeId(this.pastedImageType).length === 0 &&
       this.input.plainText.trimStart().startsWith("!")

--- a/apps/cli/src/plugins/tui/components/job-viewer.ts
+++ b/apps/cli/src/plugins/tui/components/job-viewer.ts
@@ -271,7 +271,7 @@ export class JobViewer {
     ])
   }
 
-  private metricsText(task: BackgroundTask): string {
+  private metricsText(task: Exclude<BackgroundTask, { kind: "agent" }>): string {
     const state = task.state()
     if (!state.running) return redactText(state.detail)
     switch (task.kind) {
@@ -279,14 +279,12 @@ export class JobViewer {
         return formatDuration(Date.now() - task.startedAt)
       case "schedule":
         return `${formatDuration(Math.max(0, task.dueAt - Date.now()))} left`
-      case "agent":
-        throw new Error("task agents render on the agent page, not the legacy viewer")
     }
   }
 
   refresh(): void {
     const task = this.task
-    if (!task) return
+    if (!task || task.kind === "agent") return
     const state = task.state()
     const width = Math.max(10, this.ctx.terminalWidth - HORIZONTAL_PADDING * 2)
     this.title.content = truncateToWidth(firstLine(redactText(task.title)), width)

--- a/apps/cli/src/plugins/tui/components/job-viewer.ts
+++ b/apps/cli/src/plugins/tui/components/job-viewer.ts
@@ -1,13 +1,5 @@
-import {
-  StyledText,
-  TextAttributes,
-  type BoxRenderable,
-  type CliRenderer,
-  type KeyEvent,
-  type TextRenderable,
-} from "@opentui/core"
+import { StyledText, TextAttributes, type BoxRenderable, type CliRenderer, type TextRenderable } from "@opentui/core"
 import type { BackgroundTask } from "../../../background/registry"
-import { formatTokens } from "../../../lib/format"
 import { compactPath } from "../../../lib/path"
 import { redactText, secretsVersion } from "../../../secrets/redactor"
 import { formatDuration } from "../lib/format"
@@ -69,21 +61,14 @@ export class JobViewer {
   private readonly role: TextRenderable
   private readonly metrics: TextRenderable
   private readonly body: BoxRenderable
-  private readonly guidance: BoxRenderable
-  private readonly guidanceText: TextRenderable
   private readonly hint: TextRenderable
   private readonly lines: TextRenderable[] = []
   private task: BackgroundTask | undefined
   private currentHeight = 0
   private cache: TranscriptCache | undefined
   private scrollFromBottom = 0
-  private guidanceValue = ""
-  private guidanceActive = false
 
-  constructor(
-    private readonly ctx: CliRenderer,
-    private readonly notice: (message: string) => void,
-  ) {
+  constructor(private readonly ctx: CliRenderer) {
     this.view = column(ctx, {
       visible: false,
       paddingLeft: HORIZONTAL_PADDING,
@@ -118,14 +103,6 @@ export class JobViewer {
       ...border(COLORS.border),
     })
     this.view.add(this.body)
-    this.guidance = row(ctx, { height: 1, visible: false })
-    this.guidance.add(label(ctx, { content: `${terminalGlyph("❯", ">")} steer: `, flexShrink: 0, color: COLORS.agent }))
-    this.guidanceText = label(ctx, { content: "", flexGrow: 1, flexShrink: 1, minWidth: 1 })
-    this.guidance.add(this.guidanceText)
-    this.guidance.add(
-      label(ctx, { content: "Enter send · Esc cancel", flexShrink: 0, marginLeft: 1, color: COLORS.faint }),
-    )
-    this.view.add(this.guidance)
     this.hint = label(ctx, {
       content: "↑↓ line · PgUp/PgDn page · Home/End jump · Esc agents",
       height: 1,
@@ -154,21 +131,10 @@ export class JobViewer {
     this.cache = undefined
     this.scrollFromBottom = 0
     this.view.visible = false
-    this.dismissGuidance()
-  }
-
-  get steerable(): boolean {
-    return this.task?.kind === "agent" && this.task.state().running && this.task.childSessionId() !== undefined
   }
 
   scrollKey(name: string): boolean {
     if (!this.task) return false
-    if (name === "i" && this.steerable && !this.guidanceActive) {
-      this.guidanceActive = true
-      this.guidanceValue = ""
-      this.syncGuidance()
-      return true
-    }
     const page = Math.max(1, this.lines.length - 1)
     switch (name) {
       case "up":
@@ -220,64 +186,6 @@ export class JobViewer {
       this.body.add(added)
       this.lines.push(added)
     }
-  }
-
-  private syncGuidance(): void {
-    this.guidance.visible = this.guidanceActive
-    this.hint.visible = !this.guidanceActive
-    this.guidanceText.content = this.guidanceValue || new StyledText([muted("type guidance for this agent")])
-    this.layoutBody()
-    this.refresh()
-  }
-
-  private dismissGuidance(): void {
-    if (!this.guidanceActive) return
-    this.guidanceActive = false
-    this.guidanceValue = ""
-    this.guidance.visible = false
-    this.hint.visible = true
-    if (this.task) {
-      this.layoutBody()
-      this.refresh()
-    }
-  }
-
-  handleInputKey(key: KeyEvent): boolean {
-    if (!this.guidanceActive || !this.task) return false
-    if (key.name === "escape") {
-      this.dismissGuidance()
-      return true
-    }
-    if (key.name === "return" || key.name === "enter") {
-      const task = this.task
-      const message = this.guidanceValue.trim()
-      if (!message || task.kind !== "agent") {
-        this.dismissGuidance()
-        return true
-      }
-      if (!task.send(message)) {
-        this.notice(`${task.id} did not accept the guidance`)
-        return true
-      }
-      this.notice(`Guidance queued for ${task.id}`)
-      this.dismissGuidance()
-      return true
-    }
-    if (key.name === "backspace" || key.name === "delete") {
-      this.guidanceValue = Array.from(this.guidanceValue).slice(0, -1).join("")
-      this.syncGuidance()
-      return true
-    }
-    if (key.ctrl && !key.meta && !key.option && !key.shift && !key.super && !key.hyper && key.name === "u") {
-      this.guidanceValue = ""
-      this.syncGuidance()
-      return true
-    }
-    if (key.ctrl || key.meta || key.option || key.super || key.hyper) return false
-    if (!key.sequence || /[\u0000-\u001f\u007f]/.test(key.sequence)) return true
-    this.guidanceValue += key.sequence
-    this.syncGuidance()
-    return true
   }
 
   private appendRows(cache: TranscriptCache, text: string): void {
@@ -356,38 +264,24 @@ export class JobViewer {
 
   private header(task: BackgroundTask, running: boolean, ok: boolean): void {
     const glyph = paint(running ? COLORS.agent : ok ? COLORS.success : COLORS.error, running ? "● " : ok ? "✓ " : "x ")
-    switch (task.kind) {
-      case "agent":
-        this.role.content = new StyledText([
-          glyph,
-          paint(COLORS.foreground, redactText(`${task.id} · ${task.role}`)),
-          muted(redactText(` · ${task.model} · ${compactPath(task.cwd)}`)),
-        ])
-        return
-      case "process":
-      case "schedule":
-        this.role.content = new StyledText([
-          glyph,
-          paint(COLORS.foreground, task.id),
-          muted(redactText(` · ${compactPath(task.cwd)}`)),
-        ])
-        return
-    }
+    this.role.content = new StyledText([
+      glyph,
+      paint(COLORS.foreground, task.id),
+      muted(redactText(` · ${compactPath(task.cwd)}`)),
+    ])
   }
 
   private metricsText(task: BackgroundTask): string {
     const state = task.state()
     if (!state.running) return redactText(state.detail)
-    if (task.kind === "process") return formatDuration(Date.now() - task.startedAt)
-    if (task.kind === "schedule") return `${formatDuration(Math.max(0, task.dueAt - Date.now()))} left`
-    const snapshot = task.snapshot()
-    if (snapshot.queued) return `queued ${formatDuration(snapshot.queuedMs)}`
-    if (snapshot.stopping) return "stopping"
-    const requests = ` · ${snapshot.providerRequests} provider requests`
-    const tokens = snapshot.contextTokens ? ` · ↓ ${formatTokens(snapshot.contextTokens)} tokens` : ""
-    const turns = ` · turn cycle ${snapshot.completedTurns}/${snapshot.turnBudget} (${snapshot.turnLimit} max)`
-    const remaining = snapshot.remainingMs === undefined ? "" : ` · ${formatDuration(snapshot.remainingMs)} left`
-    return `${formatDuration(snapshot.elapsedMs)}${requests}${tokens}${turns}${remaining} · idle ${formatDuration(snapshot.idleMs)}`
+    switch (task.kind) {
+      case "process":
+        return formatDuration(Date.now() - task.startedAt)
+      case "schedule":
+        return `${formatDuration(Math.max(0, task.dueAt - Date.now()))} left`
+      case "agent":
+        throw new Error("task agents render on the agent page, not the legacy viewer")
+    }
   }
 
   refresh(): void {
@@ -397,7 +291,6 @@ export class JobViewer {
     const width = Math.max(10, this.ctx.terminalWidth - HORIZONTAL_PADDING * 2)
     this.title.content = truncateToWidth(firstLine(redactText(task.title)), width)
     this.header(task, state.running, !state.running && state.ok)
-    this.hint.content = `↑↓ line · PgUp/PgDn page · Home/End jump${this.steerable ? " · i steer" : ""} · Esc tasks`
     const cache = this.syncCache(task, width)
     const partialRows = cache.partial ? wrapLine(sanitize(cache.partial), width) : []
     const renderedRowCount = cache.rowCount + partialRows.length
@@ -406,8 +299,7 @@ export class JobViewer {
     }
     cache.renderedRowCount = renderedRowCount
     const all = partialRows.length > 0 ? [...cache.rows, ...partialRows] : cache.rows
-    const fallback = task.kind === "agent" ? task.snapshot().activity : "(no output yet)"
-    const filled = all.length > 0 ? all : [redactText(fallback)]
+    const filled = all.length > 0 ? all : ["(no output yet)"]
     this.scrollFromBottom = Math.min(this.scrollFromBottom, Math.max(0, filled.length - this.lines.length))
     const end = filled.length - this.scrollFromBottom
     const visible = filled.slice(Math.max(0, end - this.lines.length), end)

--- a/apps/cli/src/plugins/tui/components/status-bar.ts
+++ b/apps/cli/src/plugins/tui/components/status-bar.ts
@@ -56,6 +56,7 @@ export class StatusBar {
   private turnElapsed: string | undefined
   private turnOutcome: TurnOutcome | undefined
   private model: string
+  private metrics: string | undefined
 
   constructor(
     ctx: RenderContext,
@@ -180,6 +181,11 @@ export class StatusBar {
     this.stopNoticeTimer()
     this.notice = redactText(notice)
     this.toggleSpinner(false)
+    this.render()
+  }
+
+  setMetrics(metrics: string | undefined): void {
+    this.metrics = metrics === undefined ? undefined : redactText(metrics)
     this.render()
   }
 
@@ -329,6 +335,7 @@ export class StatusBar {
     if (this.loading) {
       return new StyledText([paint(COLORS.agent, spinnerGlyph()), muted(` ${this.loading}`)])
     }
+    if (this.metrics) return new StyledText([muted(this.metrics)])
     const state = this.stateContent()
     if (state) return state
     if (this.turnElapsed && this.turnOutcome === "completed") {

--- a/apps/cli/src/plugins/tui/controllers/child-events.test.ts
+++ b/apps/cli/src/plugins/tui/controllers/child-events.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, test } from "bun:test"
+import type { AgentEvent } from "../../../agent/events"
+import type { Block, ReasoningBlock, TextBlock, ToolBlock } from "../scrollback/blocks"
+import { ChildEventController, type ChildStatusBar } from "./child-events"
+
+interface Recorder {
+  blocks: Block[]
+  status: string[]
+  controller: ChildEventController
+}
+
+function recorder(streaming: boolean): Recorder {
+  const blocks: Block[] = []
+  const status: string[] = []
+  let open: TextBlock | ReasoningBlock | undefined
+  const transcript = streaming
+    ? {
+        append: (block: Block) => {
+          open = undefined
+          blocks.push(block)
+        },
+        appendStream: (kind: "text" | "reasoning", text: string) => {
+          if (open && open.kind === kind) {
+            open.text += text
+            return
+          }
+          const created: TextBlock | ReasoningBlock =
+            kind === "text" ? { kind: "text", text } : { kind: "reasoning", text }
+          open = created
+          blocks.push(created)
+        },
+        endStream: () => {
+          if (!open) return false
+          open = undefined
+          return true
+        },
+      }
+    : {
+        append: (block: Block) => {
+          blocks.push(block)
+        },
+        appendStream: () => {},
+        endStream: () => false,
+      }
+  const statusBar: ChildStatusBar = {
+    setState: (state) => status.push(`state:${state}`),
+    setMode: (mode) => status.push(`mode:${mode}`),
+    setModel: (model) => status.push(`model:${model}`),
+    setThinking: (thinking) => status.push(`thinking:${thinking ?? "off"}`),
+    setUsage: (context) => status.push(`usage:${JSON.stringify(context)}`),
+    setTurnOutcome: (outcome) => status.push(`turn:${outcome}`),
+  }
+  return { blocks, status, controller: new ChildEventController(transcript, statusBar) }
+}
+
+function run(events: AgentEvent[]): Block[] {
+  const recorded = recorder(false)
+  for (const event of events) recorded.controller.handle(event)
+  return recorded.blocks
+}
+
+function runStreamed(events: AgentEvent[]): Block[] {
+  const recorded = recorder(true)
+  for (const event of events) recorded.controller.handle(event)
+  return recorded.blocks
+}
+
+function toolBlock(overrides: Partial<ToolBlock>): ToolBlock {
+  return {
+    kind: "tool",
+    tool: "read",
+    title: "file",
+    readOnly: true,
+    denial: undefined,
+    output: "ok",
+    execution: undefined,
+    elapsed: undefined,
+    expanded: false,
+    ...overrides,
+  }
+}
+
+describe("child event mapping", () => {
+  test("accumulates text deltas into one block and skips the assistant fallback", () => {
+    const blocks = runStreamed([
+      { type: "text_delta", text: "Hel" },
+      { type: "text_delta", text: "lo" },
+      { type: "assistant_message", text: "Hello" },
+    ])
+    expect(blocks).toEqual([{ kind: "text", text: "Hello" }])
+  })
+
+  test("assistant_message without streamed deltas becomes a text block", () => {
+    expect(run([{ type: "assistant_message", text: "final report" }])).toEqual([{ kind: "text", text: "final report" }])
+  })
+
+  test("reasoning deltas accumulate and assistant text closes the reasoning stream", () => {
+    const blocks = runStreamed([
+      { type: "reasoning_summary_delta", text: "think" },
+      { type: "reasoning_summary_delta", text: "ing" },
+      { type: "reasoning_summary", text: "thinking" },
+      { type: "assistant_message", text: "answer" },
+    ])
+    expect(blocks).toEqual([
+      { kind: "reasoning", text: "thinking" },
+      { kind: "text", text: "answer" },
+    ])
+  })
+
+  test("reasoning_summary without streamed deltas becomes a reasoning block", () => {
+    expect(run([{ type: "reasoning_summary", text: "thought" }])).toEqual([{ kind: "reasoning", text: "thought" }])
+  })
+
+  test("reasoning_delta is ignored", () => {
+    expect(run([{ type: "reasoning_delta", text: "raw" }])).toEqual([])
+  })
+
+  test("a retry resets the streamed flags so the final message is kept", () => {
+    const blocks = runStreamed([
+      { type: "text_delta", text: "partial" },
+      { type: "retry_scheduled", attempt: 2, maxAttempts: 3, delayMs: 5_000, message: "boom" },
+      { type: "assistant_message", text: "recovered" },
+    ])
+    expect(blocks).toEqual([
+      { kind: "text", text: "partial" },
+      { kind: "info", text: "retrying in 5s · attempt 2/3 · boom" },
+      { kind: "text", text: "recovered" },
+    ])
+  })
+
+  test("user_message becomes a user block", () => {
+    expect(run([{ type: "user_message", messageId: "m1", text: "do it", imageCount: 0, sentAt: 42 }])).toEqual([
+      { kind: "user", text: "do it", imageCount: 0, sentAt: 42 },
+    ])
+  })
+
+  test("tool_finished measures elapsed from its tool_started", () => {
+    const blocks = run([
+      { type: "tool_started", callId: "call-1", tool: "read", title: "file", readOnly: true },
+      { type: "tool_updated", callId: "call-1", text: "progress" },
+      { type: "tool_finished", callId: "call-1", tool: "read", title: "file", readOnly: true, output: "ok" },
+    ])
+    expect(blocks).toEqual([toolBlock({ elapsed: expect.any(String) })])
+  })
+
+  test("tool_finished without a start has no elapsed", () => {
+    expect(
+      run([{ type: "tool_finished", callId: "call-1", tool: "read", title: "file", readOnly: true, output: "ok" }]),
+    ).toEqual([toolBlock({})])
+  })
+
+  test("shell_finished renders an expanded bash tool block", () => {
+    const blocks = run([
+      { type: "tool_started", callId: "call-1", tool: "bash", title: "ls", readOnly: true },
+      {
+        type: "shell_finished",
+        messageId: "m1",
+        callId: "call-1",
+        input: "ls",
+        command: "ls",
+        output: "ok",
+        readOnly: true,
+      },
+    ])
+    expect(blocks).toEqual([toolBlock({ tool: "bash", title: "ls", expanded: true, elapsed: expect.any(String) })])
+  })
+
+  test("denials surface through the shell tool block", () => {
+    const blocks = run([
+      { type: "tool_started", callId: "call-1", tool: "bash", title: "rm", readOnly: false },
+      {
+        type: "shell_finished",
+        messageId: "m1",
+        callId: "call-1",
+        input: "rm",
+        command: "rm",
+        output: "denied",
+        readOnly: false,
+        denial: "policy",
+      },
+    ])
+    expect(blocks).toEqual([
+      toolBlock({
+        tool: "bash",
+        title: "rm",
+        readOnly: false,
+        denial: "policy",
+        output: "denied",
+        expanded: true,
+        elapsed: expect.any(String),
+      }),
+    ])
+  })
+
+  test("hook_finished becomes a hook block", () => {
+    expect(
+      run([{ type: "hook_finished", hook: "guard", event: "before_tool", action: "continued", elapsedMs: 12 }]),
+    ).toEqual([{ kind: "hook", text: "hook: guard · before_tool · continued · 12ms" }])
+  })
+
+  test("background_results become background blocks with process log paths", () => {
+    expect(
+      run([
+        {
+          type: "background_results",
+          results: [
+            { kind: "agent", id: "agent-1", task: "research", status: "completed", output: "done" },
+            { kind: "process", id: "proc-1", command: "bun test", status: "failed", output: "", record: "/tmp/log" },
+            {
+              kind: "process",
+              id: "proc-2",
+              command: "bun dev",
+              status: "failed",
+              output: "",
+              record: "/tmp/log2",
+              recordCapped: true,
+            },
+          ],
+        },
+      ]),
+    ).toEqual([
+      { kind: "background", id: "agent-1", label: "research", status: "completed", output: "done" },
+      { kind: "background", id: "proc-1", label: "bun test", status: "failed", output: "", record: "/tmp/log" },
+      {
+        kind: "background",
+        id: "proc-2",
+        label: "bun dev",
+        status: "failed",
+        output: "",
+        record: "/tmp/log2 (capped)",
+      },
+    ])
+  })
+
+  test("a draft plan becomes a plan block and an approved plan an info block", () => {
+    expect(
+      run([
+        { type: "plan_updated", plan: { status: "draft", path: "/tmp/project/plans/x.md", markdown: "# Plan" } },
+        { type: "plan_updated", plan: { status: "approved", path: "/tmp/project/plans/x.md", markdown: "# Plan" } },
+      ]),
+    ).toEqual([
+      { kind: "plan", path: "/tmp/project/plans/x.md", text: "# Plan" },
+      { kind: "info", text: "plan approved · /tmp/project/plans/x.md" },
+    ])
+  })
+
+  test("compacted becomes a compaction block", () => {
+    expect(run([{ type: "compacted", summary: "kept the gist", replaced: 12, tokensBefore: 4_000 }])).toEqual([
+      { kind: "compaction", state: "compacted", summary: "kept the gist", replaced: 12, tokensBefore: 4_000 },
+    ])
+  })
+
+  test("workspace_changed becomes an info block", () => {
+    expect(run([{ type: "workspace_changed", cwd: "/tmp/next", previous: "/tmp/prev" }])).toEqual([
+      { kind: "info", text: "workspace: /tmp/prev → /tmp/next" },
+    ])
+  })
+
+  test("interrupts and failures become info and error blocks", () => {
+    expect(
+      run([
+        { type: "turn_interrupted" },
+        { type: "turn_failed", message: "provider exploded" },
+        { type: "error", message: "plain error" },
+      ]),
+    ).toEqual([
+      { kind: "info", text: "Interrupted" },
+      { kind: "error", text: "provider exploded" },
+      { kind: "error", text: "plain error" },
+    ])
+  })
+
+  test("status-bar-only and unreachable child events produce no blocks", () => {
+    expect(
+      run([
+        { type: "state_changed", state: "idle" },
+        { type: "turn_ended" },
+        { type: "context_updated", context: { outputTokens: 5 } },
+        { type: "context_window_changed" },
+        { type: "model_changed", provider: "p", model: "m" },
+        { type: "mode_changed", mode: "plan" },
+        { type: "thinking_changed", thinking: undefined },
+        { type: "tool_call_updated", callId: "c", tool: "t", args: {} },
+        { type: "hook_started", hook: "h", event: "prompt" },
+        { type: "session_started", id: "s", cwd: "/tmp", resumed: false, provider: "p", model: "m", mode: "plan" },
+        { type: "session_replay_finished" },
+        { type: "session_title_changed", title: "t" },
+        { type: "conversation_rewound", messageId: "m", prompt: "p", removedMessages: 1, fileCount: 0 },
+        { type: "conversation_redone", messageId: "m", prompt: "p", restoredMessages: 1, fileCount: 0 },
+        { type: "queue_changed", entries: [] },
+        { type: "queue_flushed", inputs: [] },
+        { type: "agent_questions", questions: [] },
+        { type: "approval_requested", callId: "c", tool: "t", title: "x", readOnly: true },
+        { type: "elicitation_requested", requestId: "r", callId: "c", questions: [] },
+        { type: "elicitation_resolved", callId: "c" },
+        {
+          type: "goal_updated",
+          goal: {
+            status: "active",
+            id: "g",
+            condition: "c",
+            startedAt: 0,
+            evaluatedTurns: 0,
+            usage: {},
+            evaluatorModel: "m",
+            consecutiveNoToolTurns: 0,
+          },
+        },
+        { type: "task_list_updated", tasks: [] },
+      ]),
+    ).toEqual([])
+  })
+
+  test("status-bar events update the sub status bar without blocks", () => {
+    const events: AgentEvent[] = [
+      { type: "state_changed", state: "streaming" },
+      { type: "turn_ended", context: { outputTokens: 5 } },
+      { type: "context_updated", context: { outputTokens: 7 } },
+      { type: "mode_changed", mode: "plan" },
+      { type: "model_changed", provider: "p", model: "m2" },
+      { type: "thinking_changed", thinking: "low" },
+    ]
+    const recorded = recorder(false)
+    for (const event of events) recorded.controller.handle(event)
+    expect(recorded.blocks).toEqual([])
+    expect(recorded.status).toEqual([
+      "state:streaming",
+      "turn:completed",
+      'usage:{"outputTokens":5}',
+      'usage:{"outputTokens":7}',
+      "mode:plan",
+      "model:m2",
+      "thinking:low",
+    ])
+  })
+})

--- a/apps/cli/src/plugins/tui/controllers/child-events.test.ts
+++ b/apps/cli/src/plugins/tui/controllers/child-events.test.ts
@@ -257,17 +257,20 @@ describe("child event mapping", () => {
   })
 
   test("interrupts and failures become info and error blocks", () => {
-    expect(
-      run([
-        { type: "turn_interrupted" },
-        { type: "turn_failed", message: "provider exploded" },
-        { type: "error", message: "plain error" },
-      ]),
-    ).toEqual([
+    const recorded = recorder(false)
+    for (const event of [
+      { type: "turn_interrupted" },
+      { type: "turn_failed", message: "provider exploded" },
+      { type: "error", message: "plain error" },
+    ] satisfies AgentEvent[]) {
+      recorded.controller.handle(event)
+    }
+    expect(recorded.blocks).toEqual([
       { kind: "info", text: "Interrupted" },
       { kind: "error", text: "provider exploded" },
       { kind: "error", text: "plain error" },
     ])
+    expect(recorded.status).toEqual(["turn:interrupted", "turn:failed"])
   })
 
   test("status-bar-only and unreachable child events produce no blocks", () => {

--- a/apps/cli/src/plugins/tui/controllers/child-events.ts
+++ b/apps/cli/src/plugins/tui/controllers/child-events.ts
@@ -142,9 +142,11 @@ export class ChildEventController {
         break
       case "turn_interrupted":
         this.transcript.append({ kind: "info", text: "Interrupted" })
+        this.statusBar.setTurnOutcome("interrupted")
         break
       case "turn_failed":
         this.transcript.append({ kind: "error", text: event.message })
+        this.statusBar.setTurnOutcome("failed")
         break
       case "error":
         this.transcript.append({ kind: "error", text: event.message })

--- a/apps/cli/src/plugins/tui/controllers/child-events.ts
+++ b/apps/cli/src/plugins/tui/controllers/child-events.ts
@@ -1,0 +1,203 @@
+import type { AgentEvent, AgentState } from "../../../agent/events"
+import type { PermissionMode } from "../../../permissions/types"
+import type { ThinkingEffort, Usage } from "../../../providers/types"
+import { compactPath } from "../../../lib/path"
+import type { Block, StreamKind } from "../scrollback/blocks"
+import { formatDuration } from "../lib/format"
+
+export interface ChildTranscript {
+  append(block: Block): void
+  appendStream(kind: StreamKind, text: string): void
+  endStream(): boolean
+}
+
+export interface ChildStatusBar {
+  setState(state: AgentState): void
+  setMode(mode: PermissionMode): void
+  setModel(model: string): void
+  setThinking(thinking: ThinkingEffort | undefined): void
+  setUsage(context: Usage | undefined): void
+  setTurnOutcome(outcome: "completed" | "failed" | "interrupted"): void
+}
+
+export class ChildEventController {
+  private assistantStreamed = false
+  private reasoningStreamed = false
+  private readonly runningTools = new Map<string, number>()
+
+  constructor(
+    private readonly transcript: ChildTranscript,
+    private readonly statusBar: ChildStatusBar,
+  ) {}
+
+  handle(event: AgentEvent): void {
+    switch (event.type) {
+      case "text_delta":
+        this.assistantStreamed = true
+        this.transcript.appendStream("text", event.text)
+        break
+      case "reasoning_summary_delta":
+        this.reasoningStreamed = true
+        this.transcript.appendStream("reasoning", event.text)
+        break
+      case "assistant_message":
+        this.transcript.endStream()
+        if (!this.assistantStreamed) this.transcript.append({ kind: "text", text: event.text })
+        this.assistantStreamed = false
+        break
+      case "reasoning_summary":
+        this.transcript.endStream()
+        if (!this.reasoningStreamed) this.transcript.append({ kind: "reasoning", text: event.text })
+        this.reasoningStreamed = false
+        break
+      case "retry_scheduled":
+        this.assistantStreamed = false
+        this.reasoningStreamed = false
+        this.transcript.append({
+          kind: "info",
+          text: `retrying in ${Math.ceil(event.delayMs / 1_000)}s · attempt ${event.attempt}/${event.maxAttempts} · ${event.message}`,
+        })
+        break
+      case "user_message":
+        this.transcript.append({
+          kind: "user",
+          text: event.text,
+          imageCount: event.imageCount,
+          sentAt: event.sentAt,
+        })
+        break
+      case "tool_started":
+        if (!this.runningTools.has(event.callId)) this.runningTools.set(event.callId, Date.now())
+        break
+      case "tool_finished":
+        this.transcript.append({
+          kind: "tool",
+          tool: event.tool,
+          title: event.title,
+          readOnly: event.readOnly,
+          denial: event.denial,
+          output: event.output,
+          execution: event.execution,
+          elapsed: this.elapsed(event.callId),
+          expanded: false,
+        })
+        break
+      case "shell_finished":
+        this.transcript.append({
+          kind: "tool",
+          tool: "bash",
+          title: event.command,
+          readOnly: event.readOnly,
+          denial: event.denial,
+          output: event.output,
+          execution: event.execution,
+          elapsed: this.elapsed(event.callId),
+          expanded: true,
+        })
+        break
+      case "hook_finished":
+        this.transcript.append({
+          kind: "hook",
+          text: `hook: ${event.hook} · ${event.event} · ${event.action} · ${event.elapsedMs}ms`,
+        })
+        break
+      case "background_results":
+        for (const result of event.results) {
+          this.transcript.append({
+            kind: "background",
+            id: result.id,
+            label: result.kind === "agent" ? result.task : result.command,
+            status: result.status,
+            output: result.output,
+            ...(result.kind === "process" && result.record !== undefined
+              ? { record: `${result.record}${result.recordCapped ? " (capped)" : ""}` }
+              : {}),
+          })
+        }
+        break
+      case "plan_updated":
+        if (event.plan.status === "draft" && !event.plan.feedback) {
+          this.transcript.append({ kind: "plan", path: compactPath(event.plan.path), text: event.plan.markdown })
+          break
+        }
+        this.transcript.append({
+          kind: "info",
+          text: `plan ${event.plan.status === "approved" ? "approved" : "saved for revision"} · ${compactPath(event.plan.path)}`,
+        })
+        break
+      case "compacted":
+        this.transcript.append({
+          kind: "compaction",
+          state: "compacted",
+          summary: event.summary,
+          replaced: event.replaced,
+          tokensBefore: event.tokensBefore,
+        })
+        break
+      case "workspace_changed":
+        this.transcript.append({
+          kind: "info",
+          text: `workspace: ${compactPath(event.previous)} → ${compactPath(event.cwd)}`,
+        })
+        break
+      case "turn_interrupted":
+        this.transcript.append({ kind: "info", text: "Interrupted" })
+        break
+      case "turn_failed":
+        this.transcript.append({ kind: "error", text: event.message })
+        break
+      case "error":
+        this.transcript.append({ kind: "error", text: event.message })
+        break
+      case "state_changed":
+        this.statusBar.setState(event.state)
+        break
+      case "turn_ended":
+        this.statusBar.setTurnOutcome("completed")
+        this.statusBar.setUsage(event.context)
+        break
+      case "context_updated":
+        this.statusBar.setUsage(event.context)
+        break
+      case "mode_changed":
+        this.statusBar.setMode(event.mode)
+        break
+      case "model_changed":
+        this.statusBar.setModel(event.model)
+        break
+      case "thinking_changed":
+        this.statusBar.setThinking(event.thinking)
+        break
+      case "context_window_changed":
+      case "reasoning_delta":
+      case "tool_updated":
+      case "tool_call_updated":
+      case "hook_started":
+      case "session_started":
+      case "session_replay_finished":
+      case "session_title_changed":
+      case "conversation_rewound":
+      case "conversation_redone":
+      case "queue_changed":
+      case "queue_flushed":
+      case "agent_questions":
+      case "approval_requested":
+      case "elicitation_requested":
+      case "elicitation_resolved":
+      case "goal_updated":
+      case "task_list_updated":
+        break
+      default: {
+        const exhaustive: never = event
+        return exhaustive
+      }
+    }
+  }
+
+  private elapsed(callId: string): string | undefined {
+    const startedAt = this.runningTools.get(callId)
+    if (startedAt === undefined) return undefined
+    this.runningTools.delete(callId)
+    return formatDuration(Date.now() - startedAt)
+  }
+}

--- a/apps/cli/src/plugins/tui/controllers/keymap.ts
+++ b/apps/cli/src/plugins/tui/controllers/keymap.ts
@@ -148,8 +148,8 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
           return
         }
         if (screen.agentPageOpen) {
-          screen.activeComposer.clear()
-          return
+          if (screen.activeComposer.clear()) return
+          if (screen.tasks.closeViewer()) return
         }
         if (!screen.overlayVisible && screen.activeComposer.clear()) return
         handleInterrupt(binding)

--- a/apps/cli/src/plugins/tui/controllers/keymap.ts
+++ b/apps/cli/src/plugins/tui/controllers/keymap.ts
@@ -6,6 +6,7 @@ import { nextPermissionMode } from "../../../permissions/modes"
 import { hasPromotion, requestBackground } from "../../../background/promotion"
 import type { Screen } from "../screen"
 import type { ResolvedShortcuts, ShortcutAction, ShortcutStroke } from "../shortcuts"
+import type { StatusBar } from "../components/status-bar"
 
 const QUIT_WINDOW_MS = 2000
 
@@ -46,6 +47,7 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
   let pendingUntil = 0
   let pendingTimer: ReturnType<typeof setTimeout> | undefined
   let pendingNotice = false
+  let pendingStatusBar: StatusBar | undefined
   let thinkingChange = Promise.resolve()
 
   function clearPending(): void {
@@ -54,8 +56,9 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
     pendingUntil = 0
     if (pendingTimer !== undefined) clearTimeout(pendingTimer)
     pendingTimer = undefined
-    if (pendingNotice) screen.statusBar.clearNotice()
+    if (pendingNotice) pendingStatusBar?.clearNotice()
     pendingNotice = false
+    pendingStatusBar = undefined
   }
 
   function handleInterrupt(binding: string): void {
@@ -69,11 +72,12 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
       return
     }
     lastInterrupt = now
-    screen.statusBar.flashNotice(`${binding} again to quit`, QUIT_WINDOW_MS)
+    screen.activeStatusBar.flashNotice(`${binding} again to quit`, QUIT_WINDOW_MS)
   }
 
   function active(action: ShortcutAction, key: KeyEvent, first: ShortcutStroke): boolean {
     if (screen.jobViewer.visible) return action === "agents.stop-all"
+    const agentPage = screen.agentPageOpen
     switch (action) {
       case "agents.open":
         return screen.tasks.count > 0 && !screen.overlayVisible
@@ -84,19 +88,21 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
       case "app.cancel":
       case "display.clear":
       case "display.toggle-details":
-      case "display.toggle-todos":
         return true
+      case "display.toggle-todos":
+        return !agentPage
       case "composer.clear":
       case "composer.newline":
-      case "session.next-mode":
         return !screen.overlayVisible
+      case "session.next-mode":
+        return !screen.overlayVisible && !agentPage
       case "composer.external-editor":
       case "composer.paste-image":
       case "thinking.decrease":
       case "thinking.increase":
-        return !key.repeated && !screen.overlayVisible
+        return !key.repeated && !screen.overlayVisible && !agentPage
       case "history.open":
-        if (screen.overlayVisible) return false
+        if (screen.overlayVisible || agentPage) return false
         if (first.name !== "escape") return true
         return (
           session.currentState === "idle" &&
@@ -124,13 +130,13 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
         screen.openAgents()
         return
       case "jobs.background":
-        screen.statusBar.flashNotice(
+        screen.activeStatusBar.flashNotice(
           requestBackground(session.id) ? "Moved the running command to background" : "No command to background",
           QUIT_WINDOW_MS,
         )
         return
       case "agents.stop-all":
-        screen.statusBar.flashNotice(
+        screen.activeStatusBar.flashNotice(
           screen.tasks.stopAllAgents() ? "Stopping all agents…" : "No agents are running",
           QUIT_WINDOW_MS,
         )
@@ -141,35 +147,39 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
           screen.syncFooter()
           return
         }
-        if (!screen.overlayVisible && screen.composer.clear()) return
+        if (screen.agentPageOpen) {
+          screen.activeComposer.clear()
+          return
+        }
+        if (!screen.overlayVisible && screen.activeComposer.clear()) return
         handleInterrupt(binding)
         return
       case "composer.clear":
-        screen.composer.setValue("")
+        screen.activeComposer.setValue("")
         return
       case "composer.external-editor":
         void edit().catch((error: unknown) => {
-          screen.scrollback.append({ kind: "error", text: describeError(error) })
+          screen.activeScrollback.append({ kind: "error", text: describeError(error) })
         })
         return
       case "composer.newline":
-        screen.composer.newLine()
+        screen.activeComposer.newLine()
         return
       case "composer.paste-image":
-        screen.statusBar.setNotice("Pasting image…")
-        void screen.composer.pasteImage().then((pasted) => {
-          screen.statusBar.flashNotice(pasted ? "Image attached" : "No image found in clipboard", QUIT_WINDOW_MS)
+        screen.activeStatusBar.setNotice("Pasting image…")
+        void screen.activeComposer.pasteImage().then((pasted) => {
+          screen.activeStatusBar.flashNotice(pasted ? "Image attached" : "No image found in clipboard", QUIT_WINDOW_MS)
         })
         return
       case "display.clear":
-        screen.scrollback.clearTranscript()
+        screen.activeScrollback.clearTranscript()
         return
       case "display.toggle-details":
-        screen.scrollback.toggleExpanded()
+        screen.activeScrollback.toggleExpanded()
         return
       case "display.toggle-todos": {
         const visible = screen.taskList.toggleVisibility()
-        screen.statusBar.flashNotice(`Todos ${visible ? "shown" : "hidden"}`, QUIT_WINDOW_MS)
+        screen.activeStatusBar.flashNotice(`Todos ${visible ? "shown" : "hidden"}`, QUIT_WINDOW_MS)
         return
       }
       case "history.open":
@@ -177,7 +187,7 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
         return
       case "session.next-mode":
         if (session.setMode(nextPermissionMode(session.currentMode))) return
-        screen.statusBar.flashNotice("Cannot change mode while a turn or interaction is active", QUIT_WINDOW_MS)
+        screen.activeStatusBar.flashNotice("Cannot change mode while a turn or interaction is active", QUIT_WINDOW_MS)
         return
       case "thinking.decrease":
         changeThinking(-1)
@@ -226,29 +236,16 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
     pendingStartedAt = startedAt
     pendingUntil = now + resolution.timeoutMs
     pendingNotice = resolution.notice !== undefined
-    if (resolution.notice) screen.statusBar.setNotice(resolution.notice)
+    if (resolution.notice) {
+      pendingStatusBar = screen.activeStatusBar
+      pendingStatusBar.setNotice(resolution.notice)
+    }
     pendingTimer = setTimeout(clearPending, resolution.timeoutMs)
     pendingTimer.unref()
     return true
   }
 
   renderer.keyInput.on("keypress", (key) => {
-    if (
-      !screen.overlayVisible &&
-      key.ctrl &&
-      !key.meta &&
-      !key.option &&
-      !key.shift &&
-      !key.super &&
-      !key.hyper &&
-      key.name === "u" &&
-      screen.jobViewer.handleInputKey(key)
-    ) {
-      clearPending()
-      key.preventDefault()
-      screen.syncFooter()
-      return
-    }
     if (handleShortcut(key)) return
     if (screen.config.handleKey(key.name)) {
       key.preventDefault()
@@ -275,11 +272,6 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
       screen.syncFooter()
       return
     }
-    if (screen.jobViewer.handleInputKey(key)) {
-      key.preventDefault()
-      screen.syncFooter()
-      return
-    }
     const unmodified = !key.ctrl && !key.meta && !key.shift
     if (!screen.overlayVisible && unmodified && screen.tasks.handleKey(key.name)) {
       key.preventDefault()
@@ -292,10 +284,10 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
       key.name === "down" &&
       !screen.tasks.focused &&
       screen.tasks.count > 0 &&
-      screen.composer.empty
+      screen.activeComposer.empty
     ) {
       key.preventDefault()
-      screen.composer.blur()
+      screen.activeComposer.blur()
       screen.tasks.focus()
       screen.syncFooter()
       return
@@ -308,7 +300,7 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
       !screen.overlayVisible &&
       unmodified &&
       (key.name === "up" || key.name === "down") &&
-      screen.composer.navigateHistory(key.name === "up" ? "older" : "newer")
+      screen.activeComposer.navigateHistory(key.name === "up" ? "older" : "newer")
     ) {
       key.preventDefault()
       return

--- a/apps/cli/src/plugins/tui/lib/agent-metrics.ts
+++ b/apps/cli/src/plugins/tui/lib/agent-metrics.ts
@@ -1,0 +1,15 @@
+import type { BackgroundAgentSnapshot, BackgroundTaskState } from "../../../background/registry"
+import { formatTokens } from "../../../lib/format"
+import { redactText } from "../../../secrets/redactor"
+import { formatDuration } from "./format"
+
+export function agentSnapshotMetrics(state: BackgroundTaskState, snapshot: BackgroundAgentSnapshot): string {
+  if (!state.running) return redactText(state.detail)
+  if (snapshot.queued) return `queued ${formatDuration(snapshot.queuedMs)}`
+  if (snapshot.stopping) return "stopping"
+  const requests = ` · ${snapshot.providerRequests} provider requests`
+  const tokens = snapshot.contextTokens ? ` · ↓ ${formatTokens(snapshot.contextTokens)} tokens` : ""
+  const turns = ` · turn cycle ${snapshot.completedTurns}/${snapshot.turnBudget} (${snapshot.turnLimit} max)`
+  const remaining = snapshot.remainingMs === undefined ? "" : ` · ${formatDuration(snapshot.remainingMs)} left`
+  return `${formatDuration(snapshot.elapsedMs)}${requests}${tokens}${turns}${remaining} · idle ${formatDuration(snapshot.idleMs)}`
+}

--- a/apps/cli/src/plugins/tui/screen.test.ts
+++ b/apps/cli/src/plugins/tui/screen.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { mainFooterHeight } from "./screen"
+import { agentSteerDecision, mainFooterHeight } from "./screen"
 
 test("live tools fill the gap between scrollback and the fixed footer", () => {
   expect(mainFooterHeight(40, 12, 8, 1)).toBe(28)
@@ -11,4 +11,19 @@ test("live tools stay attached as completed rows enter scrollback", () => {
 
 test("the footer returns to its content height without live tools", () => {
   expect(mainFooterHeight(40, 12, 8, 0)).toBe(8)
+})
+
+test("image steering is rejected with an error even for a steerable agent", () => {
+  expect(agentSteerDecision(true, { text: "look", images: [{ mediaType: "image/png", data: "x" }] })).toEqual({
+    kind: "error",
+    message: "image input is not available while steering a task agent",
+  })
+})
+
+test("an agent that is not accepting input bounces with a notice", () => {
+  expect(agentSteerDecision(false, { text: "hello", images: [] })).toEqual({ kind: "bounce" })
+})
+
+test("text steering for a running agent is sent", () => {
+  expect(agentSteerDecision(true, { text: "hello", images: [] })).toEqual({ kind: "send" })
 })

--- a/apps/cli/src/plugins/tui/screen.ts
+++ b/apps/cli/src/plugins/tui/screen.ts
@@ -602,7 +602,7 @@ export class Screen {
       this.openMainPage()
       return
     }
-    if (task.kind === "agent" && this.childStores.has(task.id)) {
+    if (task.kind === "agent") {
       this.openAgentPage(task)
       return
     }
@@ -665,7 +665,7 @@ export class Screen {
     this.agentComposer.focus()
   }
 
-  private openJobPage(task: BackgroundTask): void {
+  private openJobPage(task: Exclude<BackgroundTask, BackgroundAgentTask>): void {
     const previous = this.page
     this.page = { kind: "job" }
     if (previous.kind === "agent") {

--- a/apps/cli/src/plugins/tui/screen.ts
+++ b/apps/cli/src/plugins/tui/screen.ts
@@ -1,6 +1,11 @@
-import type { BoxRenderable, CliRenderer } from "@opentui/core"
+import { RenderableEvents, type BoxRenderable, type CliRenderer, type RGBA } from "@opentui/core"
 import type { AgentSession } from "../../agent/session/session"
-import type { BackgroundTask } from "../../background/registry"
+import {
+  listBackgroundTasks,
+  subscribeBackgroundTasks,
+  type BackgroundAgentTask,
+  type BackgroundTask,
+} from "../../background/registry"
 import { runCommand } from "../../commands/run"
 import type { CommandContext, SelectRequest } from "../../commands/types"
 import { describeError } from "../../lib/error"
@@ -24,7 +29,11 @@ import { ShortcutHelp } from "./components/shortcut-help"
 import { StatusBar, STATUS_ROWS } from "./components/status-bar"
 import { TaskList } from "./components/task-list"
 import { saveTuiConfig, type TuiConfig } from "./config"
+import { ChildEventController } from "./controllers/child-events"
 import { column } from "./lib/renderables"
+import { agentSnapshotMetrics } from "./lib/agent-metrics"
+import { truncateToWidth } from "./lib/text"
+import { COLORS } from "./theme/colors"
 import type { MessageHistory } from "./message-history"
 import { Scrollback } from "./scrollback/scrollback"
 import type { ResolvedShortcuts } from "./shortcuts"
@@ -36,7 +45,14 @@ export interface ScreenActions extends PermissionPopoverActions, ElicitationPopo
 
 const SCROLLBACK_GAP_ROWS = 1
 
-type ScreenPage = { kind: "main" } | { kind: "job" }
+type ScreenPage = { kind: "main" } | { kind: "agent"; taskId: string } | { kind: "job" }
+
+interface ChildStore {
+  task: BackgroundAgentTask
+  scrollback: Scrollback
+  statusBar: StatusBar
+  detach: () => void
+}
 
 export function mainFooterHeight(
   terminalHeight: number,
@@ -46,6 +62,17 @@ export function mainFooterHeight(
 ): number {
   if (liveRows === 0) return contentRows
   return Math.max(contentRows, terminalHeight - scrollbackRows)
+}
+
+export function agentSteerDecision(
+  steerable: boolean,
+  input: UserInput,
+): { kind: "error"; message: string } | { kind: "bounce" } | { kind: "send" } {
+  if (input.images.length > 0) {
+    return { kind: "error", message: "image input is not available while steering a task agent" }
+  }
+  if (!steerable) return { kind: "bounce" }
+  return { kind: "send" }
 }
 
 export class Screen {
@@ -62,10 +89,14 @@ export class Screen {
   readonly config: ConfigPopover
   readonly palette: CompletionPalette
   readonly composer: Composer
+  readonly agentComposer: Composer
   readonly statusBar: StatusBar
   readonly tasks: BackgroundTasks
   readonly taskList: TaskList
   private readonly shortcutHelp: ShortcutHelp
+  private readonly childStores = new Map<string, ChildStore>()
+  private readonly preferences: TuiConfig
+  private readonly shortcuts: ResolvedShortcuts
   private overlaid = false
   private paletteBelow = true
   private pendingScrollbackRows = 0
@@ -83,6 +114,8 @@ export class Screen {
     shortcuts: ResolvedShortcuts,
     actions: ScreenActions,
   ) {
+    this.preferences = preferences
+    this.shortcuts = shortcuts
     this.cwd = redactText(session.currentWorkingDirectory)
     this.scrollback = new Scrollback(
       renderer,
@@ -92,7 +125,7 @@ export class Screen {
       shortcuts.help("display.toggle-details"),
     )
     this.view = column(renderer, { width: "100%", height: "100%" })
-    this.jobViewer = new JobViewer(renderer, (message) => this.statusBar.setNotice(message))
+    this.jobViewer = new JobViewer(renderer)
     this.live = new LiveTools(renderer, () => this.syncFooter(), shortcuts.help("jobs.background"))
     this.queued = new QueuedInputs(renderer, () => this.syncFooter())
     this.taskList = new TaskList(renderer, () => this.syncFooter())
@@ -132,11 +165,17 @@ export class Screen {
       renderer,
       session.currentWorkingDirectory,
       {
-        completeCommand: (line) => this.composer.setValue(line),
-        completeSkill: (query, name, trailingSpace) => this.composer.completeSkill(query, name, trailingSpace),
-        completeFile: (query, path) => this.composer.completeFile(query, path),
-        runCommand: (line) => this.runCommand(line),
-        error: (message) => this.scrollback.append({ kind: "error", text: message }),
+        completeCommand: (line) => this.activeComposer.setValue(line),
+        completeSkill: (query, name, trailingSpace) => this.activeComposer.completeSkill(query, name, trailingSpace),
+        completeFile: (query, path) => this.activeComposer.completeFile(query, path),
+        runCommand: (line) => {
+          if (this.page.kind === "agent") {
+            this.rejectAgentCommand()
+            return
+          }
+          this.runCommand(line)
+        },
+        error: (message) => this.activeScrollback.append({ kind: "error", text: message }),
       },
       () => this.syncFooter(),
     )
@@ -167,23 +206,45 @@ export class Screen {
       },
       resize: () => this.syncFooter(),
     })
+    this.agentComposer = new Composer(
+      renderer,
+      history,
+      {
+        submit: (input) => this.submitAgentSteer(input),
+        run: () => this.rejectAgentCommand(),
+        error: (message) => this.appendAgentSteerError(message),
+        change: (value, cursor) => {
+          if (value.trimStart().startsWith("/")) {
+            this.palette.dismiss()
+            return
+          }
+          this.placePalette()
+          this.palette.update(value, cursor, this.paletteLimit())
+        },
+        resize: () => this.syncFooter(),
+      },
+      COLORS.agent,
+    )
     this.tasks = new BackgroundTasks(
       renderer,
       {
         changed: () => {
           this.jobViewer.refresh()
+          this.refreshActiveAgentStatusBar()
           this.syncFooter()
         },
         released: () => {
-          if (!this.overlayVisible) this.composer.focus()
+          if (!this.overlayVisible) this.activeComposer.focus()
         },
         viewJob: (task) => this.viewJob(task),
-        scrollViewer: (name) => this.jobViewer.scrollKey(name),
+        scrollViewer: (name) => this.page.kind === "job" && this.jobViewer.scrollKey(name),
         error: (message) => this.scrollback.append({ kind: "error", text: message }),
       },
       shortcuts.help("agents.stop-all"),
       () => this.session.id,
     )
+    const unsubscribeChildStores = subscribeBackgroundTasks(() => this.syncChildStores())
+    this.view.on(RenderableEvents.DESTROYED, unsubscribeChildStores)
 
     this.mainPanel = column(renderer, { paddingLeft: 2, paddingRight: 2, marginBottom: "auto" })
     this.mainPanel.add(this.live.view)
@@ -197,6 +258,7 @@ export class Screen {
     this.view.add(this.config.view)
     this.view.add(this.jobViewer.view)
     this.view.add(this.composer.view)
+    this.view.add(this.agentComposer.view)
     this.view.add(this.shortcutHelp.view)
     this.view.add(this.palette.view)
     this.view.add(this.statusBar.view)
@@ -212,6 +274,37 @@ export class Screen {
       this.picker.visible ||
       this.config.visible
     )
+  }
+
+  get agentPageOpen(): boolean {
+    return this.page.kind === "agent"
+  }
+
+  get activeScrollback(): Scrollback {
+    if (this.page.kind === "agent") return this.childStores.get(this.page.taskId)?.scrollback ?? this.scrollback
+    return this.scrollback
+  }
+
+  get activeComposer(): Composer {
+    if (this.page.kind === "agent") return this.agentComposer
+    return this.composer
+  }
+
+  get activeStatusBar(): StatusBar {
+    if (this.page.kind === "agent") return this.childStores.get(this.page.taskId)?.statusBar ?? this.statusBar
+    return this.statusBar
+  }
+
+  setTerminalBackground(background: RGBA): boolean {
+    let changed = this.scrollback.setTerminalBackground(background)
+    for (const store of this.childStores.values()) {
+      changed = store.scrollback.setTerminalBackground(background) || changed
+    }
+    return changed
+  }
+
+  replayActiveTranscript(): void {
+    this.activeScrollback.replay()
   }
 
   requestApproval(suggestion: string | undefined): void {
@@ -275,6 +368,7 @@ export class Screen {
   }
 
   async select<T>(request: SelectRequest<T>): Promise<T | undefined> {
+    this.tasks.closeViewer()
     this.config.hide()
     const options = request.options.map((option) => ({
       ...option,
@@ -289,12 +383,14 @@ export class Screen {
   }
 
   async ask(question: string): Promise<string | undefined> {
+    this.tasks.closeViewer()
     this.config.hide()
     this.picker.hide()
     return this.secret.show(redactText(question), false)
   }
 
   async askSecret(question: string): Promise<string | undefined> {
+    this.tasks.closeViewer()
     this.config.hide()
     this.picker.hide()
     const value = await this.secret.show(redactText(question))
@@ -334,6 +430,28 @@ export class Screen {
 
   syncFooter(): void {
     const overlaid = this.overlayVisible
+    if (this.page.kind === "agent") {
+      this.shortcutHelp.setCovered(true)
+      this.composer.setVisible(false)
+      this.composer.blur()
+      this.agentComposer.setVisible(true)
+      this.statusBar.view.visible = false
+      this.showAgentStatusBar(this.page.taskId)
+      this.tasks.view.visible = true
+      const paletteRows = this.palette.visible ? this.palette.height : 0
+      if (this.paletteBelow) this.reserved = 0
+      else this.reserved = Math.max(this.reserved, paletteRows)
+      const editing = this.agentComposer.rows + this.shortcutHelp.height + Math.max(paletteRows, this.reserved)
+      const contentRows = editing + STATUS_ROWS + this.tasks.height
+      this.renderer.footerHeight = mainFooterHeight(
+        this.renderer.terminalHeight,
+        this.activeScrollback.rows + this.pendingScrollbackRows,
+        contentRows,
+        0,
+      )
+      this.activeStatusBar.setHint(this.palette.visible ? "↑↓ · Tab · Enter · Esc" : undefined)
+      return
+    }
     const jobPage = this.page.kind === "job"
     this.shortcutHelp.setCovered(overlaid || jobPage)
     if (jobPage) {
@@ -341,12 +459,16 @@ export class Screen {
       this.reserved = 0
       this.composer.setVisible(false)
       this.composer.blur()
+      this.agentComposer.setVisible(false)
       this.statusBar.view.visible = false
+      this.showAgentStatusBar(undefined)
       this.tasks.view.visible = false
       this.jobViewer.resize(this.renderer.terminalHeight)
       return
     }
     this.statusBar.view.visible = true
+    this.showAgentStatusBar(undefined)
+    this.agentComposer.setVisible(false)
     this.tasks.view.visible = true
     if (overlaid !== this.overlaid) {
       this.overlaid = overlaid
@@ -365,7 +487,7 @@ export class Screen {
       this.composer.setVisible(!overlaid)
     }
     if (overlaid) this.palette.dismiss()
-    this.statusBar.setHint(this.palette.visible ? "↑↓ · Tab · Enter · Esc" : undefined)
+    this.activeStatusBar.setHint(this.palette.visible ? "↑↓ · Tab · Enter · Esc" : undefined)
     this.elicitation.fit()
     const overlayRows = this.permission.visible
       ? this.permission.height
@@ -407,6 +529,9 @@ export class Screen {
   }
 
   private closedFooterRows(): number {
+    if (this.page.kind === "agent") {
+      return this.agentComposer.rows + this.shortcutHelp.height + STATUS_ROWS + this.tasks.height
+    }
     if (this.jobViewer.visible) {
       return this.jobViewer.height + this.composer.rows + this.shortcutHelp.height + STATUS_ROWS + this.tasks.height
     }
@@ -424,7 +549,7 @@ export class Screen {
   private spaceBelowFooter(): number {
     const terminal = this.renderer.terminalHeight
     const footer = this.closedFooterRows()
-    const content = this.scrollback.rows + SCROLLBACK_GAP_ROWS
+    const content = this.activeScrollback.rows + SCROLLBACK_GAP_ROWS
     const top = Math.max(0, Math.min(content, terminal - footer))
     return Math.max(0, terminal - top - footer)
   }
@@ -442,7 +567,7 @@ export class Screen {
     if (below === this.paletteBelow) return
     this.paletteBelow = below
     this.view.remove(this.palette.view)
-    this.view.insertBefore(this.palette.view, below ? this.statusBar.view : this.composer.view)
+    this.view.insertBefore(this.palette.view, below ? this.activeStatusBar.view : this.activeComposer.view)
     this.syncFooter()
   }
 
@@ -473,27 +598,181 @@ export class Screen {
   }
 
   private viewJob(task: BackgroundTask | undefined): void {
-    if (task) {
-      const entering = this.page.kind === "main"
-      this.page = { kind: "job" }
-      this.jobViewer.show(task)
-      this.mainPanel.visible = false
-      this.palette.dismiss()
-      if (entering) {
-        this.scrollback.setActive(false)
-        this.renderer.externalOutputMode = "passthrough"
-        this.renderer.screenMode = "alternate-screen"
-      }
-      this.syncFooter()
+    if (task === undefined) {
+      this.openMainPage()
       return
     }
-    if (this.page.kind === "main") return
-    this.page = { kind: "main" }
-    this.jobViewer.hide()
-    this.mainPanel.visible = true
+    if (task.kind === "agent" && this.childStores.has(task.id)) {
+      this.openAgentPage(task)
+      return
+    }
+    this.openJobPage(task)
+  }
+
+  private openMainPage(): void {
+    switch (this.page.kind) {
+      case "main":
+        return
+      case "agent": {
+        const store = this.childStores.get(this.page.taskId)
+        this.page = { kind: "main" }
+        this.palette.dismiss()
+        store?.scrollback.setActive(false)
+        this.scrollback.setActive(true)
+        this.mainPanel.visible = true
+        this.agentComposer.setVisible(false)
+        this.agentComposer.setBadge(undefined)
+        this.agentComposer.blur()
+        if (!this.tasks.focused) this.composer.focus()
+        this.syncFooter()
+        return
+      }
+      case "job":
+        this.page = { kind: "main" }
+        this.jobViewer.hide()
+        this.mainPanel.visible = true
+        this.syncFooter()
+        this.renderer.screenMode = "split-footer"
+        this.renderer.externalOutputMode = "capture-stdout"
+        this.scrollback.setActive(true)
+        return
+    }
+  }
+
+  private openAgentPage(task: BackgroundAgentTask): void {
+    const store = this.childStores.get(task.id)
+    if (!store) return
+    const previous = this.page
+    if (previous.kind === "agent") {
+      if (previous.taskId === task.id) return
+      this.childStores.get(previous.taskId)?.scrollback.setActive(false)
+    }
+    if (previous.kind === "job") {
+      this.jobViewer.hide()
+      this.renderer.screenMode = "split-footer"
+      this.renderer.externalOutputMode = "capture-stdout"
+    } else {
+      this.scrollback.setActive(false)
+    }
+    this.page = { kind: "agent", taskId: task.id }
+    this.palette.dismiss()
+    this.mainPanel.visible = false
+    this.agentComposer.setBadge(` ${truncateToWidth(redactText(task.id), 24)}`)
+    store.scrollback.setActive(true)
+    this.seedAgentStatusBar(store)
     this.syncFooter()
-    this.renderer.screenMode = "split-footer"
-    this.renderer.externalOutputMode = "capture-stdout"
-    this.scrollback.setActive(true)
+    this.tasks.blur()
+    this.agentComposer.focus()
+  }
+
+  private openJobPage(task: BackgroundTask): void {
+    const previous = this.page
+    this.page = { kind: "job" }
+    if (previous.kind === "agent") {
+      this.palette.dismiss()
+      this.childStores.get(previous.taskId)?.scrollback.setActive(false)
+      this.agentComposer.setVisible(false)
+      this.agentComposer.blur()
+    }
+    this.jobViewer.show(task)
+    this.mainPanel.visible = false
+    this.palette.dismiss()
+    if (previous.kind !== "job") {
+      this.scrollback.setActive(false)
+      this.renderer.externalOutputMode = "passthrough"
+      this.renderer.screenMode = "alternate-screen"
+    }
+    this.syncFooter()
+  }
+
+  private activeChildStore(): ChildStore | undefined {
+    if (this.page.kind !== "agent") return undefined
+    return this.childStores.get(this.page.taskId)
+  }
+
+  private submitAgentSteer(input: UserInput): boolean {
+    const store = this.activeChildStore()
+    if (!store) return false
+    const steerable = store.task.state().running && store.task.childSessionId() !== undefined
+    const decision = agentSteerDecision(steerable, input)
+    if (decision.kind === "error") {
+      this.appendAgentSteerError(decision.message)
+      return false
+    }
+    if (decision.kind === "bounce" || !store.task.send(input.text)) {
+      this.activeStatusBar.flashNotice(`${store.task.id} is not accepting input`)
+      return false
+    }
+    return true
+  }
+
+  private rejectAgentCommand(): void {
+    this.appendAgentSteerError("commands are not available while steering a task agent")
+  }
+
+  private appendAgentSteerError(message: string): void {
+    this.activeScrollback.append({ kind: "error", text: message })
+  }
+
+  private showAgentStatusBar(taskId: string | undefined): void {
+    for (const [id, store] of this.childStores) {
+      store.statusBar.view.visible = id === taskId
+    }
+  }
+
+  private seedAgentStatusBar(store: ChildStore): void {
+    store.statusBar.setModel(store.task.model)
+    store.statusBar.setMode(store.task.mode)
+    store.statusBar.setMetrics(agentSnapshotMetrics(store.task.state(), store.task.snapshot()))
+  }
+
+  private refreshActiveAgentStatusBar(): void {
+    if (this.page.kind !== "agent") return
+    const store = this.childStores.get(this.page.taskId)
+    if (store) this.seedAgentStatusBar(store)
+  }
+
+  private syncChildStores(): void {
+    const agents = listBackgroundTasks().filter((task): task is BackgroundAgentTask => task.kind === "agent")
+    for (const task of agents) {
+      if (this.childStores.has(task.id)) continue
+      this.childStores.set(task.id, this.createChildStore(task))
+    }
+    for (const id of [...this.childStores.keys()]) {
+      if (agents.some((task) => task.id === id)) continue
+      this.disposeChildStore(id)
+    }
+  }
+
+  private createChildStore(task: BackgroundAgentTask): ChildStore {
+    const scrollback = new Scrollback(
+      this.renderer,
+      0,
+      (rows) => this.reclaim(rows),
+      this.preferences,
+      this.shortcuts.help("display.toggle-details"),
+    )
+    scrollback.setActive(false)
+    const statusBar = new StatusBar(this.renderer, task.model, undefined, task.mode)
+    statusBar.view.visible = false
+    this.view.insertBefore(statusBar.view, this.tasks.view)
+    const controller = new ChildEventController(scrollback, statusBar)
+    return {
+      task,
+      scrollback,
+      statusBar,
+      detach: task.onEvent === undefined ? () => {} : task.onEvent((event) => controller.handle(event)),
+    }
+  }
+
+  private disposeChildStore(id: string): void {
+    const store = this.childStores.get(id)
+    if (!store) return
+    if (this.page.kind === "agent" && this.page.taskId === id) this.openMainPage()
+    this.childStores.delete(id)
+    store.scrollback.setActive(false)
+    store.detach()
+    this.view.remove(store.statusBar.view)
+    store.statusBar.view.destroyRecursively()
   }
 }

--- a/docs/background-work.md
+++ b/docs/background-work.md
@@ -83,7 +83,7 @@ Stopping a job from the TUI is never silent: the result is marked `stopped by th
 
 - The status bar shows live counts (`2 agents · 1 job · …`) whenever background work exists.
 - Running agents are summarized above the composer by ID and elapsed time; queued agents show `queued <time>` until they start.
-- The navigator at the bottom lists every process, task agent, and schedule: running rows first, then finished rows (newest first). Schedule rows show their remaining time. The full viewer shows live activity and timing, plus context, tool, and turn metrics for agents. Successfully completed agents are dismissed when the primary session returns to idle; failed agents and finished jobs remain reviewable until dismissed or evicted, and jobs started by a sub-agent are attributed with `⟨agent-id⟩`.
+- The navigator at the bottom lists every process, task agent, and schedule: running rows first, then finished rows (newest first). Schedule rows show their remaining time. Successfully completed agents are dismissed when the primary session returns to idle; failed agents and finished jobs remain reviewable until dismissed or evicted, and jobs started by a sub-agent are attributed with `⟨agent-id⟩`.
 - Normal transcript mode shows a completed background result as its ID and first report line. Use `display.toggle-details` (default `ctrl+o`) to reveal its assignment, status, line count, report output, and record path.
 
 Open the navigator with `/agents` (alias `/jobs`), the `agents.open` shortcut (default `ctrl+x ctrl+a`), or by pressing `↓` with an empty composer.
@@ -98,7 +98,9 @@ Navigator keys:
 | `x` / `k` | Stop a running job, or dismiss a finished row              |
 | `esc`     | Close the viewer, collapse the preview, or leave           |
 
-The viewer takes over the screen and follows the job's output live. While it is open, `↑`/`↓` keep moving the selection in the list below and `enter` switches the viewer to the selected job (or closes it on the viewed row), so you can hop between running agents without leaving the viewer. `pgup`/`pgdn` scroll the transcript, `home` jumps to the top, and `end` returns to the bottom and resumes following (scrolling up pauses following and shows `· paused`). For a running agent, `i` opens a steering input, type guidance and press `enter` to queue it into the agent's current turn; the transcript marks it as `User guidance`.
+Opening a process or schedule job takes over the screen with the raw-text viewer and follows its output live. While it is open, `↑`/`↓` keep moving the selection in the list below and `enter` switches the viewer to the selected job (or closes it on the viewed row), so you can hop between jobs without leaving the viewer. `pgup`/`pgdn` scroll the transcript, `home` jumps to the top, and `end` returns to the bottom and resumes following (scrolling up pauses following and shows `· paused`).
+
+Opening a task agent instead clears the terminal scrollback and prints the agent's transcript (reasoning, tool activity, errors, and guidance) through the same native scrollback as the main session, with its own status bar showing the agent's model, mode, and live metrics; the navigator stays visible below it. The composer shows an agent-colored indicator while the page is open and steers the viewed agent: submitted text is queued into the agent's current turn, appears as a user block in its transcript, and is recorded as `User guidance` in the plain-text transcript surfaced by `job_output`. Slash commands and image input are rejected with an error in the transcript, and submissions bounce with a status-bar notice while the agent is queued, stopping, between turns, or finished. `esc` closes the page and restores the main transcript from memory; the steering draft is kept for the next visit. Approvals, prompts, and other popovers always close the agent page and render on the main page.
 
 `agents.stop-all` (default `ctrl+x ctrl+k`) stops every running agent at once.
 


### PR DESCRIPTION
Add dedicated TUI views for background task agents with live event streaming, agent-specific status and metrics, and an integrated guidance composer. Simplify the legacy job viewer for process and schedule output, refresh related navigation and documentation, and add coverage for event multicast and child event rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated pages for background agent tasks with transcript history, status, metrics, scrolling, and task navigation.
  - Added live agent event updates, including reasoning, tool activity, progress, usage, errors, and completion states.
  - Added steering input for running agents, with validation for unsupported commands and image input.
  - Added composer indicators and badges for clearer task context.

- **Improvements**
  - Process and scheduled jobs now use a live raw-text viewer.
  - Improved transcript replay, resizing, editor integration, and status-bar updates.

- **Documentation**
  - Updated background task viewing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->