### PR TITLE
Fix task agent steering and supervision waits

### DIFF
--- a/apps/cli/src/agent/session/session-control.test.ts
+++ b/apps/cli/src/agent/session/session-control.test.ts
@@ -174,6 +174,66 @@ describe("AgentSession control flow", () => {
     expect(observed.some((event) => event.type === "turn_interrupted")).toBe(false)
   })
 
+  test("steering interrupts automatic subagent compaction and continues with the guidance", async () => {
+    const entered = latch()
+    const blockedSummary: ProviderRound = async function* (request) {
+      entered.release()
+      await new Promise<void>((resolve, reject) => {
+        if (request.signal?.aborted) {
+          resolve()
+          return
+        }
+        const timeout = setTimeout(() => reject(new Error("compaction was not interrupted")), 1_000)
+        request.signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timeout)
+            resolve()
+          },
+          { once: true },
+        )
+      })
+      if (!request.signal?.aborted) yield { type: "done" }
+      throw request.signal?.reason
+    }
+    const provider = new ScriptedProvider(
+      [
+        completedRound("s".repeat(1_000), { totalInputTokens: 90 }),
+        blockedSummary,
+        completedRound("Recovered summary"),
+        completedRound("Stopped and returned the compacted result."),
+      ],
+      200,
+      90,
+    )
+    const session = harness.createSession(provider, { kind: "subagent" })
+    const observed: AgentEvent[] = []
+
+    await runSettledTurn(session, { text: "Fill the context.", images: [] })
+    const running = runSettledTurn(session, { text: "Continue the work.", images: [] }, (event) => {
+      observed.push(event)
+    })
+    await entered.promise
+
+    expect(session.steer("Parent guidance:\nStop now and return the result.")).toBe(true)
+    const outcome = await running
+
+    expect(outcome).toEqual({
+      status: "completed",
+      response: "Stopped and returned the compacted result.",
+      usage: undefined,
+      context: undefined,
+    })
+    expect(provider.requests).toHaveLength(4)
+    expect(provider.requests[1]?.signal?.aborted).toBe(true)
+    expect(provider.requests[3]?.input).toContainEqual({
+      type: "user_message",
+      text: interjectionMessage("Parent guidance:\nStop now and return the result."),
+      images: [],
+    })
+    expect(observed.some((event) => event.type === "turn_interrupted")).toBe(false)
+  })
+
   test("hard interruption overrides a steering handoff before the provider settles", async () => {
     const entered = latch()
     const release = latch()

--- a/apps/cli/src/agent/session/session-control.test.ts
+++ b/apps/cli/src/agent/session/session-control.test.ts
@@ -97,6 +97,119 @@ describe("AgentSession control flow", () => {
     expect(observed.filter((event) => event.type === "queue_flushed")).toHaveLength(0)
   })
 
+  test("allows tools that explicitly support identical repeated calls", async () => {
+    const toolName = `repeatable_probe_${crypto.randomUUID().replaceAll("-", "_")}`
+    let executions = 0
+    const tool: Tool = {
+      name: toolName,
+      description: "Wait for external activity",
+      parameters: { type: "object", additionalProperties: false },
+      title: () => "Wait for activity",
+      readOnly: () => true,
+      allowRepeatedCalls: () => true,
+      async execute() {
+        executions += 1
+        return { output: "Still waiting." }
+      },
+    }
+    const provider = new ScriptedProvider([
+      toolRound("wait-1", toolName, {}),
+      toolRound("wait-2", toolName, {}),
+      toolRound("wait-3", toolName, {}),
+      toolRound("wait-4", toolName, {}),
+      completedRound("Finished waiting."),
+    ])
+    const session = harness.createSession(provider)
+
+    registerTool(tool)
+    try {
+      const outcome = await runSettledTurn(session, { text: "Wait until the work finishes.", images: [] })
+
+      expect(outcome.status).toBe("completed")
+      expect(outcome.response).toBe("Finished waiting.")
+      expect(executions).toBe(4)
+    } finally {
+      unregisterTool(tool)
+    }
+  })
+
+  test("steering interrupts an active provider round and continues with the guidance", async () => {
+    const entered = latch()
+    const blockedRound: ProviderRound = async function* (request) {
+      entered.release()
+      await new Promise<void>((resolve) => {
+        if (request.signal?.aborted) {
+          resolve()
+          return
+        }
+        request.signal?.addEventListener("abort", () => resolve(), { once: true })
+      })
+      if (!request.signal?.aborted) yield { type: "done" }
+      throw request.signal?.reason
+    }
+    const provider = new ScriptedProvider([blockedRound, completedRound("Stopped and returned the result.")])
+    const session = harness.createSession(provider, { kind: "subagent" })
+    const observed: AgentEvent[] = []
+
+    const running = runSettledTurn(session, { text: "Inspect the repository.", images: [] }, (event) => {
+      observed.push(event)
+    })
+    await entered.promise
+
+    expect(session.steer("Parent guidance:\nStop now and return the result.")).toBe(true)
+    const outcome = await running
+
+    expect(outcome).toEqual({
+      status: "completed",
+      response: "Stopped and returned the result.",
+      usage: undefined,
+      context: undefined,
+    })
+    expect(provider.requests).toHaveLength(2)
+    expect(provider.requests[1]?.input.at(-1)).toEqual({
+      type: "user_message",
+      text: interjectionMessage("Parent guidance:\nStop now and return the result."),
+      images: [],
+    })
+    expect(observed.some((event) => event.type === "turn_interrupted")).toBe(false)
+  })
+
+  test("hard interruption overrides a steering handoff before the provider settles", async () => {
+    const entered = latch()
+    const release = latch()
+    const blockedRound: ProviderRound = async function* (request) {
+      entered.release()
+      await new Promise<void>((resolve) => {
+        if (request.signal?.aborted) {
+          resolve()
+          return
+        }
+        request.signal?.addEventListener("abort", () => resolve(), { once: true })
+      })
+      await release.promise
+      if (!request.signal?.aborted) yield { type: "done" }
+      throw request.signal?.reason
+    }
+    const provider = new ScriptedProvider([blockedRound, completedRound("Guidance should not run.")])
+    const session = harness.createSession(provider, { kind: "subagent" })
+    const observed: AgentEvent[] = []
+
+    const running = runSettledTurn(session, { text: "Inspect the repository.", images: [] }, (event) => {
+      observed.push(event)
+    })
+    await entered.promise
+
+    expect(session.steer("Parent guidance:\nStop now and return the result.")).toBe(true)
+    session.interrupt()
+    release.release()
+    const outcome = await running
+
+    expect(outcome).toEqual({ status: "interrupted", response: "" })
+    expect(provider.requests).toHaveLength(1)
+    expect(session.currentState).toBe("idle")
+    expect(observed.filter((event) => event.type === "turn_interrupted")).toHaveLength(1)
+  })
+
   test("resumes the interrupted work after answering a prompt queued mid-tool-run", async () => {
     const toolName = `resume_probe_${crypto.randomUUID().replaceAll("-", "_")}`
     const tool: Tool = {

--- a/apps/cli/src/agent/session/session.ts
+++ b/apps/cli/src/agent/session/session.ts
@@ -68,7 +68,10 @@ import { runDirectShell, runTurn, type TurnHost, type TurnSummary } from "./turn
 import { ToolCallRunner, type ToolRunnerHost } from "./tool-runner"
 import {
   addUsage,
+  interruptForSteering,
   isAbortError,
+  isSteeringInterrupt,
+  supersedeSteeringInterrupt,
   type AgentSessionDeps,
   type AgentSessionState,
   type CompactionOutcome,
@@ -110,6 +113,7 @@ export class AgentSession {
   private readonly redoStack = new RedoStack()
   private readonly contextBudget = new ContextBudget()
   private providerRequests = 0
+  private providerRoundActive = false
   private tasks: TrackedTask[] = []
   private readonly listeners = new Set<(event: AgentEvent) => void>()
   private readonly recorder: SessionRecorder | undefined
@@ -901,11 +905,12 @@ export class AgentSession {
     if (this.movingHistory || !this.turnActive || !this.acceptingQueuedInput) return false
     this.noteAgentActivity()
     this.queue.push(redactUserInput({ text, images: [] }))
+    if (this.providerRoundActive && this.abortController) interruptForSteering(this.abortController)
     return true
   }
 
-  private startTurn(inputs: UserInput[]): void {
-    this.startPreparedTurn((signal) => this.acceptInputs(inputs, signal, false))
+  private startTurn(inputs: UserInput[], interjected = false): void {
+    this.startPreparedTurn((signal) => this.acceptInputs(inputs, signal, interjected))
   }
 
   private startBackgroundResultTurn(): boolean {
@@ -965,11 +970,21 @@ export class AgentSession {
     if (this.settlePause()) return
 
     if (controller.signal.aborted) {
-      this.failAgentQuestions("the parent turn was interrupted")
-      const active = this.goals.active()
-      if (active) this.goals.suspend(active.id, "interruption", "Goal automation was interrupted")
+      const steered = isSteeringInterrupt(controller.signal)
+      if (!steered) {
+        this.failAgentQuestions("the parent turn was interrupted")
+        const active = this.goals.active()
+        if (active) this.goals.suspend(active.id, "interruption", "Goal automation was interrupted")
+      }
       this.setState("idle")
-      if (!failure && this.promoteOnAbort && this.queue.first !== undefined && this.startNextQueued()) return
+      if (
+        !failure &&
+        (steered || this.promoteOnAbort) &&
+        this.queue.first !== undefined &&
+        this.startNextQueued(steered)
+      ) {
+        return
+      }
       this.queue.flush()
       this.settleBackgroundAgents()
       return
@@ -1164,7 +1179,7 @@ export class AgentSession {
       })
   }
 
-  private startNextQueued(): boolean {
+  private startNextQueued(interjected = false): boolean {
     const shell = this.queue.takeDirectShell()
     if (shell) {
       this.startDirectShell(shell)
@@ -1172,7 +1187,7 @@ export class AgentSession {
     }
     const inputs = this.queue.takePrompts()
     if (inputs.length === 0) return false
-    this.startTurn(inputs)
+    this.startTurn(inputs, interjected)
     return true
   }
 
@@ -1342,6 +1357,7 @@ export class AgentSession {
 
   interrupt(queued: "promote" | "flush" = "flush"): void {
     this.promoteOnAbort = queued === "promote"
+    supersedeSteeringInterrupt(this.abortController?.signal)
     this.abortController?.abort()
     this.interactions.resolveApproval({ decision: "deny", cause: "user" })
     this.interactions.resolveElicitation({ status: "rejected" })
@@ -1503,6 +1519,7 @@ export class AgentSession {
       profileId: () => this.selectedProfileId(),
       emit: (event) => this.emit(event),
       commitProviderRound: (items, turnUsage, request) => {
+        this.providerRoundActive = false
         for (const item of items) this.saveItem(item)
         this.contextBudget.commitProvider(
           items,
@@ -1515,7 +1532,10 @@ export class AgentSession {
         this.emit({ type: "context_updated", context: turnUsage })
       },
       redactOutputItem: redactProviderOutputItem,
-      onRequestStarted: () => this.recordProviderRequest(),
+      onRequestStarted: () => {
+        this.providerRoundActive = true
+        this.recordProviderRequest()
+      },
     }
   }
 

--- a/apps/cli/src/agent/session/session.ts
+++ b/apps/cli/src/agent/session/session.ts
@@ -905,7 +905,9 @@ export class AgentSession {
     if (this.movingHistory || !this.turnActive || !this.acceptingQueuedInput) return false
     this.noteAgentActivity()
     this.queue.push(redactUserInput({ text, images: [] }))
-    if (this.providerRoundActive && this.abortController) interruptForSteering(this.abortController)
+    if ((this.providerRoundActive || this.state === "compacting") && this.abortController) {
+      interruptForSteering(this.abortController)
+    }
     return true
   }
 
@@ -947,7 +949,7 @@ export class AgentSession {
       })
       .catch((error) => {
         if (isAbortError(error) || controller.signal.aborted) {
-          this.emit({ type: "turn_interrupted" })
+          if (!isSteeringInterrupt(controller.signal)) this.emit({ type: "turn_interrupted" })
           return
         }
         failure = describeError(error)

--- a/apps/cli/src/agent/session/stream.ts
+++ b/apps/cli/src/agent/session/stream.ts
@@ -11,7 +11,7 @@ import type { Provider, ProviderOutputItem, StreamRequest, Usage } from "../../p
 import { createRedactedStream, type RedactedStream } from "../../secrets/redactor"
 import type { AgentEvent } from "../events"
 import { OutputLoopDetector, type OutputLoop } from "./loop-detection"
-import { isAbortError } from "./types"
+import { isAbortError, isSteeringInterrupt } from "./types"
 import type { SessionKind } from "../types"
 
 const MAX_PROVIDER_ATTEMPTS = 6
@@ -122,7 +122,7 @@ export async function streamProviderTurn(
       if (isAbortError(error) || signal.aborted) {
         host.buffer.flush()
         host.commitProviderRound(round.items, round.usage, request)
-        host.emit({ type: "turn_interrupted" })
+        if (!isSteeringInterrupt(signal)) host.emit({ type: "turn_interrupted" })
         return undefined
       }
       const outputLoop = error instanceof OutputLoopError
@@ -151,7 +151,7 @@ export async function streamProviderTurn(
         await sleep(delayMs, undefined, { signal })
       } catch (waitError) {
         if (!isAbortError(waitError) && !signal.aborted) throw waitError
-        host.emit({ type: "turn_interrupted" })
+        if (!isSteeringInterrupt(signal)) host.emit({ type: "turn_interrupted" })
         return undefined
       }
     }

--- a/apps/cli/src/agent/session/tool-runner.ts
+++ b/apps/cli/src/agent/session/tool-runner.ts
@@ -215,7 +215,9 @@ export class ToolCallRunner {
           continue
         }
 
-        const loop = signal.aborted ? "allow" : toolLoops.inspect(call)
+        const tool = this.host.availableTool(call.name)
+        const repeated = tool?.allowRepeatedCalls?.(call.args, { cwd: this.host.cwd() }) ?? false
+        const loop = signal.aborted || repeated ? "allow" : toolLoops.inspect(call)
         if (loop !== "allow") {
           outcomes[index] = this.loopOutcome(call, loop)
           if (loop === "stop") loopError = new Error(`turn stopped after repeated ${call.name} tool calls`)

--- a/apps/cli/src/agent/session/turn.ts
+++ b/apps/cli/src/agent/session/turn.ts
@@ -10,7 +10,7 @@ import { ToolLoopDetector } from "./loop-detection"
 import type { OutputContract } from "./output-contract"
 import { directShellCommand, interjectionResumeMessage } from "./queue"
 import { streamProviderTurn, type StreamRoundHost } from "./stream"
-import type { TurnUsage } from "./types"
+import { isSteeringInterrupt, type TurnUsage } from "./types"
 import { ToolCallRunner, type PreparedToolCall, type ToolCallEntry, type ToolCallOutcome } from "./tool-runner"
 
 export interface TurnHost {
@@ -67,7 +67,7 @@ export async function runTurn(
     if (host.drainBackgroundResults()) toolLoops.reset()
     if (host.drainAgentQuestions()) toolLoops.reset()
     if (signal.aborted) {
-      host.emit({ type: "turn_interrupted" })
+      if (!isSteeringInterrupt(signal)) host.emit({ type: "turn_interrupted" })
       return
     }
     if (host.paused()) return
@@ -165,7 +165,7 @@ export async function runTurn(
     if (contract?.exhausted) throw contract.failure()
 
     if (signal.aborted) {
-      host.emit({ type: "turn_interrupted" })
+      if (!isSteeringInterrupt(signal)) host.emit({ type: "turn_interrupted" })
       return
     }
     if (host.restartRequested()) {

--- a/apps/cli/src/agent/session/types.ts
+++ b/apps/cli/src/agent/session/types.ts
@@ -93,6 +93,32 @@ export function addUsage(total: Usage | undefined, usage: Usage): Usage {
   }
 }
 
+const steeringInterrupts = new WeakSet<object>()
+const supersededSteeringInterrupts = new WeakSet<object>()
+
+export function interruptForSteering(controller: AbortController): void {
+  const reason = {}
+  steeringInterrupts.add(reason)
+  controller.abort(reason)
+}
+
+export function supersedeSteeringInterrupt(signal: AbortSignal | undefined): void {
+  const reason: unknown = signal?.reason
+  if (typeof reason !== "object" || reason === null || !steeringInterrupts.has(reason)) return
+  supersededSteeringInterrupts.add(reason)
+}
+
+export function isSteeringInterrupt(signal: AbortSignal): boolean {
+  const reason: unknown = signal.reason
+  return (
+    signal.aborted &&
+    typeof reason === "object" &&
+    reason !== null &&
+    steeringInterrupts.has(reason) &&
+    !supersededSteeringInterrupts.has(reason)
+  )
+}
+
 export function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError"
 }

--- a/apps/cli/src/agent/task/wait.ts
+++ b/apps/cli/src/agent/task/wait.ts
@@ -46,6 +46,9 @@ export const waitAgentTool: SessionTool = {
   readOnly() {
     return true
   },
+  allowRepeatedCalls() {
+    return true
+  },
   async execute(args, ctx) {
     if (unsettledAgentJobs(ctx.session.id).length === 0 && !ctx.agentActivity.pending) {
       throw new Error("no running task agents or queued task-agent activity")

--- a/apps/cli/src/tools/types.ts
+++ b/apps/cli/src/tools/types.ts
@@ -79,6 +79,7 @@ interface ToolContract extends ToolDefinition {
   undo?(args: Record<string, unknown>, ctx: ToolCallContext): UndoAction
   sandboxed?(args: Record<string, unknown>, ctx: ToolCallContext): boolean
   concurrency?(args: Record<string, unknown>, ctx: ToolCallContext): ToolConcurrency
+  allowRepeatedCalls?(args: Record<string, unknown>, ctx: ToolCallContext): boolean
   permission?(args: Record<string, unknown>, ctx: ToolPermissionContext): ToolPermission
 }
 


### PR DESCRIPTION
## Summary

- interrupt active task-agent provider rounds when parent guidance arrives
- preserve hard cancellation precedence over steering handoffs
- allow legitimate repeated `wait_agent` calls without triggering tool-loop failure
- add regression coverage for steering, cancellation races, and repeatable calls

## Testing

- `bun checks:fix`
- 603 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Steering input can interrupt an active agent response and resume with the latest queued instruction.
  - Repeated tool calls are supported when explicitly allowed, including repeated waiting actions.
  - Hard interruptions take precedence over pending steering instructions.

- **Bug Fixes**
  - Steering interruptions no longer appear as ordinary turn interruptions.
  - Queued input is preserved when an active response is redirected.
  - Retry and streaming behavior now handle steering interruptions consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->