### PR TITLE
Add interactive token usage dashboard

### DIFF
--- a/apps/cli/src/plugins/tui/app.ts
+++ b/apps/cli/src/plugins/tui/app.ts
@@ -189,6 +189,7 @@ export async function startTui(events: EventService, config: TuiConfig, options:
   const resetCommands = setTuiCommandActions({
     agents: () => screen.openAgents(),
     config: () => screen.openConfig(),
+    usage: (summary, view, provider) => screen.openUsage(summary, view, provider),
     terminal: () => describeTerminal(renderer.capabilities),
     quit,
     detach: async () => {

--- a/apps/cli/src/plugins/tui/commands.test.ts
+++ b/apps/cli/src/plugins/tui/commands.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { parseUsageCommandArguments } from "./commands"
+
+describe("usage command arguments", () => {
+  test("accepts a view and provider in either order", () => {
+    expect(parseUsageCommandArguments([])).toEqual({ view: "daily" })
+    expect(parseUsageCommandArguments(["weekly", "openai-chatgpt"])).toEqual({
+      view: "weekly",
+      provider: "openai-chatgpt",
+    })
+    expect(parseUsageCommandArguments(["openai-chatgpt", "cumulative"])).toEqual({
+      view: "cumulative",
+      provider: "openai-chatgpt",
+    })
+    expect(parseUsageCommandArguments(["week"])).toEqual({ view: "weekly" })
+  })
+
+  test("rejects duplicate arguments", () => {
+    expect(() => parseUsageCommandArguments(["daily", "weekly"])).toThrow(
+      "usage: /usage [daily|weekly|cumulative] [provider]",
+    )
+    expect(() => parseUsageCommandArguments(["one", "two"])).toThrow(
+      "usage: /usage [daily|weekly|cumulative] [provider]",
+    )
+  })
+})

--- a/apps/cli/src/plugins/tui/commands.ts
+++ b/apps/cli/src/plugins/tui/commands.ts
@@ -4,12 +4,18 @@ import { stopBackgroundWorker, takeOverBackgroundSession } from "../../bg/attach
 import type { DetachOutcome } from "../../bg/launch"
 import { clearBackgroundSessions, listBackgroundSessions, type BgView } from "../../bg/state"
 import type { Command, CommandContext } from "../../commands/types"
+import { usageDir } from "../../config/paths"
 import { formatRelative } from "../../lib/time"
+import { getProvider } from "../../providers/registry"
+import { parseUsageActivityView, type UsageActivityView } from "../../usage/activity"
+import { flushProviderUsage } from "../../usage/recorder"
+import { readProviderUsageSummary, type ProviderUsageSummary } from "../../usage/summary"
 import type { PluginContext } from "../types"
 
 interface TuiCommandActions {
   agents(): void
   config(): void
+  usage(summary: ProviderUsageSummary, view: UsageActivityView, provider?: string): void
   terminal(): string[]
   quit(): void
   detach(): Promise<DetachOutcome>
@@ -39,6 +45,50 @@ const configCommand: Command = {
   async run() {
     if (!actions) throw new Error("tui is not running")
     actions.config()
+  },
+}
+
+interface UsageCommandArguments {
+  view: UsageActivityView
+  provider?: string
+}
+
+export function parseUsageCommandArguments(args: string[]): UsageCommandArguments {
+  if (args.length > 2) throw new Error("usage: /usage [daily|weekly|cumulative] [provider]")
+
+  let view: UsageActivityView = "daily"
+  let viewSelected = false
+  let provider: string | undefined
+  for (const argument of args) {
+    const parsedView = parseUsageActivityView(argument)
+    if (parsedView) {
+      if (viewSelected) throw new Error("usage: /usage [daily|weekly|cumulative] [provider]")
+      view = parsedView
+      viewSelected = true
+      continue
+    }
+    if (provider) throw new Error("usage: /usage [daily|weekly|cumulative] [provider]")
+    provider = argument
+  }
+  return provider === undefined ? { view } : { view, provider }
+}
+
+const usageCommand: Command = {
+  name: "usage",
+  describe: "show daily, weekly, or cumulative token activity",
+  async run(args, ctx) {
+    if (!actions) throw new Error("tui is not running")
+    const parsed = parseUsageCommandArguments(args)
+    const provider = parsed.provider === undefined ? undefined : getProvider(parsed.provider)
+    if (parsed.provider !== undefined && !provider) throw new Error(`unknown provider: ${parsed.provider}`)
+
+    await flushProviderUsage()
+    const summary = await readProviderUsageSummary(
+      usageDir(),
+      ctx.session.id,
+      provider === undefined ? {} : { provider: provider.id },
+    )
+    actions.usage(summary, parsed.view, provider?.name)
   },
 }
 
@@ -163,5 +213,6 @@ export function registerTuiCommands(ctx: PluginContext): void {
   ctx.registerCommand(backgroundCommand)
   ctx.registerCommand(configCommand)
   ctx.registerCommand(terminalCommand)
+  ctx.registerCommand(usageCommand)
   ctx.registerCommand(quitCommand)
 }

--- a/apps/cli/src/plugins/tui/components/usage-popover.test.ts
+++ b/apps/cli/src/plugins/tui/components/usage-popover.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+import type { ProviderUsageSummary } from "../../../usage/summary"
+import { UsagePopover } from "./usage-popover"
+
+const summary: ProviderUsageSummary = {
+  session: {
+    requests: 2,
+    totalTokens: 1_234,
+    totalInputTokens: 1_000,
+    cacheReadInputTokens: 700,
+    cacheWriteInputTokens: 25,
+    outputTokens: 234,
+  },
+  weekly: {
+    requests: 18,
+    totalTokens: 56_789,
+    totalInputTokens: 50_000,
+    cacheReadInputTokens: 30_000,
+    cacheWriteInputTokens: 500,
+    outputTokens: 6_789,
+  },
+  allTime: {
+    requests: 320,
+    totalTokens: 9_876_543,
+    totalInputTokens: 8_000_000,
+    cacheReadInputTokens: 6_000_000,
+    cacheWriteInputTokens: 100_000,
+    outputTokens: 1_876_543,
+  },
+  daily: [
+    {
+      date: "2026-08-21",
+      requests: 8,
+      totalTokens: 20_000,
+      totalInputTokens: 18_000,
+      cacheReadInputTokens: 10_000,
+      cacheWriteInputTokens: 0,
+      outputTokens: 2_000,
+    },
+    {
+      date: "2026-08-22",
+      requests: 10,
+      totalTokens: 36_789,
+      totalInputTokens: 32_000,
+      cacheReadInputTokens: 20_000,
+      cacheWriteInputTokens: 500,
+      outputTokens: 4_789,
+    },
+  ],
+}
+
+test("renders activity views, toggles the metric, and closes with escape", async () => {
+  const setup = await createTestRenderer({ width: 110, height: 24 })
+  let changes = 0
+  const popover = new UsagePopover(
+    setup.renderer,
+    () => changes++,
+    () => 110,
+    () => new Date("2026-08-22T12:00:00.000Z"),
+  )
+  setup.renderer.root.add(popover.view)
+
+  try {
+    popover.show(summary, "daily", "OpenAI ChatGPT")
+    await setup.renderOnce()
+
+    let frame = setup.captureCharFrame()
+    expect(frame).toContain("/usage daily")
+    expect(frame).toContain("OpenAI ChatGPT")
+    expect(frame).toContain("Uncached activity")
+    expect(frame).toContain("Lifetime 3.88M")
+    expect(frame).toContain("Raw 9.88M")
+    expect(frame).toContain("Cache 6M (75%)")
+    expect(frame).toContain("Streak 2d")
+    expect(frame).toContain("Su")
+    const sunday = frame.split("\n").find((line) => line.includes(" Su "))!
+    expect([...sunday].filter((character) => character === "□")).toHaveLength(52)
+    expect(frame).toContain("daily · weekly · cumulative")
+
+    expect(popover.handleKey("right")).toBeTrue()
+    await setup.renderOnce()
+    frame = setup.captureCharFrame()
+    expect(frame).toContain("/usage weekly")
+    expect(frame).toContain("Each column = 1 week")
+
+    expect(popover.handleKey("m")).toBeTrue()
+    await setup.renderOnce()
+    frame = setup.captureCharFrame()
+    expect(frame).toContain("Reported activity")
+    expect(frame).toContain("Lifetime 9.88M")
+    expect(frame).toContain("cache reads included")
+
+    expect(popover.handleKey("escape")).toBeTrue()
+    expect(popover.visible).toBeFalse()
+    expect(changes).toBe(4)
+  } finally {
+    setup.renderer.destroy()
+  }
+})

--- a/apps/cli/src/plugins/tui/components/usage-popover.ts
+++ b/apps/cli/src/plugins/tui/components/usage-popover.ts
@@ -1,0 +1,409 @@
+import {
+  RGBA,
+  StyledText,
+  TextAttributes,
+  type BoxRenderable,
+  type RenderContext,
+  type TextChunk,
+  type TextRenderable,
+} from "@opentui/core"
+import {
+  buildUsageActivity,
+  formatUsageNumber,
+  formatUsagePercent,
+  nextUsageActivityView,
+  type UsageActivity,
+  type UsageActivityMetric,
+  type UsageActivityView,
+} from "../../../usage/activity"
+import type { ProviderUsageSummary } from "../../../usage/summary"
+import { column, label, row } from "../lib/renderables"
+import { COLORS } from "../theme/colors"
+import { background, border, muted, paint } from "../theme/styles"
+
+const WEEK_COUNT = 52
+const DAY_COUNT = 7
+const DAY_MS = 24 * 60 * 60 * 1000
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+const EMPTY_GLYPH = "□"
+const ACTIVE_GLYPH = "■"
+
+interface ChartWindow {
+  dates: number[]
+  values: number[]
+  firstColumn: number
+  shownColumns: number
+  columnOffsets: number[]
+}
+
+function utcDay(date: Date): number {
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) / DAY_MS
+}
+
+function dateKey(day: number): string {
+  return new Date(day * DAY_MS).toISOString().slice(0, 10)
+}
+
+function chartWindow(activity: UsageActivity, now: Date, width: number): ChartWindow {
+  const today = utcDay(now)
+  const start = today - now.getUTCDay() - (WEEK_COUNT - 1) * DAY_COUNT
+  const dates = Array.from({ length: WEEK_COUNT * DAY_COUNT }, (_, index) => start + index)
+  const byDate = new Map(activity.days.map((day) => [day.date, day.tokens]))
+  const values = dates.map((day) => byDate.get(dateKey(day)) ?? 0)
+  const innerWidth = Math.max(1, width - 6)
+  const shownColumns = Math.max(1, Math.min(WEEK_COUNT, innerWidth - 4))
+  const gapCount = Math.max(0, Math.min(shownColumns - 1, innerWidth - 4 - shownColumns))
+  const columnOffsets: number[] = []
+  let offset = 0
+  for (let column = 0; column < shownColumns; column++) {
+    if (column > 0) {
+      const gap = column - 1
+      const previous = Math.floor((gap * gapCount) / (shownColumns - 1))
+      const next = Math.floor(((gap + 1) * gapCount) / (shownColumns - 1))
+      offset += next > previous ? 2 : 1
+    }
+    columnOffsets.push(offset)
+  }
+  return { dates, values, shownColumns, columnOffsets, firstColumn: WEEK_COUNT - shownColumns }
+}
+
+function dailyLevels(values: number[]): number[] {
+  const peak = Math.max(0, ...values)
+  return values.map((value) => {
+    if (value <= 0 || peak <= 0) return 0
+    if (value * 4 > peak * 3) return 4
+    if (value * 2 > peak) return 3
+    if (value * 4 > peak) return 2
+    return 1
+  })
+}
+
+function activityColors(): RGBA[] {
+  return [0, 0.35, 0.55, 0.75, 1].map((strength) =>
+    RGBA.fromValues(
+      COLORS.background.r + (COLORS.agent.r - COLORS.background.r) * strength,
+      COLORS.background.g + (COLORS.agent.g - COLORS.background.g) * strength,
+      COLORS.background.b + (COLORS.agent.b - COLORS.background.b) * strength,
+    ),
+  )
+}
+
+function weeklyValues(values: number[]): number[] {
+  return Array.from({ length: WEEK_COUNT }, (_, week) =>
+    values.slice(week * DAY_COUNT, week * DAY_COUNT + DAY_COUNT).reduce((total, value) => total + value, 0),
+  )
+}
+
+function barHeights(values: number[]): number[] {
+  const peak = Math.max(0, ...values)
+  return values.map((value) => {
+    if (value <= 0 || peak <= 0) return 0
+    return Math.ceil((value * DAY_COUNT) / peak)
+  })
+}
+
+function monthLabels(window: ChartWindow): string {
+  const cells = Array.from({ length: window.columnOffsets.at(-1)! + 1 }, () => " ")
+  let lastEnd = 0
+  for (let column = window.firstColumn; column < WEEK_COUNT; column++) {
+    const date = new Date(window.dates[column * DAY_COUNT]! * DAY_MS)
+    if (date.getUTCDate() > 7) continue
+    const month = MONTHS[date.getUTCMonth()]!
+    const offset = window.columnOffsets[column - window.firstColumn]!
+    if (offset < lastEnd || offset + month.length > cells.length) continue
+    for (let index = 0; index < month.length; index++) cells[offset + index] = month[index]!
+    lastEnd = offset + month.length + 1
+  }
+  return `    ${cells.join("")}`
+}
+
+function streakLabel(activity: UsageActivity): string {
+  if (activity.currentStreakDays === activity.longestStreakDays) return `${activity.currentStreakDays}d`
+  return `${activity.currentStreakDays}d (best ${activity.longestStreakDays}d)`
+}
+
+function metricLabel(metric: UsageActivityMetric): string {
+  return metric === "uncached" ? "Uncached activity" : "Reported activity"
+}
+
+interface SummaryField {
+  label: string
+  value: string
+  suffix?: string
+}
+
+function summaryRows(activity: UsageActivity, width: number): StyledText[] {
+  const fields: SummaryField[] = [
+    { label: "Session", value: formatUsageNumber(activity.sessionTokens) },
+    { label: "Last 7d", value: formatUsageNumber(activity.weeklyTokens) },
+    { label: "Lifetime", value: formatUsageNumber(activity.lifetimeTokens) },
+    { label: "Peak day", value: formatUsageNumber(activity.peakDailyTokens) },
+    { label: "Raw", value: formatUsageNumber(activity.reportedLifetimeTokens) },
+    {
+      label: "Cache",
+      value: formatUsageNumber(activity.cacheReadTokens),
+      suffix: ` (${formatUsagePercent(activity.cacheReadTokens, activity.inputTokens)})`,
+    },
+    { label: "Requests", value: formatUsageNumber(activity.requests) },
+    { label: "Streak", value: streakLabel(activity) },
+  ]
+  const columns = width >= 100 ? 4 : 2
+  const contentWidth = Math.max(1, Math.min(107, width - 6))
+  const cellWidth = Math.max(1, Math.floor((contentWidth - 1 - (columns - 1) * 2) / columns))
+  const rows: StyledText[] = []
+  for (let offset = 0; offset < fields.length; offset += columns) {
+    const chunks: TextChunk[] = [muted(" ")]
+    for (let index = 0; index < columns; index++) {
+      const field = fields[offset + index]!
+      if (index > 0) chunks.push(muted("  "))
+      chunks.push(muted(`${field.label} `), paint(COLORS.warning, field.value))
+      if (field.suffix) chunks.push(muted(field.suffix))
+      const length = field.label.length + 1 + field.value.length + (field.suffix?.length ?? 0)
+      if (index < columns - 1 && length < cellWidth) chunks.push(muted(" ".repeat(cellWidth - length)))
+    }
+    rows.push(new StyledText(chunks))
+  }
+  return rows
+}
+
+function hasColumnGap(window: ChartWindow, index: number): boolean {
+  return index > 0 && window.columnOffsets[index]! > window.columnOffsets[index - 1]! + 1
+}
+
+function chartRows(window: ChartWindow, view: UsageActivityView, now: Date): StyledText[] {
+  const rows: StyledText[] = []
+  if (view === "daily") {
+    const levels = dailyLevels(window.values)
+    const colors = activityColors()
+    const today = utcDay(now)
+    for (let rowIndex = 0; rowIndex < DAY_COUNT; rowIndex++) {
+      const chunks: TextChunk[] = [muted(` ${WEEKDAYS[rowIndex]} `)]
+      for (let column = window.firstColumn; column < WEEK_COUNT; column++) {
+        const shownIndex = column - window.firstColumn
+        if (hasColumnGap(window, shownIndex)) chunks.push(muted(" "))
+        const index = column * DAY_COUNT + rowIndex
+        if (window.dates[index]! > today) {
+          chunks.push(muted(" "))
+          continue
+        }
+        const level = levels[index]!
+        chunks.push(level === 0 ? muted(EMPTY_GLYPH) : paint(colors[level]!, ACTIVE_GLYPH))
+      }
+      rows.push(new StyledText(chunks))
+    }
+    return rows
+  }
+
+  const weeks = weeklyValues(window.values)
+  const totals =
+    view === "weekly" ? weeks : weeks.map((_, index) => weeks.slice(0, index + 1).reduce((a, b) => a + b, 0))
+  const heights = barHeights(totals)
+  for (let rowIndex = 0; rowIndex < DAY_COUNT; rowIndex++) {
+    const gutter = rowIndex === 0 ? "max " : rowIndex === DAY_COUNT - 1 ? "  0 " : "    "
+    const chunks: TextChunk[] = [muted(gutter)]
+    for (let column = window.firstColumn; column < WEEK_COUNT; column++) {
+      const shownIndex = column - window.firstColumn
+      if (hasColumnGap(window, shownIndex)) chunks.push(muted(" "))
+      chunks.push(heights[column]! >= DAY_COUNT - rowIndex ? paint(COLORS.agent, "█") : muted(" "))
+    }
+    rows.push(new StyledText(chunks))
+  }
+  return rows
+}
+
+function chartCaption(window: ChartWindow, view: UsageActivityView): StyledText {
+  if (view === "daily") {
+    const colors = activityColors()
+    return new StyledText([
+      muted("    Less "),
+      muted(EMPTY_GLYPH),
+      muted(" "),
+      paint(colors[1]!, ACTIVE_GLYPH),
+      muted(" "),
+      paint(colors[2]!, ACTIVE_GLYPH),
+      muted(" "),
+      paint(colors[3]!, ACTIVE_GLYPH),
+      muted(" "),
+      paint(colors[4]!, ACTIVE_GLYPH),
+      muted(" More"),
+    ])
+  }
+  const weeks = weeklyValues(window.values)
+  const value = view === "weekly" ? Math.max(0, ...weeks) : weeks.reduce((total, week) => total + week, 0)
+  const label = view === "weekly" ? "Each column = 1 week · tallest " : "Running total · top "
+  return new StyledText([muted(`    ${label}`), paint(COLORS.warning, formatUsageNumber(value))])
+}
+
+function viewsFooter(active: UsageActivityView): StyledText {
+  const chunks: TextChunk[] = [muted("    ")]
+  const views: UsageActivityView[] = ["daily", "weekly", "cumulative"]
+  for (let index = 0; index < views.length; index++) {
+    const view = views[index]!
+    if (index > 0) chunks.push(muted(" · "))
+    chunks.push(view === active ? paint(COLORS.warning, view) : muted(view))
+  }
+  return new StyledText(chunks)
+}
+
+export class UsagePopover {
+  readonly view: BoxRenderable
+  private readonly title: TextRenderable
+  private readonly provider: TextRenderable
+  private readonly activityTitle: TextRenderable
+  private readonly summaries: TextRenderable[] = []
+  private readonly months: TextRenderable
+  private readonly chart: TextRenderable[] = []
+  private readonly caption: TextRenderable
+  private readonly views: TextRenderable
+  private readonly hint: TextRenderable
+  private summary: ProviderUsageSummary | undefined
+  private activityView: UsageActivityView = "daily"
+  private metric: UsageActivityMetric = "uncached"
+  private providerName: string | undefined
+  private summaryRowCount = 4
+
+  get visible(): boolean {
+    return this.view.visible
+  }
+
+  get height(): number {
+    return this.summaryRowCount + 16
+  }
+
+  constructor(
+    ctx: RenderContext,
+    private readonly onChange: () => void,
+    private readonly availableWidth: () => number,
+    private readonly now: () => Date = () => new Date(),
+  ) {
+    this.view = column(ctx, {
+      visible: false,
+      height: 19,
+      border: true,
+      borderStyle: "rounded",
+      paddingLeft: 1,
+      paddingRight: 1,
+      marginLeft: 1,
+      marginRight: 1,
+      marginTop: 1,
+      ...background(),
+      ...border(COLORS.agent),
+    })
+
+    const header = row(ctx, { height: 1 })
+    this.title = label(ctx, {
+      content: "",
+      flexGrow: 1,
+      flexShrink: 1,
+      minWidth: 1,
+      attributes: TextAttributes.BOLD,
+      color: COLORS.agent,
+    })
+    this.provider = label(ctx, { content: "", flexShrink: 0, marginLeft: 1 })
+    header.add(this.title)
+    header.add(this.provider)
+    this.view.add(header)
+
+    this.activityTitle = label(ctx, { content: "", attributes: TextAttributes.BOLD })
+    this.months = label(ctx)
+    this.view.add(this.activityTitle)
+    for (let index = 0; index < 4; index++) {
+      const summary = label(ctx)
+      this.summaries.push(summary)
+      this.view.add(summary)
+    }
+    this.view.add(this.months)
+
+    for (let index = 0; index < DAY_COUNT; index++) {
+      const chartRow = label(ctx)
+      this.chart.push(chartRow)
+      this.view.add(chartRow)
+    }
+
+    this.caption = label(ctx)
+    this.views = label(ctx)
+    this.hint = label(ctx, { color: COLORS.faint })
+    this.view.add(this.caption)
+    this.view.add(this.views)
+    this.view.add(this.hint)
+  }
+
+  show(summary: ProviderUsageSummary, view: UsageActivityView, provider?: string): void {
+    this.summary = summary
+    this.activityView = view
+    this.metric = "uncached"
+    this.providerName = provider
+    this.render()
+    this.view.visible = true
+    this.onChange()
+  }
+
+  fit(): void {
+    if (!this.view.visible) return
+    this.render()
+  }
+
+  hide(): void {
+    if (!this.view.visible) return
+    this.view.visible = false
+    this.onChange()
+  }
+
+  handleKey(name: string): boolean {
+    if (!this.view.visible) return false
+    if (name === "escape") {
+      this.hide()
+      return true
+    }
+    if (name === "left" || name === "right") {
+      this.activityView = nextUsageActivityView(this.activityView, name === "left" ? -1 : 1)
+      this.render()
+      this.onChange()
+      return true
+    }
+    if (name === "d" || name === "w" || name === "c") {
+      this.activityView = name === "d" ? "daily" : name === "w" ? "weekly" : "cumulative"
+      this.render()
+      this.onChange()
+      return true
+    }
+    if (name === "m") {
+      this.metric = this.metric === "uncached" ? "reported" : "uncached"
+      this.render()
+      this.onChange()
+    }
+    return true
+  }
+
+  private render(): void {
+    if (!this.summary) return
+    const now = this.now()
+    const width = this.availableWidth()
+    const activity = buildUsageActivity(this.summary, this.metric, now)
+    const window = chartWindow(activity, now, width)
+    this.title.content = `/usage ${this.activityView}`
+    this.provider.content = new StyledText([muted(this.providerName ?? "All providers")])
+    this.activityTitle.content = new StyledText([
+      paint(COLORS.foreground, ` ${metricLabel(this.metric)}`),
+      muted(window.shownColumns === WEEK_COUNT ? " · 52 weeks" : ` · recent ${window.shownColumns} weeks`),
+    ])
+    const summaries = summaryRows(activity, width)
+    this.summaryRowCount = summaries.length
+    this.view.height = this.summaryRowCount + 15
+    this.summaries.forEach((summary, index) => {
+      summary.visible = index < summaries.length
+      if (summaries[index]) summary.content = summaries[index]
+    })
+    this.months.content = new StyledText([muted(monthLabels(window))])
+    const rows = chartRows(window, this.activityView, now)
+    this.chart.forEach((row, index) => {
+      row.content = rows[index]!
+    })
+    this.caption.content = chartCaption(window, this.activityView)
+    this.views.content = viewsFooter(this.activityView)
+    const hint = "    ←→ view · M metric · Esc close"
+    this.hint.content =
+      width < 64 ? hint : `${hint} · ${this.metric === "uncached" ? "cache reads excluded" : "cache reads included"}`
+  }
+}

--- a/apps/cli/src/plugins/tui/controllers/keymap.ts
+++ b/apps/cli/src/plugins/tui/controllers/keymap.ts
@@ -247,6 +247,10 @@ export function bindKeys(renderer: CliRenderer, deps: KeymapDeps): void {
 
   renderer.keyInput.on("keypress", (key) => {
     if (handleShortcut(key)) return
+    if (screen.usage.handleKey(key.name)) {
+      key.preventDefault()
+      return
+    }
     if (screen.config.handleKey(key.name)) {
       key.preventDefault()
       screen.syncFooter()

--- a/apps/cli/src/plugins/tui/screen.ts
+++ b/apps/cli/src/plugins/tui/screen.ts
@@ -13,6 +13,8 @@ import { compactPath } from "../../lib/path"
 import type { PermissionMode } from "../../permissions/types"
 import type { ThinkingEffort, UserInput } from "../../providers/types"
 import { protectSecretValue, redactText } from "../../secrets/redactor"
+import type { UsageActivityView } from "../../usage/activity"
+import type { ProviderUsageSummary } from "../../usage/summary"
 import type { ElicitationQuestion } from "../../tools/types"
 import { JobViewer } from "./components/job-viewer"
 import { BackgroundTasks } from "./components/background-tasks"
@@ -28,6 +30,7 @@ import { SecretInput } from "./components/secret-input"
 import { ShortcutHelp } from "./components/shortcut-help"
 import { StatusBar, STATUS_ROWS } from "./components/status-bar"
 import { TaskList } from "./components/task-list"
+import { UsagePopover } from "./components/usage-popover"
 import { saveTuiConfig, type TuiConfig } from "./config"
 import { ChildEventController } from "./controllers/child-events"
 import { column } from "./lib/renderables"
@@ -87,6 +90,7 @@ export class Screen {
   readonly secret: SecretInput
   readonly picker: Picker
   readonly config: ConfigPopover
+  readonly usage: UsagePopover
   readonly palette: CompletionPalette
   readonly composer: Composer
   readonly agentComposer: Composer
@@ -160,6 +164,11 @@ export class Screen {
         changed: () => this.syncFooter(),
         error: (message) => this.scrollback.append({ kind: "error", text: message }),
       },
+    )
+    this.usage = new UsagePopover(
+      renderer,
+      () => this.syncFooter(),
+      () => this.renderer.terminalWidth,
     )
     this.palette = new CompletionPalette(
       renderer,
@@ -256,6 +265,7 @@ export class Screen {
     this.view.add(this.secret.view)
     this.view.add(this.picker.view)
     this.view.add(this.config.view)
+    this.view.add(this.usage.view)
     this.view.add(this.jobViewer.view)
     this.view.add(this.composer.view)
     this.view.add(this.agentComposer.view)
@@ -272,7 +282,8 @@ export class Screen {
       this.elicitation.visible ||
       this.secret.visible ||
       this.picker.visible ||
-      this.config.visible
+      this.config.visible ||
+      this.usage.visible
     )
   }
 
@@ -310,6 +321,7 @@ export class Screen {
   requestApproval(suggestion: string | undefined): void {
     this.tasks.closeViewer()
     this.config.hide()
+    this.usage.hide()
     this.picker.hide()
     this.permission.show(suggestion)
     this.syncFooter()
@@ -323,6 +335,7 @@ export class Screen {
   requestElicitation(requestId: string, questions: ElicitationQuestion[]): void {
     this.tasks.closeViewer()
     this.config.hide()
+    this.usage.hide()
     this.picker.hide()
     this.elicitation.show(requestId, questions)
     this.syncFooter()
@@ -370,6 +383,7 @@ export class Screen {
   async select<T>(request: SelectRequest<T>): Promise<T | undefined> {
     this.tasks.closeViewer()
     this.config.hide()
+    this.usage.hide()
     const options = request.options.map((option) => ({
       ...option,
       label: redactText(option.label),
@@ -385,6 +399,7 @@ export class Screen {
   async ask(question: string): Promise<string | undefined> {
     this.tasks.closeViewer()
     this.config.hide()
+    this.usage.hide()
     this.picker.hide()
     return this.secret.show(redactText(question), false)
   }
@@ -392,6 +407,7 @@ export class Screen {
   async askSecret(question: string): Promise<string | undefined> {
     this.tasks.closeViewer()
     this.config.hide()
+    this.usage.hide()
     this.picker.hide()
     const value = await this.secret.show(redactText(question))
     if (value !== undefined) protectSecretValue(value)
@@ -406,8 +422,16 @@ export class Screen {
 
   openConfig(): void {
     this.picker.hide()
+    this.usage.hide()
     this.config.show()
     this.syncFooter()
+  }
+
+  openUsage(summary: ProviderUsageSummary, view: UsageActivityView, provider?: string): void {
+    this.tasks.closeViewer()
+    this.picker.hide()
+    this.config.hide()
+    this.usage.show(summary, view, provider === undefined ? undefined : redactText(provider))
   }
 
   openAgents(): void {
@@ -489,6 +513,7 @@ export class Screen {
     if (overlaid) this.palette.dismiss()
     this.activeStatusBar.setHint(this.palette.visible ? "↑↓ · Tab · Enter · Esc" : undefined)
     this.elicitation.fit()
+    this.usage.fit()
     const overlayRows = this.permission.visible
       ? this.permission.height
       : this.elicitation.visible
@@ -497,7 +522,9 @@ export class Screen {
           ? this.secret.height
           : this.picker.visible
             ? this.picker.height
-            : this.config.height
+            : this.config.visible
+              ? this.config.height
+              : this.usage.height
     const paletteRows = this.palette.visible ? this.palette.height : 0
     if (this.paletteBelow || overlaid) this.reserved = 0
     else this.reserved = Math.max(this.reserved, paletteRows)

--- a/apps/cli/src/profiler/profiler.ts
+++ b/apps/cli/src/profiler/profiler.ts
@@ -168,6 +168,7 @@ type ToolConcurrency = "shared" | "exclusive"
 export interface ProviderRequestProfile {
   requestId: string
   startedAt: number
+  sessionId: string
   phase: ProviderPhase
   provider: string
   model: string
@@ -502,7 +503,7 @@ export function profileProviderRequestStarted(
   thinking: ThinkingEffort | undefined,
   attempt: number,
 ): ProviderRequestProfile {
-  const profile = { requestId: nextLabel("request"), startedAt: Date.now(), phase, provider, model }
+  const profile = { requestId: nextLabel("request"), startedAt: Date.now(), sessionId, phase, provider, model }
   record({
     type: "provider_request_started",
     request: profile.requestId,
@@ -542,6 +543,7 @@ export function profileProviderRequestFinished(
 ): void {
   if (usage) {
     recordProviderUsage({
+      sessionId: profile.sessionId,
       provider: profile.provider,
       model: profile.model,
       phase: profile.phase,

--- a/apps/cli/src/usage/activity.test.ts
+++ b/apps/cli/src/usage/activity.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test"
+import type { DatedUsageTotals, ProviderUsageSummary, UsageTotals } from "./summary"
+import {
+  buildUsageActivity,
+  formatUsageNumber,
+  nextUsageActivityView,
+  parseUsageActivityView,
+  usageMetricTokens,
+} from "./activity"
+
+function totals(input: number, cache: number, output: number, requests = 1): UsageTotals {
+  return {
+    requests,
+    totalTokens: input + output,
+    totalInputTokens: input,
+    cacheReadInputTokens: cache,
+    cacheWriteInputTokens: 0,
+    outputTokens: output,
+  }
+}
+
+function day(date: string, input: number, cache: number, output: number): DatedUsageTotals {
+  return { date, ...totals(input, cache, output) }
+}
+
+describe("usage activity", () => {
+  test("distinguishes reported and uncached activity and derives reliable statistics", () => {
+    const summary: ProviderUsageSummary = {
+      session: totals(1_000, 800, 100, 2),
+      weekly: totals(5_000, 4_000, 500, 5),
+      allTime: totals(10_000, 8_000, 1_000, 10),
+      daily: [
+        day("2026-08-17", 100, 50, 10),
+        day("2026-08-18", 200, 100, 20),
+        day("2026-08-20", 300, 200, 30),
+        day("2026-08-21", 400, 300, 40),
+        day("2026-08-22", 500, 400, 50),
+        day("2026-08-23", 10_000, 0, 1_000),
+      ],
+    }
+
+    const activity = buildUsageActivity(summary, "uncached", new Date("2026-08-22T12:00:00.000Z"))
+
+    expect(activity).toEqual({
+      metric: "uncached",
+      sessionTokens: 300,
+      weeklyTokens: 1_500,
+      lifetimeTokens: 3_000,
+      reportedLifetimeTokens: 11_000,
+      cacheReadTokens: 8_000,
+      inputTokens: 10_000,
+      peakDailyTokens: 150,
+      currentStreakDays: 3,
+      longestStreakDays: 3,
+      requests: 10,
+      days: [
+        { date: "2026-08-17", tokens: 60 },
+        { date: "2026-08-18", tokens: 120 },
+        { date: "2026-08-20", tokens: 130 },
+        { date: "2026-08-21", tokens: 140 },
+        { date: "2026-08-22", tokens: 150 },
+      ],
+    })
+    expect(usageMetricTokens(summary.allTime, "reported")).toBe(11_000)
+    expect(usageMetricTokens(summary.allTime, "uncached")).toBe(3_000)
+  })
+
+  test("parses views, cycles them, and formats compact values", () => {
+    expect(parseUsageActivityView("day")).toBe("daily")
+    expect(parseUsageActivityView("WEEKLY")).toBe("weekly")
+    expect(parseUsageActivityView("cumulative")).toBe("cumulative")
+    expect(parseUsageActivityView("provider")).toBeUndefined()
+    expect(nextUsageActivityView("daily", -1)).toBe("cumulative")
+    expect(nextUsageActivityView("cumulative", 1)).toBe("daily")
+    expect(formatUsageNumber(999)).toBe("999")
+    expect(formatUsageNumber(1_250)).toBe("1.25K")
+    expect(formatUsageNumber(26_600_000_000)).toBe("26.6B")
+  })
+})

--- a/apps/cli/src/usage/activity.ts
+++ b/apps/cli/src/usage/activity.ts
@@ -1,0 +1,128 @@
+import type { ProviderUsageSummary, UsageTotals } from "./summary"
+
+export type UsageActivityView = "daily" | "weekly" | "cumulative"
+export type UsageActivityMetric = "uncached" | "reported"
+
+export interface UsageActivityDay {
+  date: string
+  tokens: number
+}
+
+export interface UsageActivity {
+  metric: UsageActivityMetric
+  sessionTokens: number
+  weeklyTokens: number
+  lifetimeTokens: number
+  reportedLifetimeTokens: number
+  cacheReadTokens: number
+  inputTokens: number
+  peakDailyTokens: number
+  currentStreakDays: number
+  longestStreakDays: number
+  requests: number
+  days: UsageActivityDay[]
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const VIEWS: UsageActivityView[] = ["daily", "weekly", "cumulative"]
+
+export function parseUsageActivityView(value: string): UsageActivityView | undefined {
+  switch (value.toLowerCase()) {
+    case "day":
+    case "daily":
+      return "daily"
+    case "week":
+    case "weekly":
+      return "weekly"
+    case "cumulative":
+      return "cumulative"
+  }
+}
+
+export function nextUsageActivityView(view: UsageActivityView, direction: -1 | 1): UsageActivityView {
+  const index = VIEWS.indexOf(view)
+  return VIEWS[(index + direction + VIEWS.length) % VIEWS.length]!
+}
+
+export function usageMetricTokens(totals: UsageTotals, metric: UsageActivityMetric): number {
+  if (metric === "reported") return totals.totalTokens
+  return Math.max(0, totals.totalInputTokens - totals.cacheReadInputTokens) + totals.outputTokens
+}
+
+export function formatUsageNumber(value: number): string {
+  if (value < 1_000) return value.toLocaleString("en-US")
+  const units = [
+    { size: 1_000_000_000_000, suffix: "T" },
+    { size: 1_000_000_000, suffix: "B" },
+    { size: 1_000_000, suffix: "M" },
+    { size: 1_000, suffix: "K" },
+  ]
+  const unit = units.find((candidate) => value >= candidate.size)!
+  const scaled = value / unit.size
+  const digits = scaled >= 100 ? 0 : scaled >= 10 ? 1 : 2
+  return `${scaled.toFixed(digits).replace(/\.0+$|(?<=\.[0-9])0+$/, "")}${unit.suffix}`
+}
+
+export function formatUsagePercent(numerator: number, denominator: number): string {
+  if (denominator <= 0) return "0%"
+  return `${Math.min(100, (numerator / denominator) * 100)
+    .toFixed(1)
+    .replace(/\.0$/, "")}%`
+}
+
+function dateDay(date: string): number {
+  return Date.parse(`${date}T00:00:00.000Z`) / DAY_MS
+}
+
+function todayKey(now: Date): string {
+  return now.toISOString().slice(0, 10)
+}
+
+function streaks(days: UsageActivityDay[], now: Date): { current: number; longest: number } {
+  const today = dateDay(todayKey(now))
+  const active = days
+    .filter((day) => day.tokens > 0 && dateDay(day.date) <= today)
+    .map((day) => dateDay(day.date))
+    .toSorted((left, right) => left - right)
+
+  let longest = 0
+  let running = 0
+  let previous: number | undefined
+  for (const day of active) {
+    running = previous !== undefined && day === previous + 1 ? running + 1 : 1
+    longest = Math.max(longest, running)
+    previous = day
+  }
+
+  const activeDays = new Set(active)
+  let current = 0
+  while (activeDays.has(today - current)) current++
+  return { current, longest }
+}
+
+export function buildUsageActivity(
+  summary: ProviderUsageSummary,
+  metric: UsageActivityMetric,
+  now: Date = new Date(),
+): UsageActivity {
+  if (!Number.isFinite(now.getTime())) throw new Error("usage activity requires a valid current time")
+  const today = todayKey(now)
+  const days = summary.daily
+    .filter((day) => day.date <= today)
+    .map((day) => ({ date: day.date, tokens: usageMetricTokens(day, metric) }))
+  const streak = streaks(days, now)
+  return {
+    metric,
+    sessionTokens: usageMetricTokens(summary.session, metric),
+    weeklyTokens: usageMetricTokens(summary.weekly, metric),
+    lifetimeTokens: usageMetricTokens(summary.allTime, metric),
+    reportedLifetimeTokens: summary.allTime.totalTokens,
+    cacheReadTokens: summary.allTime.cacheReadInputTokens,
+    inputTokens: summary.allTime.totalInputTokens,
+    peakDailyTokens: days.reduce((peak, day) => Math.max(peak, day.tokens), 0),
+    currentStreakDays: streak.current,
+    longestStreakDays: streak.longest,
+    requests: summary.allTime.requests,
+    days,
+  }
+}

--- a/apps/cli/src/usage/recorder.test.ts
+++ b/apps/cli/src/usage/recorder.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { chmod, mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import { UsageRecorder } from "./recorder"
+import { UsageRecorder, usageSessionFingerprint } from "./recorder"
 
 let directory: string | undefined
 
@@ -23,6 +23,7 @@ describe("usage recorder", () => {
     )
 
     recorder.record({
+      sessionId: "session-id",
       provider: "openai-chatgpt",
       model: "gpt-5.6-sol",
       phase: "turn",
@@ -40,9 +41,10 @@ describe("usage recorder", () => {
     const path = join(directory, "run-id.jsonl")
     expect(JSON.parse((await readFile(path, "utf8")).trim())).toEqual({
       type: "provider_usage",
-      version: 1,
+      version: 2,
       id: "request-id",
       timestamp: "2026-08-22T12:34:56.000Z",
+      session: usageSessionFingerprint("session-id"),
       provider: "openai-chatgpt",
       model: "gpt-5.6-sol",
       phase: "turn",

--- a/apps/cli/src/usage/recorder.ts
+++ b/apps/cli/src/usage/recorder.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { appendFile, mkdir } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { usageDir } from "../config/paths"
@@ -7,6 +8,7 @@ export type UsagePhase = "turn" | "compaction" | "goal_evaluation"
 export type UsageOutcome = "completed" | "failed" | "interrupted"
 
 export interface ProviderUsageInput {
+  sessionId: string
   provider: string
   model: string
   phase: UsagePhase
@@ -23,14 +25,19 @@ export interface ProviderUsageTokens {
 
 export interface ProviderUsageRecord {
   type: "provider_usage"
-  version: 1
+  version: 2
   id: string
   timestamp: string
+  session: string
   provider: string
   model: string
   phase: UsagePhase
   outcome: UsageOutcome
   usage: ProviderUsageTokens
+}
+
+export function usageSessionFingerprint(sessionId: string): string {
+  return createHash("sha256").update(`xal-usage-session-v1\0${sessionId}`).digest("hex")
 }
 
 export class UsageRecorder {
@@ -53,9 +60,10 @@ export class UsageRecorder {
     const cacheWriteInputTokens = input.usage.cacheWriteInputTokens ?? 0
     const record: ProviderUsageRecord = {
       type: "provider_usage",
-      version: 1,
+      version: 2,
       id: this.nextId(),
       timestamp: this.now().toISOString(),
+      session: usageSessionFingerprint(input.sessionId),
       provider: input.provider,
       model: input.model,
       phase: input.phase,

--- a/apps/cli/src/usage/summary.test.ts
+++ b/apps/cli/src/usage/summary.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { usageSessionFingerprint } from "./recorder"
+import { readProviderUsageSummary } from "./summary"
+
+let directory: string | undefined
+
+afterEach(async () => {
+  if (directory) await rm(directory, { recursive: true, force: true })
+  directory = undefined
+})
+
+interface RecordOptions {
+  version: 1 | 2
+  timestamp: string
+  provider: string
+  sessionId?: string
+  totalInputTokens: number
+  cacheReadInputTokens?: number
+  cacheWriteInputTokens?: number
+  outputTokens: number
+}
+
+function record(options: RecordOptions): string {
+  return JSON.stringify({
+    type: "provider_usage",
+    version: options.version,
+    id: crypto.randomUUID(),
+    timestamp: options.timestamp,
+    ...(options.version === 2 && options.sessionId ? { session: usageSessionFingerprint(options.sessionId) } : {}),
+    provider: options.provider,
+    model: "test-model",
+    phase: "turn",
+    outcome: "completed",
+    usage: {
+      totalInputTokens: options.totalInputTokens,
+      cacheReadInputTokens: options.cacheReadInputTokens ?? 0,
+      cacheWriteInputTokens: options.cacheWriteInputTokens ?? 0,
+      outputTokens: options.outputTokens,
+    },
+  })
+}
+
+const zeroTotals = {
+  requests: 0,
+  totalTokens: 0,
+  totalInputTokens: 0,
+  cacheReadInputTokens: 0,
+  cacheWriteInputTokens: 0,
+  outputTokens: 0,
+}
+
+describe("provider usage summary", () => {
+  test("filters one provider across session, rolling seven days, and all time", async () => {
+    directory = await mkdtemp(join(tmpdir(), "xal-usage-summary-"))
+    await writeFile(
+      join(directory, "first.jsonl"),
+      [
+        record({
+          version: 2,
+          timestamp: "2026-08-22T12:34:56.000Z",
+          provider: "selected-provider",
+          sessionId: "selected",
+          totalInputTokens: 100,
+          cacheReadInputTokens: 40,
+          cacheWriteInputTokens: 5,
+          outputTokens: 10,
+        }),
+        record({
+          version: 2,
+          timestamp: "2026-08-15T12:34:55.999Z",
+          provider: "selected-provider",
+          sessionId: "selected",
+          totalInputTokens: 200,
+          outputTokens: 20,
+        }),
+        record({
+          version: 1,
+          timestamp: "2026-08-15T12:34:56.000Z",
+          provider: "selected-provider",
+          totalInputTokens: 300,
+          cacheReadInputTokens: 10,
+          outputTokens: 30,
+        }),
+        record({
+          version: 2,
+          timestamp: "2026-08-20T12:34:56.000Z",
+          provider: "other-provider",
+          sessionId: "selected",
+          totalInputTokens: 500,
+          cacheReadInputTokens: 30,
+          cacheWriteInputTokens: 2,
+          outputTokens: 50,
+        }),
+        "",
+      ].join("\n"),
+    )
+    await writeFile(
+      join(directory, "second.jsonl"),
+      `${record({
+        version: 2,
+        timestamp: "2026-08-18T12:34:56.000Z",
+        provider: "selected-provider",
+        sessionId: "other",
+        totalInputTokens: 400,
+        cacheReadInputTokens: 20,
+        cacheWriteInputTokens: 1,
+        outputTokens: 40,
+      })}\n`,
+    )
+
+    const summary = await readProviderUsageSummary(directory, "selected", {
+      provider: "selected-provider",
+      now: new Date("2026-08-22T12:34:56.000Z"),
+    })
+
+    expect(summary).toEqual({
+      session: {
+        requests: 2,
+        totalTokens: 330,
+        totalInputTokens: 300,
+        cacheReadInputTokens: 40,
+        cacheWriteInputTokens: 5,
+        outputTokens: 30,
+      },
+      weekly: {
+        requests: 3,
+        totalTokens: 880,
+        totalInputTokens: 800,
+        cacheReadInputTokens: 70,
+        cacheWriteInputTokens: 6,
+        outputTokens: 80,
+      },
+      allTime: {
+        requests: 4,
+        totalTokens: 1_100,
+        totalInputTokens: 1_000,
+        cacheReadInputTokens: 70,
+        cacheWriteInputTokens: 6,
+        outputTokens: 100,
+      },
+      daily: [
+        {
+          date: "2026-08-15",
+          requests: 2,
+          totalTokens: 550,
+          totalInputTokens: 500,
+          cacheReadInputTokens: 10,
+          cacheWriteInputTokens: 0,
+          outputTokens: 50,
+        },
+        {
+          date: "2026-08-18",
+          requests: 1,
+          totalTokens: 440,
+          totalInputTokens: 400,
+          cacheReadInputTokens: 20,
+          cacheWriteInputTokens: 1,
+          outputTokens: 40,
+        },
+        {
+          date: "2026-08-22",
+          requests: 1,
+          totalTokens: 110,
+          totalInputTokens: 100,
+          cacheReadInputTokens: 40,
+          cacheWriteInputTokens: 5,
+          outputTokens: 10,
+        },
+      ],
+    })
+  })
+
+  test("returns zero totals before the ledger exists", async () => {
+    directory = join(tmpdir(), `xal-missing-usage-${crypto.randomUUID()}`)
+
+    const summary = await readProviderUsageSummary(directory, "session")
+
+    expect(summary).toEqual({ session: zeroTotals, weekly: zeroTotals, allTime: zeroTotals, daily: [] })
+  })
+
+  test("fails on a malformed ledger record", async () => {
+    directory = await mkdtemp(join(tmpdir(), "xal-usage-summary-"))
+    await writeFile(join(directory, "broken.jsonl"), "not-json\n")
+
+    await expect(readProviderUsageSummary(directory, "session")).rejects.toThrow("invalid usage record: ")
+  })
+
+  test("fails on a timestamp outside the native ledger shape", async () => {
+    directory = await mkdtemp(join(tmpdir(), "xal-usage-summary-"))
+    await writeFile(
+      join(directory, "broken.jsonl"),
+      `${record({
+        version: 2,
+        timestamp: "2026-08-22",
+        provider: "test-provider",
+        sessionId: "session",
+        totalInputTokens: 1,
+        outputTokens: 1,
+      })}\n`,
+    )
+
+    await expect(readProviderUsageSummary(directory, "session")).rejects.toThrow("invalid usage record: ")
+  })
+})

--- a/apps/cli/src/usage/summary.ts
+++ b/apps/cli/src/usage/summary.ts
@@ -1,0 +1,179 @@
+import { readdir, readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { asNumber, asString, isRecord } from "../lib/json"
+import { usageSessionFingerprint } from "./recorder"
+
+export interface UsageTotals {
+  requests: number
+  totalTokens: number
+  totalInputTokens: number
+  cacheReadInputTokens: number
+  cacheWriteInputTokens: number
+  outputTokens: number
+}
+
+export interface DatedUsageTotals extends UsageTotals {
+  date: string
+}
+
+export interface ProviderUsageSummary {
+  session: UsageTotals
+  weekly: UsageTotals
+  allTime: UsageTotals
+  daily: DatedUsageTotals[]
+}
+
+export interface ProviderUsageSummaryOptions {
+  provider?: string
+  now?: Date
+}
+
+interface ParsedUsageRecord {
+  session?: string
+  date: string
+  timestampMs: number
+  provider: string
+  usage: Omit<UsageTotals, "requests" | "totalTokens">
+}
+
+function emptyTotals(): UsageTotals {
+  return {
+    requests: 0,
+    totalTokens: 0,
+    totalInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheWriteInputTokens: 0,
+    outputTokens: 0,
+  }
+}
+
+function isTokenCount(value: number | undefined): value is number {
+  return value !== undefined && Number.isSafeInteger(value) && value >= 0
+}
+
+function invalidRecord(location: string, cause?: unknown): Error {
+  return new Error(`invalid usage record: ${location}`, cause === undefined ? undefined : { cause })
+}
+
+function parseRecord(line: string, location: string): ParsedUsageRecord {
+  let value: unknown
+  try {
+    value = JSON.parse(line)
+  } catch (error) {
+    throw invalidRecord(location, error)
+  }
+  if (!isRecord(value) || value.type !== "provider_usage") throw invalidRecord(location)
+
+  const version = asNumber(value.version)
+  if (version !== 1 && version !== 2) throw invalidRecord(location)
+  const id = asString(value.id)
+  const timestamp = asString(value.timestamp)
+  const provider = asString(value.provider)
+  const model = asString(value.model)
+  if (!id || !timestamp || !provider || !model) throw invalidRecord(location)
+  const timestampMs = Date.parse(timestamp)
+  if (!Number.isFinite(timestampMs) || new Date(timestampMs).toISOString() !== timestamp) throw invalidRecord(location)
+  if (value.phase !== "turn" && value.phase !== "compaction" && value.phase !== "goal_evaluation") {
+    throw invalidRecord(location)
+  }
+  if (value.outcome !== "completed" && value.outcome !== "failed" && value.outcome !== "interrupted") {
+    throw invalidRecord(location)
+  }
+  if (!isRecord(value.usage)) throw invalidRecord(location)
+
+  const totalInputTokens = asNumber(value.usage.totalInputTokens)
+  const cacheReadInputTokens = asNumber(value.usage.cacheReadInputTokens)
+  const cacheWriteInputTokens = asNumber(value.usage.cacheWriteInputTokens)
+  const outputTokens = asNumber(value.usage.outputTokens)
+  if (
+    !isTokenCount(totalInputTokens) ||
+    !isTokenCount(cacheReadInputTokens) ||
+    !isTokenCount(cacheWriteInputTokens) ||
+    !isTokenCount(outputTokens)
+  ) {
+    throw invalidRecord(location)
+  }
+
+  const usage = { totalInputTokens, cacheReadInputTokens, cacheWriteInputTokens, outputTokens }
+  const date = timestamp.slice(0, 10)
+  if (version === 1) return { date, timestampMs, provider, usage }
+
+  const session = asString(value.session)
+  if (!session || !/^[a-f0-9]{64}$/.test(session)) throw invalidRecord(location)
+  return { session, date, timestampMs, provider, usage }
+}
+
+function addCount(total: number, value: number, location: string): number {
+  const next = total + value
+  if (!Number.isSafeInteger(next)) throw new Error(`usage total exceeds the supported range: ${location}`)
+  return next
+}
+
+function addRecord(total: UsageTotals, record: ParsedUsageRecord, location: string): void {
+  total.requests = addCount(total.requests, 1, location)
+  total.totalInputTokens = addCount(total.totalInputTokens, record.usage.totalInputTokens, location)
+  total.cacheReadInputTokens = addCount(total.cacheReadInputTokens, record.usage.cacheReadInputTokens, location)
+  total.cacheWriteInputTokens = addCount(total.cacheWriteInputTokens, record.usage.cacheWriteInputTokens, location)
+  total.outputTokens = addCount(total.outputTokens, record.usage.outputTokens, location)
+  total.totalTokens = addCount(
+    total.totalTokens,
+    addCount(record.usage.totalInputTokens, record.usage.outputTokens, location),
+    location,
+  )
+}
+
+function isMissingDirectory(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT"
+}
+
+export async function readProviderUsageSummary(
+  directory: string,
+  sessionId: string,
+  options: ProviderUsageSummaryOptions = {},
+): Promise<ProviderUsageSummary> {
+  const summary: ProviderUsageSummary = {
+    session: emptyTotals(),
+    weekly: emptyTotals(),
+    allTime: emptyTotals(),
+    daily: [],
+  }
+  const daily = new Map<string, UsageTotals>()
+  const now = options.now ?? new Date()
+  const nowMs = now.getTime()
+  if (!Number.isFinite(nowMs)) throw new Error("usage summary requires a valid current time")
+
+  let entries
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  } catch (error) {
+    if (isMissingDirectory(error)) return summary
+    throw error
+  }
+
+  const session = usageSessionFingerprint(sessionId)
+  const weeklyCutoffMs = nowMs - 7 * 24 * 60 * 60 * 1000
+  for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue
+    const path = join(directory, entry.name)
+    const lines = (await readFile(path, "utf8")).split("\n")
+    for (let index = 0; index < lines.length; index++) {
+      const line = lines[index]!
+      if (index === lines.length - 1 && line === "") continue
+      const location = `${path}:${index + 1}`
+      const record = parseRecord(line, location)
+      if (options.provider !== undefined && record.provider !== options.provider) continue
+      addRecord(summary.allTime, record, location)
+      const day = daily.get(record.date) ?? emptyTotals()
+      if (!daily.has(record.date)) daily.set(record.date, day)
+      addRecord(day, record, location)
+      if (record.timestampMs >= weeklyCutoffMs && record.timestampMs <= nowMs) {
+        addRecord(summary.weekly, record, location)
+      }
+      if (record.session === session) addRecord(summary.session, record, location)
+    }
+  }
+  summary.daily = [...daily]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([date, totals]) => ({ date, ...totals }))
+  return summary
+}

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -54,6 +54,14 @@ Version-2 sessions remain compatible. Existing checkpoints without a strategy ke
 
 Compaction uses the conversation model's low-effort fast variant when available. Its complete semantic history projection removes opaque provider replay payloads while preserving assistant text, reasoning summaries, tool calls, and tool results. The summary request disables tools and omits their schemas because it cannot call them; its cache identity is recomputed from that exact prompt. This keeps the checkpoint provider-neutral without paying to resend unusable schemas or encrypted transport state.
 
+## Token usage
+
+`/usage [daily|weekly|cumulative] [provider]` opens an Escape-dismissable token activity dashboard. The view and provider arguments may appear in either order, `day` and `week` are accepted as view aliases, and omitting the view opens the daily heatmap. Omit the provider to include every provider, or pass a provider ID or alias to filter the complete dashboard. The chart covers 52 UTC calendar weeks whenever they fit; very narrow terminals label and show the most recent weeks that fit. Weekly bars group each calendar week and cumulative bars show the running total.
+
+The default activity metric is provider-reported input minus cache-read input, plus output. This matches the useful non-cached activity convention instead of promoting a raw input total dominated by cache hits. Press Left or Right to switch views, `D`, `W`, or `C` to select one directly, and `M` to toggle the chart and primary totals between uncached activity and raw provider-reported processing. The dashboard also shows the raw total, cache-read share, request count, peak day, and current and best activity streaks.
+
+Session totals include normal turns, compaction, and goal evaluation requests associated with the active session. Last 7d is the rolling previous seven 24-hour periods from now. Lifetime and chart totals cover usage recorded locally by Xal across all projects, not provider account quotas or billing history. Older version-1 ledger records contribute to Last 7d, Lifetime, and chart data but predate session grouping. See [Local usage dashboards](/docs/integrations#local-usage-dashboards) for the ledger format and storage location.
+
 ## Skills
 
 Xal discovers reusable skill packages from four directories, in increasing priority:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -9,9 +9,10 @@ Xal writes one prompt-free usage record after each provider request that reports
 ```json
 {
   "type": "provider_usage",
-  "version": 1,
+  "version": 2,
   "id": "…",
   "timestamp": "2026-08-22T12:34:56.000Z",
+  "session": "4d2a…",
   "provider": "openai-chatgpt",
   "model": "gpt-5.6-sol",
   "phase": "turn",
@@ -20,11 +21,13 @@ Xal writes one prompt-free usage record after each provider request that reports
 }
 ```
 
-`totalInputTokens` includes cached input. The cache-read and cache-write fields identify the subsets that may be priced differently. `outputTokens` is the provider-reported output total. `phase` distinguishes normal turns from compaction and goal-evaluation requests, while `outcome` preserves requests that reported billable usage before failing or being interrupted.
+`totalInputTokens` includes cached input. The cache-read and cache-write fields identify the subsets that may be priced differently. `outputTokens` is the provider-reported output total. `phase` distinguishes normal turns from compaction and goal-evaluation requests, while `outcome` preserves requests that reported usage before failing or being interrupted. `session` is a one-way fingerprint used to group records without storing the real session ID. Version-1 records remain valid and contribute to rolling, lifetime, and chart totals, but they cannot be attributed to a session.
 
-The ledger contains no prompts, responses, working directories, profile names, credentials, or account identifiers. Files and directories are created with user-only permissions. Xal flushes pending records during shutdown and exits with an error if the ledger could not be written. Existing session transcripts are not backfilled, so collection starts with the first run of a Xal version that supports the ledger.
+The built-in `/usage` dashboard reads this ledger directly. Its default activity value is `totalInputTokens - cacheReadInputTokens + outputTokens`, clamped so input cannot become negative. The raw provider-reported input-plus-output total and cache-read share remain visible, and `M` switches the chart to that raw metric. Daily chart buckets use UTC dates, Last 7d is a rolling seven-day window, and Lifetime spans every local ledger file across all Xal projects. These are local processing records, not provider account quotas, invoices, or usage that occurred outside Xal.
 
-Usage dashboards should read this native ledger instead of treating Xal as Codex or asking Xal to write into another tool's home directory. The `provider` field lets a dashboard attribute ChatGPT usage to Codex, Anthropic usage to Claude, xAI usage to Grok, and other supported providers without coupling to Xal's full session format.
+The ledger contains no prompts, responses, working directories, real session IDs, profile names, credentials, or account identifiers. Files and directories are created with user-only permissions. Xal flushes pending records during shutdown and exits with an error if the ledger could not be written. Existing session transcripts are not backfilled, so collection starts with the first run of a Xal version that supports the ledger.
+
+Usage dashboards should read this native ledger instead of treating Xal as Codex or asking Xal to write into another tool's home directory. The `provider` field lets a dashboard attribute usage to each supported provider without coupling to Xal's full session format.
 
 ## Profiler records
 


### PR DESCRIPTION
## Summary

- add a local usage summary with session fingerprints, rolling seven-day totals, lifetime totals, and UTC daily buckets
- add a responsive `/usage` dashboard with square 52-week activity cells, weekly and cumulative charts, aligned statistics, and Escape dismissal
- support provider and view arguments in either order plus keyboard view and metric switching
- default activity to uncached input plus output while keeping raw reported processing and cache share visible
- document the local ledger scope, metric semantics, controls, and version compatibility

## Testing

- `bun checks`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `/usage` dashboard with daily, weekly, and cumulative views.
  - View token activity, cache metrics, request counts, usage streaks, peaks, and provider-specific totals.
  - Navigate views and toggle between reported and uncached activity metrics.
  - Added keyboard controls and responsive dashboard sizing.

- **Privacy**
  - Session attribution now uses anonymized fingerprints rather than storing raw session identifiers.

- **Documentation**
  - Documented usage dashboard controls, metrics, storage, compatibility, and privacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->