### PR TITLE
Fix elicitation input width for long custom answers

### DIFF
--- a/apps/cli/src/plugins/tui/components/elicitation-popover.test.ts
+++ b/apps/cli/src/plugins/tui/components/elicitation-popover.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { InputRenderable, type BaseRenderable } from "@opentui/core"
+import { createTestRenderer } from "@opentui/core/testing"
+import { ElicitationPopover } from "./elicitation-popover"
+
+function findInput(view: BaseRenderable): InputRenderable | undefined {
+  if (view instanceof InputRenderable) return view
+  for (const child of view.getChildren()) {
+    const input = findInput(child)
+    if (input) return input
+  }
+}
+
+test("long custom answers use the full input width", async () => {
+  const setup = await createTestRenderer({ width: 150, height: 24 })
+  const popover = new ElicitationPopover(
+    setup.renderer,
+    { answer() {}, reject() {} },
+    () => {},
+    () => 20,
+  )
+  setup.renderer.root.add(popover.view)
+
+  try {
+    popover.show("request", [
+      { id: "question", header: "Migration strategy", question: "How should it be replaced?", options: [] },
+    ])
+    await setup.renderOnce()
+    popover.handleKey("enter")
+    await setup.renderOnce()
+
+    const input = findInput(popover.view)
+    if (!input) throw new Error("Elicitation input not found")
+    input.insertText("a".repeat(200))
+    await setup.renderOnce()
+
+    const inputRow = setup
+      .captureCharFrame()
+      .split("\n")
+      .find((line) => line.includes("aaaa"))
+    if (!inputRow) throw new Error("Rendered elicitation input row not found")
+    expect(inputRow.lastIndexOf("a")).toBeGreaterThanOrEqual(input.x + input.width - 3)
+  } finally {
+    popover.hide()
+    setup.renderer.destroy()
+  }
+})

--- a/apps/cli/src/plugins/tui/components/elicitation-popover.ts
+++ b/apps/cli/src/plugins/tui/components/elicitation-popover.ts
@@ -176,6 +176,7 @@ export class ElicitationPopover {
       flexGrow: 1,
       flexShrink: 1,
       minWidth: 1,
+      scrollMargin: 0,
       onKeyDown: (key) => {
         imeKeyDown(key, {
           barrier: this.imeCommit,


### PR DESCRIPTION
Set the elicitation input scroll margin to zero so long custom answers use the full available width, with a regression test covering the rendered input row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long custom elicitation responses now use the full available input width, improving visibility while typing.

* **Tests**
  * Added regression coverage to verify correct rendering of long elicitation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->